### PR TITLE
docs: state pattern licensing in README + CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,9 @@ This file is intentionally a starting point. The contribution process will becom
 
 ## Pattern Contributions
 
-Custom patterns are welcome as community work, but official bundled firmware patterns will be curated for now. If you make something interesting, share it on Discord or open an issue with a video and the source.
+Custom patterns are welcome as community work, but official bundled firmware patterns will be curated for now. If you make something interesting, share it in the Discord **patterns** channel (follow the post guidelines there) or open an issue with the source.
+
+**Licensing — inbound = outbound.** By sharing a pattern (Discord, issue, or PR) you agree to license it under **CC-BY-SA 4.0** — the same commons as the rest of Patternflow — with attribution kept in the code header (`// Author:` and `// SPDX-License-Identifier: CC-BY-SA-4.0`). There is no copyright assignment (no CLA): you keep authorship, and the project just gets the right to bundle and redistribute it. You may set a different license in the header as long as it still lets the project bundle and redistribute the pattern.
 
 ## Project Rules
 

--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ Patternflow's PCB fabrication and 3D-printed enclosure are sponsored by **[PCBWa
 
 - Firmware & web — **MIT** ([LICENSE-MIT](./LICENSE-MIT))
 - Hardware & designs — **CC-BY-SA 4.0** ([LICENSE-CC-BY-SA](./LICENSE-CC-BY-SA))
+- Patterns — **CC-BY-SA 4.0**. Community submissions are inbound = outbound: by sharing a pattern you license it under CC-BY-SA 4.0 with attribution kept in the code header (no CLA). See [CONTRIBUTING.md](CONTRIBUTING.md).
 
 "Patternflow" is a trademark of SeungHun Lee.
 


### PR DESCRIPTION
Document the pattern licensing decision now that the Discord channel is set up (#116 closed).

- **README** License section: Patterns are **CC-BY-SA 4.0**, community submissions inbound = outbound (attribution in the code header, no CLA).
- **CONTRIBUTING.md** Pattern Contributions: spells out the same terms and points to the Discord patterns channel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)