### PR TITLE
chore: add GitHub issue form templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,51 @@
+name: Bug report
+description: Something is broken or not working as expected.
+labels: ["type:bug"]
+body:
+  - type: markdown
+    attributes:
+      value: Thanks for the report. The more concrete the steps, the faster it gets fixed.
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      description: Which part of the project does this affect?
+      options:
+        - firmware
+        - web
+        - pcb
+        - enclosure
+        - pattern
+        - docs
+        - not sure
+    validations:
+      required: true
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: What went wrong, and what did you expect instead?
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: List the exact steps so someone else can hit the same bug.
+      placeholder: |
+        1. ...
+        2. ...
+        3. ...
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Firmware version / commit
+      description: Release tag or git commit, if relevant (firmware/web bugs).
+      placeholder: e.g. v1.0.0 or commit abc1234
+  - type: textarea
+    id: context
+    attributes:
+      label: Anything else?
+      description: Photos, logs, board variant, browser — whatever helps.

--- a/.github/ISSUE_TEMPLATE/build_help.yml
+++ b/.github/ISSUE_TEMPLATE/build_help.yml
@@ -1,0 +1,39 @@
+name: Build / hardware help
+description: Stuck while building or flashing your own Patternflow.
+labels: ["type:question"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        For quick back-and-forth, the [Discord](https://discord.gg/Vr9QtsxeTk) is often faster.
+        Open an issue here when it is worth keeping a written record (e.g. an unclear step).
+  - type: dropdown
+    id: stage
+    attributes:
+      label: Which path / stage?
+      options:
+        - Custom PCB
+        - Breadboard wiring
+        - 3D printed enclosure
+        - Laser-cut enclosure
+        - Flashing firmware
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: stuck
+    attributes:
+      label: Where are you stuck?
+      description: What you are trying to do and what is going wrong.
+    validations:
+      required: true
+  - type: textarea
+    id: tried
+    attributes:
+      label: What have you tried?
+      description: Steps already attempted, error messages, measurements.
+  - type: textarea
+    id: photos
+    attributes:
+      label: Photos / parts
+      description: Drag in photos of the build, and list any parts or sources that differ from the BOM.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,9 @@
+# Turn off blank issues so everything starts from a template.
+blank_issues_enabled: false
+contact_links:
+  - name: Discord community
+    url: https://discord.gg/Vr9QtsxeTk
+    about: Build questions and general chat are usually fastest here.
+  - name: Contributing guide
+    url: https://github.com/engmung/PatternFlow/blob/main/CONTRIBUTING.md
+    about: How to contribute docs, firmware, hardware, or web changes.

--- a/.github/ISSUE_TEMPLATE/docs_issue.yml
+++ b/.github/ISSUE_TEMPLATE/docs_issue.yml
@@ -1,0 +1,24 @@
+name: Documentation issue
+description: Something in the guides, README, or site is wrong, unclear, or missing.
+labels: ["area:docs"]
+body:
+  - type: input
+    id: where
+    attributes:
+      label: Which doc or page?
+      description: File path or URL.
+      placeholder: e.g. BUILD_GUIDE.md, or https://patternflow.work/build
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: What is wrong or missing?
+      description: The unclear, outdated, or absent part.
+    validations:
+      required: true
+  - type: textarea
+    id: fix
+    attributes:
+      label: Suggested fix
+      description: How would you word or structure it? Optional.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,41 @@
+name: Feature request
+description: Suggest a new capability or addition.
+labels: ["type:feature"]
+body:
+  - type: markdown
+    attributes:
+      value: Lead with the problem you are trying to solve, not just the solution.
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      description: Which part of the project would this touch?
+      options:
+        - firmware
+        - web
+        - pcb
+        - enclosure
+        - pattern
+        - docs
+        - not sure
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / motivation
+      description: What is hard or missing today? Who does it affect?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What would you like to see happen?
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you thought about, if any.

--- a/.github/ISSUE_TEMPLATE/pattern_submission.yml
+++ b/.github/ISSUE_TEMPLATE/pattern_submission.yml
@@ -1,0 +1,46 @@
+name: Pattern submission
+description: Share a custom pattern you made for Patternflow.
+labels: ["area:pattern"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Custom patterns are separate from the official release firmware, but good ones
+        get shared with the community. You can develop and test patterns in the
+        [Pattern Lab](https://patternflow.work/pattern-lab).
+  - type: input
+    id: name
+    attributes:
+      label: Pattern name
+    validations:
+      required: true
+  - type: input
+    id: video
+    attributes:
+      label: Video / Instagram link
+      description: A short clip of it running, if you have one.
+  - type: textarea
+    id: code
+    attributes:
+      label: Pattern code or Pattern Lab JSON
+      description: Paste the JavaScript pattern, or the "Copy JSON" output from Pattern Lab.
+      render: javascript
+    validations:
+      required: true
+  - type: textarea
+    id: knobs
+    attributes:
+      label: Knob mapping
+      description: What does each of the four knobs (and buttons) do?
+      placeholder: |
+        Knob 1: ...
+        Knob 2: ...
+        Knob 3: ...
+        Knob 4: ...
+  - type: checkboxes
+    id: license
+    attributes:
+      label: License
+      options:
+        - label: I'm okay with this pattern being shared with the Patternflow community under the project license.
+          required: true


### PR DESCRIPTION
Adds structured issue forms so every new issue starts categorized and consistent — the first step toward a systematic issue/roadmap setup.

## What's included (`.github/ISSUE_TEMPLATE/`)
- **Bug report** → auto-labels `type:bug` (area dropdown, repro steps, version)
- **Feature request** → `type:feature` (problem-first, proposal, alternatives)
- **Build / hardware help** → `type:question` (path/stage, where stuck, photos)
- **Documentation issue** → `area:docs` (which page, what's wrong, suggested fix)
- **Pattern submission** → `area:pattern` (code/JSON, knob mapping, license check)
- **config.yml** → disables blank issues, links Discord + the contributing guide

All auto-applied labels already exist in the repo. Forms use the YAML "issue forms" format, so fields are enforced and render as proper inputs.

## Not included (suggested next steps)
- Milestones mapped to the roadmap phases
- A Projects v2 board for status (Todo / In progress / Done)
- Later: wire `/roadmap` to that board/milestones for richer visualization

🤖 Generated with [Claude Code](https://claude.com/claude-code)