### PR TITLE
simplify landing-page live editor: fixed-height + presets + drop esp3…

### DIFF
--- a/web/src/components/sections/PatternPanel.module.css
+++ b/web/src/components/sections/PatternPanel.module.css
@@ -259,8 +259,7 @@
   color: var(--pf-cream);
 }
 
-.unsupported,
-.editorFootnote {
+.unsupported {
   margin-top: 10px;
   color: var(--pf-ink-muted);
   font-family: var(--pf-mono);
@@ -291,19 +290,6 @@
   font-weight: 500;
 }
 
-.costMeter {
-  margin-top: 4px;
-  font-family: var(--pf-mono);
-  font-size: var(--pf-fs-mono);
-  line-height: 1.4;
-}
-
-.costLow,
-.costMedium,
-.costHigh {
-  color: var(--pf-ink-muted);
-}
-
 .editorActions {
   display: flex;
   flex-wrap: wrap;
@@ -328,11 +314,42 @@
   border-color: var(--pf-ink);
 }
 
-.editorFootnote {
-  margin: 0;
+.presetChips {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
   padding: 10px 14px;
   border-top: 1px solid var(--pf-rule);
   background: var(--pf-cream);
+}
+
+.presetChipsLabel {
+  font-family: var(--pf-mono);
+  font-size: var(--pf-fs-mono);
+  letter-spacing: var(--pf-track-mono);
+  text-transform: uppercase;
+  color: var(--pf-ghost);
+  margin-right: 4px;
+}
+
+.presetChip {
+  min-height: 30px;
+  padding: 0 12px;
+  border: 1px solid var(--pf-rule);
+  background: #ffffff;
+  color: var(--pf-ink);
+  font-family: var(--pf-mono);
+  font-size: var(--pf-fs-mono);
+  letter-spacing: var(--pf-track-mono);
+  text-transform: uppercase;
+  cursor: pointer;
+}
+
+.presetChip:hover {
+  background: var(--pf-ink);
+  color: var(--pf-cream);
+  border-color: var(--pf-ink);
 }
 
 .metaRows {

--- a/web/src/components/sections/PatternPanel.tsx
+++ b/web/src/components/sections/PatternPanel.tsx
@@ -6,7 +6,7 @@ import { SectionContent } from '@/lib/content';
 import Script from 'next/script';
 import { useAppStore } from '@/store/useAppStore';
 import Editor from '@monaco-editor/react';
-import { analyzeEsp32Cost } from '@/lib/esp32CostAnalyzer';
+import { livePresets } from '@/lib/patternSamples';
 import { captureEvent } from '@/lib/posthogEvents';
 import styles from './PatternPanel.module.css';
 
@@ -247,15 +247,12 @@ const presetPatterns: PresetPattern[] = [
 
 
 
-const costClassByLevel = {
-  LOW: styles.costLow,
-  MEDIUM: styles.costMedium,
-  HIGH: styles.costHigh,
-} as const;
-
 const EDITOR_LINE_HEIGHT = 20;
-const EDITOR_VERTICAL_CHROME = 24;
-const EDITOR_MIN_HEIGHT = 400;
+// Fixed editor height — most visitors only paste AI-generated code and
+// rarely scroll the source themselves, so growing the page with line
+// count just pushed the rest of the section out of view. The editor
+// now scrolls internally instead.
+const EDITOR_HEIGHT = 480;
 const INSTAGRAM_URL = 'https://www.instagram.com/patternflow.work/';
 
 export default function PatternPanel({ content }: PatternPanelProps) {
@@ -263,12 +260,6 @@ export default function PatternPanel({ content }: PatternPanelProps) {
   const activePatternId = useAppStore(state => state.activePatternId);
   const customJsCode = useAppStore(state => state.customJsCode);
   const setCustomJsCode = useAppStore(state => state.setCustomJsCode);
-  const esp32Cost = analyzeEsp32Cost(customJsCode);
-  const editorLineCount = Math.max(1, customJsCode.split('\n').length);
-  const editorHeight = Math.max(
-    EDITOR_MIN_HEIGHT,
-    editorLineCount * EDITOR_LINE_HEIGHT + EDITOR_VERTICAL_CHROME,
-  );
 
   const selectBuiltInPattern = (pattern: PresetPattern, track = true) => {
     const store = useAppStore.getState();
@@ -312,6 +303,17 @@ export default function PatternPanel({ content }: PatternPanelProps) {
     alert('AI Prompt copied to clipboard! Paste it in ChatGPT/Claude to generate a pattern.');
   };
 
+  const handleLoadPreset = (presetId: string) => {
+    const preset = livePresets.find((p) => p.id === presetId);
+    if (!preset) return;
+    setCustomJsCode(preset.code);
+    captureEvent('live_preset_loaded', {
+      preset_id: preset.id,
+      preset_name: preset.name,
+      surface: 'live_editor',
+    });
+  };
+
   const handleCopyVariantPrompt = () => {
     navigator.clipboard.writeText(getVariantPrompt(customJsCode));
     captureEvent('copy_variants_prompt_clicked', {
@@ -323,8 +325,6 @@ export default function PatternPanel({ content }: PatternPanelProps) {
   const handleCopyConvertPrompt = () => {
     navigator.clipboard.writeText(getConvertPrompt(customJsCode));
     captureEvent('copy_cpp_prompt_clicked', {
-      esp32_cost_level: esp32Cost.level,
-      esp32_cost_score: esp32Cost.score,
       surface: 'live_editor',
     });
     alert('C++ Conversion Prompt copied to clipboard! Paste it in ChatGPT/Claude to get your ESP32 C++ code.');
@@ -452,9 +452,6 @@ export default function PatternPanel({ content }: PatternPanelProps) {
               <div className={styles.editorHeader}>
                 <div>
                   <span className={styles.editorTitle}>JavaScript Pattern Editor</span>
-                  <div className={`${styles.costMeter} ${costClassByLevel[esp32Cost.level]}`}>
-                    ESP32 cost: {esp32Cost.level} · score {esp32Cost.score} · per pixel: trig {esp32Cost.perPixel.trig}, pow {esp32Cost.perPixel.pow}, sqrt {esp32Cost.perPixel.sqrt}, atan2 {esp32Cost.perPixel.atan2}
-                  </div>
                 </div>
                 <div className={styles.editorActions}>
                   <button type="button" onClick={handleCopyCreatePrompt}>
@@ -469,7 +466,7 @@ export default function PatternPanel({ content }: PatternPanelProps) {
                 </div>
               </div>
               <Editor
-                height={editorHeight}
+                height={EDITOR_HEIGHT}
                 defaultLanguage="javascript"
                 theme="vs-dark"
                 value={customJsCode}
@@ -480,19 +477,28 @@ export default function PatternPanel({ content }: PatternPanelProps) {
                   lineHeight: EDITOR_LINE_HEIGHT,
                   scrollBeyondLastLine: false,
                   scrollbar: {
-                    vertical: 'hidden',
+                    vertical: 'auto',
                     horizontal: 'auto',
-                    handleMouseWheel: false,
+                    handleMouseWheel: true,
                   },
                   overviewRulerLanes: 0,
                   hideCursorInOverviewRuler: true,
                   automaticLayout: true,
                 }}
               />
-              <div className={styles.editorFootnote}>
-                <strong>Estimate:</strong>{' '}
-                per frame: trig {esp32Cost.perFrame.trig.toLocaleString()}, pow {esp32Cost.perFrame.pow.toLocaleString()}, sqrt {esp32Cost.perFrame.sqrt.toLocaleString()}, atan2 {esp32Cost.perFrame.atan2.toLocaleString()}.{' '}
-                {esp32Cost.notes.join(' ')}
+              <div className={styles.presetChips} aria-label="Live editor presets">
+                <span className={styles.presetChipsLabel}>Try a preset</span>
+                {livePresets.map((preset) => (
+                  <button
+                    key={preset.id}
+                    type="button"
+                    className={styles.presetChip}
+                    onClick={() => handleLoadPreset(preset.id)}
+                    title={preset.desc}
+                  >
+                    {preset.name}
+                  </button>
+                ))}
               </div>
               <div className={styles.sourceRow}>
                 <div className={styles.applyGuide}>

--- a/web/src/lib/patternSamples.ts
+++ b/web/src/lib/patternSamples.ts
@@ -101,3 +101,295 @@ export function draw(display, params, time) {
     }
   }
 }`;
+
+// --- Live editor presets ---
+// Embedded as string templates so the landing-page Live Editor can load
+// them with one click. Each preset is a complete standalone pattern.
+
+export const plasmaRidgesPattern = `// Plasma Ridges — nested trig field with chaos warping
+function hsvToRgb(h, s, v) {
+    let r, g, b;
+    let i = Math.floor(h * 6);
+    let f = h * 6 - i;
+    let p = v * (1 - s);
+    let q = v * (1 - f * s);
+    let t = v * (1 - (1 - f) * s);
+    switch (i % 6) {
+        case 0: r = v; g = t; b = p; break;
+        case 1: r = q; g = v; b = p; break;
+        case 2: r = p; g = v; b = t; break;
+        case 3: r = p; g = q; b = v; break;
+        case 4: r = t; g = p; b = v; break;
+        case 5: r = v; g = p; b = q; break;
+    }
+    return [Math.floor(r * 255), Math.floor(g * 255), Math.floor(b * 255)];
+}
+
+function clamp(val, min, max) { return Math.max(min, Math.min(max, val)); }
+
+export function setup(params) {
+    params.hueBase = 0.5;
+    params.speed = 1.0;
+    params.scale = 0.1;
+    params.chaos = 1.0;
+    params.timeAcc = 0.0;
+}
+
+export function update(dt, input, params) {
+    params.hueBase = (params.hueBase + input.knobDeltas[0] * 0.05) % 1.0;
+    if (params.hueBase < 0) params.hueBase += 1.0;
+    params.speed = Math.max(0.0, params.speed + input.knobDeltas[1] * 0.05);
+    params.scale = clamp(params.scale + input.knobDeltas[2] * 0.01, 0.02, 0.2);
+    params.chaos = clamp(params.chaos + input.knobDeltas[3] * 0.1, 0.0, 3.0);
+    params.timeAcc += dt * params.speed;
+}
+
+export function draw(display, params, time) {
+    let t = params.timeAcc;
+    let s = params.scale;
+    let c = params.chaos;
+
+    for (let y = 0; y < display.height; y++) {
+        let ny = y * s;
+        for (let x = 0; x < display.width; x++) {
+            let nx = x * s;
+
+            // Nested trigonometric functions for liquid plasma/domain warping
+            let v1 = Math.sin(nx + t);
+            let v2 = Math.cos(ny - t * 0.8);
+
+            // Add chaos distortion
+            let warpX = Math.sin(ny * 2.0 + t) * c;
+            let warpY = Math.cos(nx * 2.0 - t * 1.2) * c;
+
+            let v3 = Math.sin((nx + warpX) * 1.5 + t * 1.5);
+            let v4 = Math.cos((ny + warpY) * 1.5 - t);
+
+            // Combine fields and take absolute value to create sharp interference "ridges"
+            let field = Math.abs(v1 + v2 + v3 + v4);
+
+            // Invert and sharpen: 0.0 is empty, highly peaked at exactly the ridges
+            let val = 1.0 - (field * 0.5);
+            val = Math.pow(clamp(val, 0.0, 1.0), 3.0); // pow is ok sparsely, makes neon tubes pop
+
+            // Boost brightness to ensure LED pop
+            val = clamp(val * 2.5, 0.0, 1.0);
+
+            // Deep organic color shifting based on position
+            let hue = (params.hueBase + nx * 0.1 + ny * 0.1 + field * 0.05) % 1.0;
+
+            let rgb = hsvToRgb(hue, 1.0 - val * 0.2, val); // Desaturate slightly at absolute brightest centers
+            display.setPixel(x, y, rgb[0], rgb[1], rgb[2]);
+        }
+    }
+}`;
+
+export const glitchRainPattern = `// Glitch Rain — bitwise cascade with neon-pink raindrop heads
+// Knob 1: Tear Severity (horizontal crack intensity)
+// Knob 2: Cascade Velocity (vertical fall frequency)
+// Knob 3: Pixel Block Size (macro chunk resolution)
+// Knob 4: Bitwise Threshold (binary mask match level)
+
+export function setup(params) {
+  params.tear = 0.5;
+  params.velocity = 2.0;
+  params.blockSize = 2.5;
+  params.bitThresh = 0.06;
+  params.timeAcc = 0;
+}
+
+export function update(dt, input, params) {
+  if (input && input.knobValues) {
+    params.tear = input.knobValues[0];
+    params.velocity = input.knobValues[1];
+    params.blockSize = input.knobValues[2];
+    params.bitThresh = input.knobValues[3];
+  }
+  params.timeAcc += dt * params.velocity * 3.0;
+}
+
+export function draw(display, params, time) {
+  let w = display.width;
+  let h = display.height;
+  let t = params.timeAcc;
+
+  let ditherPattern = [0, 12, 3, 15, 8, 4, 11, 7, 2, 14, 1, 13, 10, 6, 9, 5];
+  let pSize = Math.max(1, Math.floor(1.0 + params.blockSize * 4.0));
+
+  for (let y = 0; y < h; y++) {
+    let faultLine = Math.sin(y * 0.08 + t * 0.4) * Math.cos(y * 0.03);
+    let hShift = 0;
+    if (faultLine > 0.9 - params.tear * 0.7) {
+      hShift = Math.floor(Math.tan(y * 0.05 + t) * (params.tear * 15.0));
+    }
+
+    for (let x = 0; x < w; x++) {
+      let sx = Math.floor(((x + hShift + w) % w) / pSize) * pSize;
+      let sy = Math.floor(y / pSize) * pSize;
+
+      let streamSeed = Math.sin(Math.floor(sx / 8) * 54.12) * 0.5 + 0.5;
+      let drop = Math.floor(sy / 4 - t * (0.6 + streamSeed * 0.4)) % 16;
+      if (drop < 0) drop += 16;
+      let rainMass = drop < 6 ? 1.0 : 0.0;
+
+      let maskVal = Math.floor(params.bitThresh * 31);
+      let bitField = (((sx / pSize) ^ (sy / pSize)) & maskVal) === 0 ? 0.5 : 0.0;
+
+      let totalSignal = rainMass * 0.6 + bitField;
+
+      let cx = sx - w * 0.5;
+      let cy = sy - h * 0.5;
+      let bgWave = Math.sin(Math.sqrt(cx * cx + cy * cy) * 0.15 - t) * 0.25;
+      totalSignal += bgWave;
+
+      let mx = x % 4;
+      let my = y % 4;
+      let thresh = ditherPattern[my * 4 + mx] / 16.0;
+
+      let r = 0, g = 0, b = 0;
+      if (totalSignal > thresh) {
+        // Falling raindrop heads pop in neon pink
+        if (rainMass > 0.0 && drop === 0) {
+          r = 255; g = 0; b = 150;
+        } else {
+          r = 255; g = 255; b = 255;
+        }
+      }
+
+      display.setPixel(x, y, r, g, b);
+    }
+  }
+}`;
+
+export const hudTickerPattern = `// HUD Ticker — sliding rows of UI/HUD segments at varying speeds
+function hsvToRgb(h, s, v) {
+    let r, g, b;
+    let i = Math.floor(h * 6);
+    let f = h * 6 - i;
+    let p = v * (1 - s);
+    let q = v * (1 - f * s);
+    let t = v * (1 - (1 - f) * s);
+    switch (i % 6) {
+        case 0: r = v; g = t; b = p; break;
+        case 1: r = q; g = v; b = p; break;
+        case 2: r = p; g = v; b = t; break;
+        case 3: r = p; g = q; b = v; break;
+        case 4: r = t; g = p; b = v; break;
+        case 5: r = v; g = p; b = q; break;
+    }
+    return [Math.floor(r * 255), Math.floor(g * 255), Math.floor(b * 255)];
+}
+
+function clamp(val, min, max) { return Math.max(min, Math.min(max, val)); }
+
+export function setup(params) {
+    params.hueBase = 0.2;
+    params.speed = 1.0;
+    params.rowHeight = 8.0;
+    params.segWidth = 16.0;
+    params.timeAcc = 0.0;
+}
+
+export function update(dt, input, params) {
+    params.hueBase = (params.hueBase + input.knobDeltas[0] * 0.05) % 1.0;
+    if (params.hueBase < 0) params.hueBase += 1.0;
+    params.speed = Math.max(0.0, params.speed + input.knobDeltas[1] * 0.05);
+    params.rowHeight = clamp(params.rowHeight + input.knobDeltas[2] * 0.5, 4.0, 16.0);
+    params.segWidth = clamp(params.segWidth + input.knobDeltas[3] * 1.0, 8.0, 48.0);
+    params.timeAcc += dt * params.speed;
+}
+
+export function draw(display, params, time) {
+    let t = params.timeAcc;
+    let rh = Math.floor(params.rowHeight);
+    let sw = Math.floor(params.segWidth);
+
+    for (let y = 0; y < display.height; y++) {
+        let rowIdx = Math.floor(y / rh);
+        let ly = y % rh;
+        let halfRh = rh >> 1;
+
+        // Each row has a unique speed and direction based on its index
+        let speedMult = (rowIdx % 2 === 0 ? 1 : -1) * ((rowIdx % 3) * 0.5 + 0.5);
+        let rowOffset = t * 20.0 * speedMult;
+
+        for (let x = 0; x < display.width; x++) {
+            let adjX = x + rowOffset;
+            let segIdx = Math.floor(adjX / sw);
+            let lx = Math.floor(adjX % sw);
+            if (lx < 0) lx += sw;
+
+            let halfSw = sw >> 1;
+
+            // Pseudo-random hash for this specific block segment
+            let hash = Math.abs(Math.sin(rowIdx * 12.9898 + segIdx * 78.233)) * 10000;
+            let val = hash - Math.floor(hash);
+
+            let r = 0, g = 0, b = 0;
+            let draw = false;
+            let hOffset = 0;
+
+            let cx = lx - halfSw;
+            let cy = ly - halfRh;
+            let maxL = Math.max(Math.abs(cx), Math.abs(cy));
+
+            // Map random segment value to distinct UI/HUD style blocks
+            if (val < 0.2) {
+                // Loading bar segment
+                if (ly > halfRh - 2 && ly < halfRh + 2 && lx < sw * 0.8) { draw = true; hOffset = 0.0; }
+            } else if (val < 0.4) {
+                // Caution chevrons
+                if ((lx + ly) % 6 < 3) { draw = true; hOffset = 0.2; }
+            } else if (val < 0.6) {
+                // Empty spacing block
+            } else if (val < 0.8) {
+                // Data nodes (dots)
+                if (lx % 4 === 0 && ly % 4 === 0) { draw = true; hOffset = 0.6; }
+            } else {
+                // Signal waveform (sine within segment)
+                let waveY = halfRh + Math.sin(lx * 0.5) * (halfRh - 1);
+                if (Math.abs(ly - waveY) < 1.5) { draw = true; hOffset = 0.8; }
+            }
+
+            // Segment boundary marker
+            if (lx === 0) {
+                draw = true;
+                hOffset = 0.5;
+            }
+
+            if (draw) {
+                let rgb = hsvToRgb((params.hueBase + hOffset) % 1.0, 0.9, 1.0);
+                r = rgb[0]; g = rgb[1]; b = rgb[2];
+            }
+            display.setPixel(x, y, r, g, b);
+        }
+    }
+}`;
+
+export type LivePreset = {
+  id: string;
+  name: string;
+  desc: string;
+  code: string;
+};
+
+export const livePresets: LivePreset[] = [
+  {
+    id: 'pattern2',
+    name: 'Pattern 2',
+    desc: 'Liquid plasma with chaos-warped neon ridges',
+    code: plasmaRidgesPattern,
+  },
+  {
+    id: 'pattern3',
+    name: 'Pattern 3',
+    desc: 'Sliding rows of UI segments at varying speeds',
+    code: hudTickerPattern,
+  },
+  {
+    id: 'pattern16',
+    name: 'Pattern 16',
+    desc: 'Bitwise cascade with neon-pink raindrop heads',
+    code: glitchRainPattern,
+  },
+];


### PR DESCRIPTION
…2 cost meter

three coordinated UX changes on the embedded Live Editor:

- click-to-load preset row below the editor: Pattern 2 (plasma ridges with chaos-warped neon), Pattern 3 (sliding HUD ticker rows), Pattern 16 (bitwise glitch rain with neon-pink raindrop heads). naming follows the instagram pattern numbers so a visitor who liked a post can pick the matching one out of the chip row. each chip swaps the editor content and the 3d preview re-renders automatically. posthog event live_preset_loaded fires for funnel tracking.

- editor is now fixed at 480px with internal scrolling instead of growing the page height with line count. most visitors paste AI- generated patterns and never scroll through the source; the auto- expanding behavior was pushing the rest of the section out of view for everyone for the benefit of nobody. monaco's vertical scrollbar is on and mouse-wheel scrolling inside the editor is enabled.

- the ESP32 cost meter (LOW/MEDIUM/HIGH plus per-pixel/per-frame trig and pow counts) is gone. the firmware optimization pass already handles every pattern fine in practice, so the meter was scaring beginners away from patterns that actually run smoothly. removed the analyzeEsp32Cost import, the cost meter element, the footnote with per-frame stats, and the esp32_cost_level/score fields on the copy_cpp_prompt_clicked analytics event. the cost analyzer remains available for the pattern-lab dev tool surface.