### PR TITLE
Web: Pattern Lab buttons, hero reframe, build-matrix issue links, live status page

### DIFF
--- a/web/src/app/api/roadmap/route.ts
+++ b/web/src/app/api/roadmap/route.ts
@@ -1,0 +1,103 @@
+import { NextResponse } from "next/server";
+
+// Read-only roadmap feed. Pulls open issues (and their sub-issue progress)
+// from the public repo on the server, so no token is exposed to the browser
+// and the result is cached/shared across visitors. A GITHUB_TOKEN env var is
+// used when present (higher rate limit) but is optional for a public repo.
+//
+// This is the "server route + cache" prototype. A later iteration can swap to
+// a GitHub Action that writes a static JSON snapshot instead.
+
+const REPO = "engmung/PatternFlow";
+const PER_PAGE = 30;
+
+// Revalidate at most every 10 minutes.
+export const revalidate = 600;
+
+type RawLabel = { name: string; color: string } | string;
+
+type RawIssue = {
+  number: number;
+  title: string;
+  html_url: string;
+  state: string;
+  updated_at: string;
+  comments: number;
+  pull_request?: unknown;
+  labels: RawLabel[];
+  sub_issues_summary?: {
+    total: number;
+    completed: number;
+    percent_completed: number;
+  };
+};
+
+export type RoadmapIssue = {
+  number: number;
+  title: string;
+  url: string;
+  state: string;
+  updatedAt: string;
+  comments: number;
+  labels: { name: string; color: string }[];
+  subIssues: { total: number; completed: number; percent: number } | null;
+};
+
+export async function GET() {
+  const headers: Record<string, string> = {
+    Accept: "application/vnd.github+json",
+    "X-GitHub-Api-Version": "2022-11-28",
+    "User-Agent": "patternflow-web",
+  };
+  if (process.env.GITHUB_TOKEN) {
+    headers.Authorization = `Bearer ${process.env.GITHUB_TOKEN}`;
+  }
+
+  try {
+    const res = await fetch(
+      `https://api.github.com/repos/${REPO}/issues?state=open&per_page=${PER_PAGE}&sort=updated&direction=desc`,
+      { headers, next: { revalidate } },
+    );
+
+    if (!res.ok) {
+      return NextResponse.json(
+        { repo: REPO, issues: [], error: `GitHub responded ${res.status}` },
+        { status: 200 },
+      );
+    }
+
+    const raw = (await res.json()) as RawIssue[];
+    const issues: RoadmapIssue[] = raw
+      // The issues endpoint also returns pull requests — drop them.
+      .filter((item) => !item.pull_request)
+      .map((item) => ({
+        number: item.number,
+        title: item.title,
+        url: item.html_url,
+        state: item.state,
+        updatedAt: item.updated_at,
+        comments: item.comments,
+        labels: (item.labels ?? [])
+          .map((label) =>
+            typeof label === "string"
+              ? { name: label, color: "888888" }
+              : { name: label.name, color: label.color || "888888" },
+          )
+          .filter((label) => label.name),
+        subIssues: item.sub_issues_summary && item.sub_issues_summary.total > 0
+          ? {
+              total: item.sub_issues_summary.total,
+              completed: item.sub_issues_summary.completed,
+              percent: item.sub_issues_summary.percent_completed,
+            }
+          : null,
+      }));
+
+    return NextResponse.json({ repo: REPO, fetchedAt: new Date().toISOString(), issues });
+  } catch (error) {
+    return NextResponse.json(
+      { repo: REPO, issues: [], error: error instanceof Error ? error.message : "Fetch failed" },
+      { status: 200 },
+    );
+  }
+}

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -172,7 +172,7 @@
   .hero-copy p.lede {
     font-size: 21px;
     line-height: 1.5;
-    max-width: 540px;
+    max-width: 580px;
     margin-bottom: 34px;
     text-wrap: pretty;
   }

--- a/web/src/app/pattern-lab/PatternLab.module.css
+++ b/web/src/app/pattern-lab/PatternLab.module.css
@@ -86,6 +86,10 @@
   letter-spacing: 0;
 }
 
+.previewHeader {
+  justify-content: flex-end;
+}
+
 .stats {
   justify-content: flex-end;
   text-align: right;
@@ -161,6 +165,37 @@
   font-family: var(--font-jetbrains), monospace;
   font-size: 12px;
   font-weight: 500;
+}
+
+.knobHeaderMeta {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.knobButton {
+  min-height: 26px;
+  border: 1px solid rgba(23, 21, 18, 0.22);
+  background: #ffffff;
+  color: #171512;
+  padding: 0 10px;
+  font: inherit;
+  font-family: var(--font-jetbrains), monospace;
+  font-size: 11px;
+  text-transform: uppercase;
+  cursor: pointer;
+  user-select: none;
+  touch-action: none;
+}
+
+.knobButton:hover {
+  border-color: #171512;
+}
+
+.knobButton:active {
+  background: #171512;
+  color: #f7f3ea;
+  border-color: #171512;
 }
 
 .knobRow {
@@ -293,6 +328,23 @@
   border-color: #171512 !important;
 }
 
+.editorActions {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.editorHeader .guideButton {
+  background: #e8dcc2 !important;
+  color: #171512 !important;
+  border-color: #171512 !important;
+}
+
+.editorHeader .guideButton:hover {
+  background: #d9c8a4 !important;
+}
+
 .sweepBar {
   margin-top: 12px;
   padding-top: 12px;
@@ -371,6 +423,106 @@
 .emptyState {
   margin: 0;
   padding: 18px 14px;
+}
+
+.modalOverlay {
+  position: fixed;
+  inset: 0;
+  z-index: 50;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 22px;
+  background: rgba(23, 21, 18, 0.55);
+}
+
+.modalCard {
+  width: min(560px, 100%);
+  max-height: 90vh;
+  overflow-y: auto;
+  border: 1px solid #171512;
+  background: #fffdf8;
+  color: #171512;
+}
+
+.modalHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 14px 16px;
+  border-bottom: 1px solid rgba(23, 21, 18, 0.18);
+}
+
+.modalHeader span {
+  font-size: 14px;
+  font-weight: 700;
+}
+
+.modalHeader button {
+  min-width: 30px;
+  min-height: 30px;
+  border: 1px solid rgba(23, 21, 18, 0.22);
+  background: #ffffff;
+  color: #171512;
+  font-size: 18px;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.modalHeader button:hover {
+  border-color: #171512;
+}
+
+.modalBody {
+  padding: 16px;
+  font-size: 13px;
+  line-height: 1.6;
+}
+
+.modalBody p {
+  margin: 0 0 12px;
+}
+
+.modalBody h4 {
+  margin: 20px 0 10px;
+  padding-top: 14px;
+  border-top: 1px solid rgba(23, 21, 18, 0.14);
+  font-size: 13px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.modalBody ul {
+  margin: 0 0 12px;
+  padding-left: 18px;
+  display: grid;
+  gap: 8px;
+}
+
+.modalBody code {
+  font-family: var(--font-jetbrains), monospace;
+  font-size: 12px;
+  background: rgba(23, 21, 18, 0.07);
+  padding: 1px 4px;
+}
+
+.modalBody pre {
+  margin: 0 0 12px;
+  padding: 12px;
+  overflow-x: auto;
+  border: 1px solid rgba(23, 21, 18, 0.18);
+  background: #171512;
+  color: #f7f3ea;
+  font-family: var(--font-jetbrains), monospace;
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.modalNote {
+  color: rgba(23, 21, 18, 0.62);
+  font-size: 12px;
 }
 
 @media (max-width: 980px) {

--- a/web/src/app/pattern-lab/PatternLabClient.tsx
+++ b/web/src/app/pattern-lab/PatternLabClient.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import Editor from "@monaco-editor/react";
-import Link from "next/link";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { analyzeEsp32Cost } from "@/lib/esp32CostAnalyzer";
 import {
@@ -18,7 +17,7 @@ import {
   LOGICAL_KNOB_UNITS_PER_TURN,
   LOGICAL_KNOB_WRAP,
 } from "@/lib/patternflowControls";
-import { sdfRunesPattern } from "@/lib/patternSamples";
+import { preset as originPreset } from "@/lib/presets/pattern-origin";
 import styles from "./PatternLab.module.css";
 
 const knobLabels = ["Knob 1", "Knob 2", "Knob 3", "Knob 4"];
@@ -125,7 +124,7 @@ function updateRangeValue(range: KnobRange, edge: "min" | "max", nextValue: numb
 }
 
 export default function PatternLabClient() {
-  const [code, setCode] = useState(sdfRunesPattern);
+  const [code, setCode] = useState(originPreset.code);
   const [knobs, setKnobs] = useState(initialKnobs);
   const [ranges, setRanges] = useState<KnobRange[]>(defaultRanges);
   const [running, setRunning] = useState(true);
@@ -136,6 +135,7 @@ export default function PatternLabClient() {
   const [copied, setCopied] = useState(false);
   const [promptCopied, setPromptCopied] = useState(false);
   const [cppPromptCopied, setCppPromptCopied] = useState(false);
+  const [buttonHelpOpen, setButtonHelpOpen] = useState(false);
   const [activeRangeId, setActiveRangeId] = useState<string | null>(null);
   const [editingRange, setEditingRange] = useState<RangeEditState | null>(null);
 
@@ -148,6 +148,8 @@ export default function PatternLabClient() {
   const runtimeErrorRef = useRef<string | null>(null);
   const rangesRef = useRef(ranges);
   const rangeDragRef = useRef<RangeDragState | null>(null);
+  const btnHeldRef = useRef([false, false, false, false]);
+  const btnPressPendingRef = useRef([false, false, false, false]);
 
   const cost = useMemo(() => analyzeEsp32Cost(code), [code]);
 
@@ -217,6 +219,10 @@ export default function PatternLabClient() {
       const knobNormalized = getNormalizedKnobs(currentKnobs, currentRanges);
       previousKnobsRef.current = [...currentKnobs];
 
+      const btnHeld = [...btnHeldRef.current];
+      const btnPressed = [...btnPressPendingRef.current];
+      btnPressPendingRef.current = [false, false, false, false];
+
       const runtime = runtimeRef.current;
       const canvas = canvasRef.current;
       if (runtime && canvas) {
@@ -228,6 +234,8 @@ export default function PatternLabClient() {
             knobValues: currentKnobs,
             knobNormalized,
             knobRanges: currentRanges,
+            btnPressed,
+            btnHeld,
           }),
         );
         lastRenderMs = performance.now() - startedAt;
@@ -260,6 +268,30 @@ export default function PatternLabClient() {
   const updateKnob = (index: number, value: number) => {
     setKnobs((current) => current.map((item, itemIndex) => itemIndex === index ? value : item));
   };
+
+  const pressButton = (index: number) => {
+    if (btnHeldRef.current[index]) return;
+    btnHeldRef.current[index] = true;
+    btnPressPendingRef.current[index] = true;
+  };
+
+  const releaseButton = (index: number) => {
+    btnHeldRef.current[index] = false;
+  };
+
+  useEffect(() => {
+    const releaseAll = () => {
+      btnHeldRef.current = [false, false, false, false];
+    };
+    window.addEventListener("pointerup", releaseAll);
+    window.addEventListener("pointercancel", releaseAll);
+    window.addEventListener("blur", releaseAll);
+    return () => {
+      window.removeEventListener("pointerup", releaseAll);
+      window.removeEventListener("pointercancel", releaseAll);
+      window.removeEventListener("blur", releaseAll);
+    };
+  }, []);
 
   const updateRange = useCallback((index: number, edge: "min" | "max", value: number) => {
     if (!Number.isFinite(value)) return;
@@ -499,6 +531,7 @@ Required API for every variation:
 - Use input.knobValues as the primary control API. input.knobValues is an array of 4 absolute knob values after the min/max ranges are applied.
 - input.knobNormalized is also available when a 0.0-1.0 value is useful.
 - Keep input.knobDeltas only as compatibility fallback if needed.
+- Optional: each knob also has a push button. input.btnPressed[i] is true only on the frame it is pressed (edge); input.btnHeld[i] is true while it is held down. Use these for momentary actions like reset, freeze, cycle, or trigger. Do not use long-press or mode-switching; that is a reserved system gesture.
 - Use display.width and display.height in loops. Do not hardcode 128 or 64 inside draw().
 - Use only plain JavaScript and Math.*. No browser APIs, DOM APIs, imports, async code, external libraries, dynamic evaluation, or per-pixel allocations.
 
@@ -619,6 +652,7 @@ When in doubt, use sqrtf.
 - In update(): param += input.knobDeltas[i] * STEP[i]; then constrain to the min/max range.
 - Use the calibrated encoder step below as STEP so physical encoders match the live editor and one detent feels the same on both.
 - Preserve knob meanings from the JS code (any comments naming the knobs) in KNOB_LABELS.
+- Encoder buttons map 1:1: JS input.btnPressed[i] / input.btnHeld[i] become C++ input.btnPressed[i] / input.btnHeld[i] (same bool[4] semantics — edge vs level). If the JS pattern resets, freezes, or triggers on a button, keep that. Never consume long-press; that gesture is reserved for the firmware mode switcher.
 
 Pattern Lab knob ranges and current values:
 ${rangeLines}
@@ -651,21 +685,9 @@ ${code}
 
   return (
     <main className={`${styles.shell}${activeRangeId ? ` ${styles.shellDragging}` : ""}`}>
-      <header className={styles.header}>
-        <Link className={styles.brand} href="/">Patternflow</Link>
-        <div className={styles.headerMeta}>
-          <span>Pattern Lab</span>
-          <span>128 x 64</span>
-          <span>{running ? "Running" : "Paused"}</span>
-        </div>
-      </header>
-
       <section className={styles.workspace}>
         <div className={styles.previewColumn}>
           <div className={styles.previewHeader}>
-            <div>
-              <h1>Preview</h1>
-            </div>
             <div className={styles.stats}>
               <span>{renderStats.fps.toFixed(0)} fps</span>
               <span>{renderStats.ms.toFixed(2)} ms</span>
@@ -693,7 +715,34 @@ ${code}
               <div key={knobLabels[index]} className={styles.knobControl}>
                 <div className={styles.knobHeader}>
                   <span>{knobLabels[index]}</span>
-                  <strong>{formatKnob(value)}</strong>
+                  <div className={styles.knobHeaderMeta}>
+                    <strong>{formatKnob(value)}</strong>
+                    <button
+                      type="button"
+                      className={styles.knobButton}
+                      aria-label={`${knobLabels[index]} button`}
+                      title="Encoder button (short press)"
+                      onPointerDown={(event) => {
+                        event.preventDefault();
+                        pressButton(index);
+                      }}
+                      onPointerUp={() => releaseButton(index)}
+                      onPointerLeave={() => releaseButton(index)}
+                      onKeyDown={(event) => {
+                        if (event.key === "Enter" || event.key === " ") {
+                          event.preventDefault();
+                          pressButton(index);
+                        }
+                      }}
+                      onKeyUp={(event) => {
+                        if (event.key === "Enter" || event.key === " ") {
+                          releaseButton(index);
+                        }
+                      }}
+                    >
+                      Push
+                    </button>
+                  </div>
                 </div>
                 <div className={styles.knobRow}>
                   <label className={styles.rangeEndpoint}>
@@ -751,15 +800,21 @@ ${code}
 
         <div className={styles.editorColumn}>
           <div className={styles.editorHeader}>
-            <div>
-              <span>JavaScript Pattern</span>
+            <button
+              type="button"
+              className={styles.guideButton}
+              onClick={() => setButtonHelpOpen(true)}
+            >
+              Code guide
+            </button>
+            <div className={styles.editorActions}>
+              <button type="button" onClick={copyVariantPrompt}>
+                {promptCopied ? "Copied" : "Copy 5 variants prompt"}
+              </button>
+              <button type="button" onClick={copyCppPrompt}>
+                {cppPromptCopied ? "Copied" : "Copy C++ prompt"}
+              </button>
             </div>
-            <button type="button" onClick={copyVariantPrompt}>
-              {promptCopied ? "Copied" : "Copy 5 variants prompt"}
-            </button>
-            <button type="button" onClick={copyCppPrompt}>
-              {cppPromptCopied ? "Copied" : "Copy C++ prompt"}
-            </button>
           </div>
           <div className={styles.editorPane}>
           <Editor
@@ -802,6 +857,98 @@ ${code}
           <p className={styles.emptyState}>No snapshots yet.</p>
         )}
       </section>
+
+      {buttonHelpOpen && (
+        <div
+          className={styles.modalOverlay}
+          role="dialog"
+          aria-modal="true"
+          aria-label="Code guide"
+          onClick={() => setButtonHelpOpen(false)}
+        >
+          <div className={styles.modalCard} onClick={(event) => event.stopPropagation()}>
+            <div className={styles.modalHeader}>
+              <span>Code guide — encoder buttons</span>
+              <button type="button" onClick={() => setButtonHelpOpen(false)} aria-label="Close">
+                ×
+              </button>
+            </div>
+            <div className={styles.modalBody}>
+              <p>
+                A pattern is plain JavaScript that exports three functions. Only{" "}
+                <code>draw</code> is required.
+              </p>
+              <pre>{`export function setup(params) {}              // runs once on load
+export function update(dt, input, params) {}  // runs each frame, before draw
+export function draw(display, params, time) {} // runs each frame`}</pre>
+              <p>
+                Store your state on the <code>params</code> object — it persists between frames.{" "}
+                <code>dt</code> is the seconds elapsed since the last frame, <code>time</code> the
+                seconds since load.
+              </p>
+
+              <h4>Controls — the input object</h4>
+              <ul>
+                <li>
+                  <code>input.knobValues[i]</code> — the knob&apos;s absolute value after its
+                  min/max range is applied. This is the primary control API.
+                </li>
+                <li>
+                  <code>input.knobNormalized[i]</code> — the same knob remapped to{" "}
+                  <code>0.0–1.0</code>, handy for blends.
+                </li>
+                <li>
+                  <code>input.knobRanges[i]</code> — the <code>[min, max]</code> pair set by the
+                  range fields under each knob.
+                </li>
+                <li>
+                  <code>input.knobDeltas[i]</code> — per-frame change in encoder detents
+                  (hardware-style); keep only as a fallback.
+                </li>
+                <li>
+                  <code>input.btnPressed[i]</code> — true only on the frame button <code>i</code> is
+                  pressed (edge). Use for one-shot actions: reset, cycle, snapshot, trigger.
+                </li>
+                <li>
+                  <code>input.btnHeld[i]</code> — true while button <code>i</code> is held down
+                  (level). Use for momentary holds: freeze, boost, reveal.
+                </li>
+              </ul>
+              <p className={styles.modalNote}>
+                <code>i</code> is <code>0–3</code>, matching Knob 1–4. Press a knob&apos;s{" "}
+                <code>Push</code> button in the controls panel to fire its button flags.
+              </p>
+
+              <h4>Encoder buttons</h4>
+              <pre>{`export function update(dt, input, params) {
+  if (input.btnPressed[0]) params.hue = 0;     // reset on tap
+  if (input.btnHeld[1]) params.frozen = true;   // act while held
+}`}</pre>
+              <p className={styles.modalNote}>
+                Long-press is reserved for the firmware mode switcher — don&apos;t build
+                mode-switching on the buttons. The Origin preset taps each knob to reset that value.
+              </p>
+
+              <h4>Drawing</h4>
+              <ul>
+                <li>
+                  <code>display.width</code> / <code>display.height</code> — loop with these, never
+                  hardcode 128 or 64.
+                </li>
+                <li>
+                  <code>display.setPixel(x, y, r, g, b)</code> — write one pixel; <code>r/g/b</code>{" "}
+                  are <code>0–255</code>.
+                </li>
+              </ul>
+              <p className={styles.modalNote}>
+                Use only plain JavaScript and <code>Math.*</code> — no DOM, imports, async, or
+                per-pixel allocations. The two prompt buttons generate AI variations of the current
+                pattern, or convert it into ESP32 firmware.
+              </p>
+            </div>
+          </div>
+        </div>
+      )}
     </main>
   );
 }

--- a/web/src/app/roadmap/Roadmap.module.css
+++ b/web/src/app/roadmap/Roadmap.module.css
@@ -1,0 +1,150 @@
+.shell {
+  max-width: 820px;
+  margin: 0 auto;
+  padding: 48px 24px 96px;
+  color: var(--pf-ink);
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding-bottom: 24px;
+  border-bottom: 1px solid var(--pf-rule);
+}
+
+.back,
+.repoLink {
+  color: var(--pf-ink);
+  font-family: var(--pf-mono);
+  font-size: var(--pf-fs-mono);
+  letter-spacing: var(--pf-track-mono);
+  text-decoration: none;
+  text-transform: uppercase;
+}
+
+.repoLink {
+  color: var(--pf-ink-muted);
+}
+
+.back:hover,
+.repoLink:hover {
+  color: var(--pf-ink);
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+
+.intro {
+  margin: 40px 0 28px;
+}
+
+.title {
+  margin: 0 0 12px;
+  font-size: clamp(34px, 5vw, 56px);
+  font-weight: 500;
+  letter-spacing: -0.02em;
+  line-height: 1.05;
+}
+
+.sub {
+  max-width: 56ch;
+  margin: 0;
+  color: var(--pf-ink-muted);
+  font-size: var(--pf-fs-body);
+  line-height: 1.5;
+}
+
+.muted {
+  color: var(--pf-ink-muted);
+  font-family: var(--pf-mono);
+  font-size: var(--pf-fs-mono);
+  letter-spacing: var(--pf-track-mono);
+}
+
+.list {
+  display: grid;
+  gap: 0;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  border-top: 1px solid var(--pf-rule);
+}
+
+.item {
+  display: grid;
+  gap: 10px;
+  padding: 18px 2px;
+  border-bottom: 1px solid var(--pf-rule);
+  color: var(--pf-ink);
+  text-decoration: none;
+}
+
+.item:hover {
+  background: var(--pf-cream);
+}
+
+.top {
+  display: flex;
+  align-items: baseline;
+  gap: 12px;
+}
+
+.num {
+  flex: 0 0 auto;
+  color: var(--pf-ink-faint);
+  font-family: var(--pf-mono);
+  font-size: var(--pf-fs-mono);
+  letter-spacing: var(--pf-track-mono);
+}
+
+.issueTitle {
+  font-size: var(--pf-fs-row);
+  line-height: 1.3;
+}
+
+.labels {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.label {
+  padding: 1px 8px;
+  border: 1px solid;
+  border-radius: 999px;
+  font-family: var(--pf-mono);
+  font-size: 10.5px;
+  letter-spacing: 0.04em;
+  text-transform: lowercase;
+  opacity: 0.85;
+}
+
+.progress {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.bar {
+  position: relative;
+  flex: 1 1 auto;
+  height: 4px;
+  max-width: 260px;
+  background: var(--pf-rule);
+  overflow: hidden;
+}
+
+.bar > span {
+  position: absolute;
+  inset: 0 auto 0 0;
+  background: var(--pf-ink);
+}
+
+.progressText {
+  flex: 0 0 auto;
+  color: var(--pf-ink-muted);
+  font-family: var(--pf-mono);
+  font-size: var(--pf-fs-mono);
+  letter-spacing: var(--pf-track-mono);
+}

--- a/web/src/app/roadmap/page.tsx
+++ b/web/src/app/roadmap/page.tsx
@@ -1,0 +1,104 @@
+'use client';
+
+import Link from 'next/link';
+import { useEffect, useState } from 'react';
+import styles from './Roadmap.module.css';
+
+type RoadmapIssue = {
+  number: number;
+  title: string;
+  url: string;
+  state: string;
+  updatedAt: string;
+  comments: number;
+  labels: { name: string; color: string }[];
+  subIssues: { total: number; completed: number; percent: number } | null;
+};
+
+type RoadmapData = { repo?: string; fetchedAt?: string; issues: RoadmapIssue[]; error?: string };
+
+const GITHUB_ISSUES_URL = 'https://github.com/engmung/PatternFlow/issues';
+
+export default function RoadmapPage() {
+  const [data, setData] = useState<RoadmapData | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    fetch('/api/roadmap')
+      .then((res) => res.json())
+      .then((payload: RoadmapData) => {
+        if (active) setData(payload);
+      })
+      .catch(() => {
+        if (active) setData({ issues: [], error: 'Failed to load' });
+      });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  return (
+    <main className={styles.shell}>
+      <header className={styles.header}>
+        <Link className={styles.back} href="/">
+          ← Patternflow
+        </Link>
+        <a className={styles.repoLink} href={GITHUB_ISSUES_URL} target="_blank" rel="noreferrer">
+          Live from GitHub
+        </a>
+      </header>
+
+      <div className={styles.intro}>
+        <h1 className={styles.title}>Project status</h1>
+        <p className={styles.sub}>
+          Open issues pulled straight from the repo — a live view of what is being worked on right
+          now, with sub-issue progress where it is tracked. Experimental.
+        </p>
+      </div>
+
+      {data === null ? (
+        <p className={styles.muted}>Loading issues…</p>
+      ) : data.issues.length === 0 ? (
+        <p className={styles.muted}>
+          {data.error ? `Could not load issues (${data.error}).` : 'No open issues right now.'}
+        </p>
+      ) : (
+        <ul className={styles.list}>
+          {data.issues.map((issue) => (
+            <li key={issue.number}>
+              <a className={styles.item} href={issue.url} target="_blank" rel="noreferrer">
+                <div className={styles.top}>
+                  <span className={styles.num}>#{issue.number}</span>
+                  <span className={styles.issueTitle}>{issue.title}</span>
+                </div>
+                {issue.labels.length > 0 && (
+                  <div className={styles.labels}>
+                    {issue.labels.map((label) => (
+                      <span
+                        key={label.name}
+                        className={styles.label}
+                        style={{ borderColor: `#${label.color}`, color: `#${label.color}` }}
+                      >
+                        {label.name}
+                      </span>
+                    ))}
+                  </div>
+                )}
+                {issue.subIssues && (
+                  <div className={styles.progress}>
+                    <span className={styles.bar}>
+                      <span style={{ width: `${issue.subIssues.percent}%` }} />
+                    </span>
+                    <span className={styles.progressText}>
+                      {issue.subIssues.completed}/{issue.subIssues.total}
+                    </span>
+                  </div>
+                )}
+              </a>
+            </li>
+          ))}
+        </ul>
+      )}
+    </main>
+  );
+}

--- a/web/src/components/sections/BuildPanel.module.css
+++ b/web/src/components/sections/BuildPanel.module.css
@@ -152,6 +152,18 @@
   background: var(--pf-cream-2);
 }
 
+.matrixLink strong {
+  text-decoration: underline;
+  text-underline-offset: 3px;
+  text-decoration-thickness: 1px;
+}
+
+.matrixLink:hover,
+.matrixLink:focus-visible {
+  outline: 0;
+  background: var(--pf-cream-2);
+}
+
 .pathLinks {
   display: flex;
   flex-wrap: wrap;

--- a/web/src/components/sections/BuildPanel.tsx
+++ b/web/src/components/sections/BuildPanel.tsx
@@ -192,9 +192,9 @@ export default function BuildPanel({ content, isActive }: BuildPanelProps) {
           <div className={`pf-prose ${styles.pathIntro}`}>
             <p>
               Pick one enclosure path and one electronics path. The current guide is the complete
-              route today; the other combinations are being prepared so you can start with the
-              tools, budget, and space you actually have. The custom PCB is stable; PCBA may
-              come later as an easier assembly option.
+              route today; the other combinations are in active testing — follow the linked issues
+              to track progress — so you can start with the tools, budget, and space you actually
+              have. The custom PCB is stable; PCBA may come later as an easier assembly option.
             </p>
           </div>
           <div className={styles.buildMatrix} role="table" aria-label="Build combinations">
@@ -206,24 +206,24 @@ export default function BuildPanel({ content, isActive }: BuildPanelProps) {
             <div className={`${styles.matrixCell} ${styles.matrixHeader} ${styles.matrixColumnHeader}`} role="columnheader">Breadboard</div>
 
             <div className={`${styles.matrixCell} ${styles.matrixHeader} ${styles.matrixRowHeader}`} role="rowheader">3D print</div>
-            <a className={`${styles.matrixCell} ${styles.matrixOption} ${styles.matrixCurrent}`} href="https://github.com/engmung/PatternFlow/blob/main/BUILD_GUIDE.md" target="_blank" rel="noreferrer" role="cell">
-              <strong>PLA print</strong>
-              <strong>Hand solder</strong>
+            <a className={`${styles.matrixCell} ${styles.matrixOption} ${styles.matrixCurrent} ${styles.matrixLink}`} href="https://github.com/engmung/PatternFlow/blob/main/BUILD_GUIDE.md" target="_blank" rel="noreferrer" role="cell">
+              <strong>Build guide</strong>
+              <span>PLA print · hand solder</span>
             </a>
-            <div className={`${styles.matrixCell} ${styles.matrixOption}`} role="cell">
-              <strong>Preparing</strong>
+            <a className={`${styles.matrixCell} ${styles.matrixOption} ${styles.matrixLink}`} href="https://github.com/engmung/PatternFlow/issues/121" target="_blank" rel="noreferrer" role="cell">
+              <strong>In testing</strong>
               <span>PCB-free wiring</span>
-            </div>
+            </a>
 
             <div className={`${styles.matrixCell} ${styles.matrixHeader} ${styles.matrixRowHeader}`} role="rowheader">Laser cut</div>
-            <div className={`${styles.matrixCell} ${styles.matrixOption}`} role="cell">
-              <strong>Preparing</strong>
+            <a className={`${styles.matrixCell} ${styles.matrixOption} ${styles.matrixLink}`} href="https://github.com/engmung/PatternFlow/issues/123" target="_blank" rel="noreferrer" role="cell">
+              <strong>In testing</strong>
               <span>Flat enclosure</span>
-            </div>
-            <div className={`${styles.matrixCell} ${styles.matrixOption}`} role="cell">
-              <strong>Preparing</strong>
+            </a>
+            <a className={`${styles.matrixCell} ${styles.matrixOption} ${styles.matrixLink}`} href="https://github.com/engmung/PatternFlow/issues/123" target="_blank" rel="noreferrer" role="cell">
+              <strong>In testing</strong>
               <span>Lowest fabrication path</span>
-            </div>
+            </a>
           </div>
           <div className={styles.pathLinks}>
             <a className="pf-link" href="https://github.com/engmung/PatternFlow/blob/main/docs/assembly/README.md" target="_blank" rel="noreferrer">

--- a/web/src/components/sections/Hero.tsx
+++ b/web/src/components/sections/Hero.tsx
@@ -11,11 +11,14 @@ export default function Hero() {
         <h1>
           <em className="wordmark">Patternflow</em>
         </h1>
-        <div className="kicker">An LED synthesizer.</div>
+        <div className="kicker">An open-source LED synthesizer played with the fingertips.</div>
         <p className="lede">
-          Play light patterns with your fingertips.
+          Interactive media art has felt expensive and exclusive.
           <br />
-          An open-source reinterpretation of{" "}
+          Patternflow makes it something anyone can make.
+          <br />
+          <br />
+          A reinterpretation of{" "}
           <a
             className="has-tip"
             data-tip="View on MoMA"
@@ -47,12 +50,14 @@ export default function Hero() {
           </em>{" "}
           (1963).
           <br />
-          <br />
-          Making interactive media art something anyone can make.
-          <br />
-          If Nam June Paik brought participation into art,
+          Where Paik brought participation into art,
           <br />
           Patternflow puts creation in everyone&apos;s hands.
+          <br />
+          <br />
+          So it&apos;s not a single device, but an open system
+          <br />
+          to build, code, and share your own light.
         </p>
         <p className="hero-kit-note">
           All source files are on GitHub.

--- a/web/src/components/sections/InsidePanel.module.css
+++ b/web/src/components/sections/InsidePanel.module.css
@@ -425,15 +425,63 @@
   font-weight: 500;
 }
 
-.journalLink {
-  display: inline-block;
-  max-width: 58ch;
+.storyLinks {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  margin-top: 24px;
+  border-top: 1px solid var(--pf-rule);
+}
+
+.storyLinkCell {
+  display: grid;
+  align-content: start;
+  gap: 8px;
+  padding: 18px 0;
   color: var(--pf-ink);
-  font-size: var(--pf-fs-body);
-  line-height: 1.65;
+  text-decoration: none;
+}
+
+.storyLinkCell:first-child {
+  padding-right: 28px;
+  border-right: 1px solid var(--pf-rule);
+}
+
+.storyLinkCell:last-child {
+  padding-left: 28px;
+}
+
+.storyLinkCell:hover .storyLinkText {
   text-decoration: underline;
   text-decoration-thickness: 1px;
   text-underline-offset: 4px;
+}
+
+.storyLinkLabel {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  color: var(--pf-ink);
+  font-family: var(--pf-mono);
+  font-size: var(--pf-fs-mono);
+  letter-spacing: var(--pf-track-mono);
+  text-transform: uppercase;
+}
+
+.storyLinkText {
+  max-width: 42ch;
+  color: var(--pf-ink-muted);
+  font-size: var(--pf-fs-body);
+  line-height: 1.55;
+}
+
+.wipTag {
+  padding: 1px 7px;
+  border: 1px solid var(--pf-rule);
+  border-radius: 999px;
+  color: var(--pf-ink-muted);
+  font-size: 10px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
 }
 
 @media (max-width: 900px) {
@@ -466,5 +514,22 @@
 
   .storyList li::before {
     left: 54px;
+  }
+}
+
+@media (max-width: 720px) {
+  .storyLinks {
+    grid-template-columns: 1fr;
+  }
+
+  .storyLinkCell:first-child {
+    padding-right: 0;
+    padding-bottom: 18px;
+    border-right: 0;
+    border-bottom: 1px solid var(--pf-rule);
+  }
+
+  .storyLinkCell:last-child {
+    padding-left: 0;
   }
 }

--- a/web/src/components/sections/InsidePanel.tsx
+++ b/web/src/components/sections/InsidePanel.tsx
@@ -261,9 +261,23 @@ export default function InsidePanel({ content }: InsidePanelProps) {
               </span>
             </li>
           </ol>
-          <Link className={styles.journalLink} href="/journal">
-            Read the journal for the fuller story, including the thoughts and feelings along the way.
-          </Link>
+          <div className={styles.storyLinks}>
+            <Link className={styles.storyLinkCell} href="/journal">
+              <span className={styles.storyLinkLabel}>Journal</span>
+              <span className={styles.storyLinkText}>
+                Read the fuller story, including the thoughts and feelings along the way.
+              </span>
+            </Link>
+            <Link className={styles.storyLinkCell} href="/roadmap">
+              <span className={styles.storyLinkLabel}>
+                Project status
+                <span className={styles.wipTag}>Work in progress</span>
+              </span>
+              <span className={styles.storyLinkText}>
+                A live view of what is being worked on right now, pulled from GitHub.
+              </span>
+            </Link>
+          </div>
         </div>
       </div>
 

--- a/web/src/lib/patternHarness.ts
+++ b/web/src/lib/patternHarness.ts
@@ -149,6 +149,8 @@ export function createIdleInput(
     knobValues?: number[];
     knobNormalized?: number[];
     knobRanges?: Array<[number, number]>;
+    btnPressed?: boolean[];
+    btnHeld?: boolean[];
   } = {},
 ): PatternInput {
   return {
@@ -156,8 +158,8 @@ export function createIdleInput(
     knobValues: options.knobValues,
     knobNormalized: options.knobNormalized,
     knobRanges: options.knobRanges,
-    btnPressed: [false, false, false, false],
-    btnHeld: [false, false, false, false],
+    btnPressed: Array.from({ length: PATTERN_KNOB_COUNT }, (_, index) => options.btnPressed?.[index] ?? false),
+    btnHeld: Array.from({ length: PATTERN_KNOB_COUNT }, (_, index) => options.btnHeld?.[index] ?? false),
   };
 }
 

--- a/web/src/lib/presets/pattern-origin.ts
+++ b/web/src/lib/presets/pattern-origin.ts
@@ -7,6 +7,7 @@ export const preset: LivePreset = {
   desc: "Concentric sine waves sampled by an emergent grid",
   code: `// Origin — concentric sine waves sampled by an emergent tile grid.
 // Knob 1: Hue (0..1) · Knob 2: Speed · Knob 3: Mode/tiling (0..4) · Knob 4: Frequency
+// Encoder button (short press): resets that knob to its origin value.
 function hsvToRgb(h, s, v) {
     let r, g, b;
     let i = Math.floor(h * 6);
@@ -36,12 +37,27 @@ export function setup(params) {
 }
 
 export function update(dt, input, params) {
+    // Knobs set absolute values, but only follow a slider while it is
+    // actually moving — that way a button reset persists until the knob
+    // is touched again, just like the hardware encoders.
     if (input && input.knobValues) {
-        params.hue = input.knobValues[0];
-        params.speed = input.knobValues[1];
-        params.mode = input.knobValues[2];
-        params.freq = input.knobValues[3];
+        let v = input.knobValues;
+        if (!params.lastKnob) params.lastKnob = [v[0], v[1], v[2], v[3]];
+        if (Math.abs(v[0] - params.lastKnob[0]) > 1e-6) params.hue = v[0];
+        if (Math.abs(v[1] - params.lastKnob[1]) > 1e-6) params.speed = v[1];
+        if (Math.abs(v[2] - params.lastKnob[2]) > 1e-6) params.mode = v[2];
+        if (Math.abs(v[3] - params.lastKnob[3]) > 1e-6) params.freq = v[3];
+        params.lastKnob = [v[0], v[1], v[2], v[3]];
     }
+
+    // Encoder button (short press): reset that knob to its origin value.
+    if (input && input.btnPressed) {
+        if (input.btnPressed[0]) params.hue = 0.0;
+        if (input.btnPressed[1]) params.speed = 0.0;
+        if (input.btnPressed[2]) params.mode = 0.0;
+        if (input.btnPressed[3]) params.freq = 0.0;
+    }
+
     params.timeAcc += dt * params.speed;
 }
 


### PR DESCRIPTION
Web-only batch of landing/site improvements on `dev`.

## Pattern Lab encoder buttons (closes #122)
- Per-knob **Push** button (pointer + keyboard) firing a one-frame `btnPressed` edge and a `btnHeld` flag; released on pointerup/blur.
- `createIdleInput` now forwards `btnPressed`/`btnHeld` (previously hardcoded false).
- **Origin** is the default pattern; a knob tap resets that value, mirroring `pattern_origin.h`.
- Button API documented in the 5-variants and C++ prompts.
- New **Code guide** popup (pattern API, controls, buttons, drawing); removed the Pattern Lab header and Preview/JavaScript labels.

## Hero copy
- Lead subtitle aligned to the GitHub one-liner ("…played with the fingertips").
- Opens on the problem (interactive media art has felt expensive and exclusive) → Patternflow's answer → Paik participation→creation → "not a single device, but an open system".
- Widen `.lede` to the column width (540→580) to stop trailing-word orphans.

## Build matrix
- Relabel the current 3D-print/Custom-PCB cell as **Build guide**.
- Link in-progress combinations to their tracking issues: breadboard + 3D print (#121), laser-cut cells (#123), shown as "In testing"; linked cells are underlined anchors.

## Live project status (experimental)
- `/api/roadmap`: server-side GitHub REST fetch (token optional, 10-min cache) → open issues with labels + sub-issue progress.
- `/roadmap` page renders it as a minimal status board.
- Linked from the Inside panel's Story footer (Journal | Project status) with a "work in progress" tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)