### PR TITLE
rewrite main readme intro with artwork framing from the prize submission

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,24 +8,32 @@
 > ⚠️ **Photosensitivity Warning**
 > Patternflow displays rapidly changing light patterns that may trigger seizures in people with photosensitive epilepsy. Viewer discretion is advised. If you experience any discomfort, stop use immediately.
 
-An LED synthesizer. Play light patterns with your fingertips.
-An open-source reinterpretation of Nam June Paik's *Participation TV* (1963).
+## Patternflow is an open-source LED synthesizer played with the fingertips.
 
-## What is this?
-
-Patternflow is an open-source hardware instrument: four rotary encoders controlling generative light patterns on a 128×64 LED matrix, powered by ESP32-S3.
-
-**Long-press encoder 4 to switch between patterns** — all bundled in a single firmware image, no reflashing needed.
+Turning four physical knobs reshapes patterns from creative coding on an LED matrix in real time. The light is no longer a visual effect to be watched but a multisensory experience connected directly to the motion of the hand.
 
 <p align="center">
   <img src="./docs/media/demo_part1_v2.webp" height="500" />
   <img src="./docs/media/demo_part2.webp" height="500" />
 </p>
 
+## At its core, this work is about **making things easy and sharing them.**
+
+Audiences do not stop at appreciating a finished piece. Through the publicly released hardware files, firmware, 3D models, web preview, and AI prompts, anyone can build their own Patternflow, generate their own patterns, test them in the browser, and upload them to the device.
+
+## Patternflow returns to Nam June Paik's *Participation TV* in the technological conditions of the present.
+
+Where *Participation TV* showed that the audience could intervene in an electronic image, Patternflow proposes the step that comes after participation. The audience can move from operating the work to making, modifying, and sharing it as creators.
+
+## **Patternflow** is therefore not a single luminous object.
+
+It is a living system in which a physical experience extends outward into open-source making and community creation.
+
+---
+
 Build it from the files, or wait for the kit.
 
 👉 **Ready to build?** Follow the **[Current Full Build Guide (docs/BUILD.md)](docs/BUILD.md)** to assemble your own Patternflow from scratch! You can also explore the modular **[Assembly Map (docs/assembly/README.md)](docs/assembly/README.md)** for alternative enclosure and electronics paths.
-
 
 > **v2.0.0 is live.** Cold-boot fix, runtime pattern switching, browser flasher, Live Editor, journal, build map, and AI-assisted custom patterns.
 
@@ -47,12 +55,14 @@ Custom patterns require a local Arduino IDE compile/upload step for now.
 
 ## Patterns
 
-PatternFlow OS v2.0.0 includes:
+PatternFlow OS v2.0.0 ships with two base patterns:
 
 - **Origin** — concentric sine waves sampled by an emergent grid
 - **Wave Saw** — rotated sawtooth waves with fractal noise distortion
 
-More pattern studies and experiments are posted on [Instagram](https://www.instagram.com/patternflow.work). Not every study becomes built-in firmware; the feed is where ongoing visual research lives.
+**Long-press encoder 4 to switch between patterns on the device** — all bundled in a single firmware image, no reflashing needed.
+
+Ongoing pattern studies are posted on [Instagram](https://www.instagram.com/patternflow.work). Every pattern shown there is mirrored on the [Discord](https://discord.gg/Vr9QtsxeTk) patterns channel with full JavaScript source, hardware-tested C++ header, and the design notes behind it — join Discord to grab a pattern from any post you liked.
 
 ## Why open source?
 
@@ -67,8 +77,6 @@ Hundreds of comments asked when it would be available, where to find the files, 
 
 So Patternflow was opened — schematics, firmware, case, build guide, all of it in this repository. Hardware designs under CC-BY-SA 4.0; firmware and web code under MIT.
 
-Patternflow is a reinterpretation of Nam June Paik's *Participation TV* (1963). Paik brought participation into art. Open-sourcing the design is an attempt to carry that gesture further, from participation into creation — not a finished object but a starting point. Build it, modify it, fork it, share it.
-
 For the full story — failed prints, broken potentiometers, two weeks of debugging a strapping pin, the first PCB — see **[the 30-day journal](https://patternflow.work/journal/v1-30-days?lang=en)**.
 
 ## Links
@@ -76,6 +84,10 @@ For the full story — failed prints, broken potentiometers, two weeks of debugg
 - [patternflow.work](https://patternflow.work) — browser flasher, Live Editor, journal, build map
 - [Releases](../../releases) — stable bundles
 - [Discord](https://discord.gg/Vr9QtsxeTk) — questions, builds, custom patterns
+
+## How it's built
+
+Patternflow is built around a standalone ESP32-S3 driving a HUB75 RGB LED matrix at low resolution — each pixel reads as a discrete point of light, with its own brightness and color. Four rotary encoders feed firmware written in Arduino-compatible C++ around a modular pattern architecture: each pattern is a self-contained module with its own setup, update, and draw routines, while the shared framework handles input, LED rendering, mode transitions, and color calibration. The PCB was designed by the artist; the enclosure is 3D-printed by default, with stainless steel, transparent acrylic, and laser-cut variations in progress.
 
 ## Repository structure
 


### PR DESCRIPTION
the previous "What is this?" intro was practical but didn't convey what this work is actually about beyond "open-source hardware instrument." new opening pulls in the four-section artwork description written for the recent prize submission:

1. patternflow is an open-source LED synthesizer played with the fingertips — the punchy thesis
2. at its core, making things easy and sharing them — what the project is really for
3. patternflow returns to nam june paik's participation TV in the technological conditions of the present — the lineage, no longer a tacked-on reference line
4. patternflow is therefore not a single luminous object — the bridge from concept to the practical build content below

the four h2 sections are the new top of the readme, immediately after the photosensitivity warning. demo images stay between section 1 and section 2 so the visual lands while the reader is still in the opener.

other small edits to keep the document tight:
- the standalone paik paragraph in "why open source?" is gone now that the new intro covers it more thoroughly. the reddit origin story stays as concrete evidence of community demand.
- "long-press encoder 4 to switch patterns" moved from the cold open into the patterns section where it actually belongs.
- patterns section now mentions discord alongside instagram — every instagram pattern is mirrored on discord with JS + C++ source.
- new compact "how it's built" paragraph between links and repository structure: one paragraph covering the esp32-s3, hub75, encoder inputs, modular pattern architecture, PCB, and enclosure. distilled from the technical description so the readme stays scannable.