### PR TITLE
ci: GitHub Actions — web build, Discord notify, roadmap snapshot

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,14 @@
+<!-- Keep it short. Delete any line that doesn't apply. -->
+
+## What
+<!-- One or two sentences: what does this change do? -->
+
+## Why
+<!-- The reason / the issue it fixes. Link issues like: Fixes #123 -->
+
+## Tested
+<!-- How did you check it works? (built locally, flashed the board, ran the site…) -->
+
+---
+- [ ] Touches `web/` → it builds (`npm run build`)
+- [ ] Sharing a pattern? It's CC-BY-SA 4.0 with an `// Author:` header (see CONTRIBUTING)

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,22 @@
+# Groups merged PRs into sections when you click "Generate release notes"
+# on a new GitHub release. Categories match by PR label, top to bottom.
+changelog:
+  exclude:
+    labels:
+      - skip-changelog
+  categories:
+    - title: 🚀 New features
+      labels:
+        - "type:feature"
+    - title: ✨ Improvements
+      labels:
+        - "type:improvement"
+    - title: 🐛 Fixes
+      labels:
+        - "type:bug"
+    - title: 📖 Docs
+      labels:
+        - "area:docs"
+    - title: 🧩 Other changes
+      labels:
+        - "*"

--- a/.github/scripts/build-roadmap.mjs
+++ b/.github/scripts/build-roadmap.mjs
@@ -1,0 +1,63 @@
+// Fetches open issues from the public repo and writes a static snapshot to
+// web/public/roadmap.json. Shape matches the old /api/roadmap response so the
+// /roadmap page can read the static file with no runtime token or rate limit.
+//
+// Run in CI (uses the built-in GITHUB_TOKEN) or locally:
+//   GITHUB_TOKEN=ghp_xxx node .github/scripts/build-roadmap.mjs
+import { writeFile, mkdir } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+
+const REPO = process.env.ROADMAP_REPO || "engmung/PatternFlow";
+const PER_PAGE = 30;
+const OUT = resolve(process.cwd(), "web/public/roadmap.json");
+
+const headers = {
+  Accept: "application/vnd.github+json",
+  "X-GitHub-Api-Version": "2022-11-28",
+  "User-Agent": "patternflow-roadmap-snapshot",
+};
+if (process.env.GITHUB_TOKEN) {
+  headers.Authorization = `Bearer ${process.env.GITHUB_TOKEN}`;
+}
+
+const res = await fetch(
+  `https://api.github.com/repos/${REPO}/issues?state=open&per_page=${PER_PAGE}&sort=updated&direction=desc`,
+  { headers },
+);
+if (!res.ok) {
+  throw new Error(`GitHub responded ${res.status}: ${await res.text()}`);
+}
+
+const raw = await res.json();
+const issues = raw
+  // The issues endpoint also returns pull requests — drop them.
+  .filter((item) => !item.pull_request)
+  .map((item) => ({
+    number: item.number,
+    title: item.title,
+    url: item.html_url,
+    state: item.state,
+    updatedAt: item.updated_at,
+    comments: item.comments,
+    labels: (item.labels ?? [])
+      .map((label) =>
+        typeof label === "string"
+          ? { name: label, color: "888888" }
+          : { name: label.name, color: label.color || "888888" },
+      )
+      .filter((label) => label.name),
+    subIssues:
+      item.sub_issues_summary && item.sub_issues_summary.total > 0
+        ? {
+            total: item.sub_issues_summary.total,
+            completed: item.sub_issues_summary.completed,
+            percent: item.sub_issues_summary.percent_completed,
+          }
+        : null,
+  }));
+
+const payload = { repo: REPO, fetchedAt: new Date().toISOString(), issues };
+
+await mkdir(dirname(OUT), { recursive: true });
+await writeFile(OUT, JSON.stringify(payload, null, 2) + "\n");
+console.log(`Wrote ${issues.length} issues to ${OUT}`);

--- a/.github/workflows/discord-notify.yml
+++ b/.github/workflows/discord-notify.yml
@@ -1,0 +1,90 @@
+name: Discord notify
+
+# Posts to Discord via webhooks when:
+#   - new commits land on main   → #dev-log   (DISCORD_WEBHOOK_DEV)
+#   - a GitHub release published  → #announcements (DISCORD_WEBHOOK_ANNOUNCE)
+# Set both secrets under Settings → Secrets and variables → Actions.
+# If a secret is missing, that job no-ops instead of failing.
+on:
+  push:
+    branches: [main]
+  release:
+    types: [published]
+
+jobs:
+  commits:
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post commits to #dev-log
+        uses: actions/github-script@v7
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_DEV }}
+        with:
+          script: |
+            const webhook = process.env.DISCORD_WEBHOOK;
+            if (!webhook) { core.info("DISCORD_WEBHOOK not set — skipping."); return; }
+
+            const commits = context.payload.commits || [];
+            if (commits.length === 0) { core.info("No commits in payload — skipping."); return; }
+
+            const repo = `${context.repo.owner}/${context.repo.repo}`;
+            const lines = commits.map((c) => {
+              const sha = c.id.slice(0, 7);
+              const msg = c.message.split("\n")[0].slice(0, 120);
+              return `[\`${sha}\`](${c.url}) ${msg} — ${c.author.name}`;
+            });
+
+            const payload = {
+              embeds: [{
+                title: `📦 ${commits.length} new commit${commits.length > 1 ? "s" : ""} on main`,
+                description: lines.join("\n").slice(0, 4000),
+                url: context.payload.compare,
+                color: 0x5865f2,
+                footer: { text: repo },
+                timestamp: new Date().toISOString(),
+              }],
+            };
+
+            const res = await fetch(webhook, {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify(payload),
+            });
+            if (!res.ok) core.setFailed(`Discord responded ${res.status}: ${await res.text()}`);
+
+  release:
+    if: github.event_name == 'release'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post release to #announcements
+        uses: actions/github-script@v7
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_ANNOUNCE }}
+        with:
+          script: |
+            const webhook = process.env.DISCORD_WEBHOOK;
+            if (!webhook) { core.info("DISCORD_WEBHOOK not set — skipping."); return; }
+
+            const r = context.payload.release;
+            const repo = `${context.repo.owner}/${context.repo.repo}`;
+            const body = (r.body || "").trim().slice(0, 3500) || "_No release notes._";
+
+            const payload = {
+              content: "@here",
+              embeds: [{
+                title: `🚀 ${r.name || r.tag_name}`,
+                description: body,
+                url: r.html_url,
+                color: 0x57f287,
+                footer: { text: repo },
+                timestamp: r.published_at,
+              }],
+            };
+
+            const res = await fetch(webhook, {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify(payload),
+            });
+            if (!res.ok) core.setFailed(`Discord responded ${res.status}: ${await res.text()}`);

--- a/.github/workflows/roadmap-snapshot.yml
+++ b/.github/workflows/roadmap-snapshot.yml
@@ -1,0 +1,45 @@
+name: Roadmap snapshot
+
+# Regenerates web/public/roadmap.json from open issues so the /roadmap page
+# reads a static file (no runtime GitHub token, no rate limit). Runs every few
+# hours, whenever issues change, and on manual dispatch.
+on:
+  schedule:
+    - cron: "0 */6 * * *" # every 6 hours
+  issues:
+    types: [opened, closed, reopened, edited, labeled, unlabeled]
+  workflow_dispatch:
+
+# Only one snapshot at a time; let the newest win.
+concurrency:
+  group: roadmap-snapshot
+  cancel-in-progress: true
+
+jobs:
+  snapshot:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Build roadmap.json
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: node .github/scripts/build-roadmap.mjs
+
+      - name: Commit if changed
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          if git diff --quiet -- web/public/roadmap.json; then
+            echo "No changes to roadmap.json."
+            exit 0
+          fi
+          git add web/public/roadmap.json
+          git commit -m "chore(roadmap): refresh snapshot [skip ci]"
+          git push

--- a/.github/workflows/web-ci.yml
+++ b/.github/workflows/web-ci.yml
@@ -1,0 +1,48 @@
+name: Web CI
+
+# Lint + build the Next.js site so broken code can't reach main.
+# Only runs when something under web/ (or this workflow) changes.
+on:
+  pull_request:
+    paths:
+      - "web/**"
+      - ".github/workflows/web-ci.yml"
+  push:
+    branches: [main]
+    paths:
+      - "web/**"
+      - ".github/workflows/web-ci.yml"
+
+# Cancel an in-progress run if newer commits are pushed to the same ref.
+concurrency:
+  group: web-ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: web
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: web/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      # Lint is reported but does not block the merge yet — the repo still has
+      # pre-existing lint errors. Drop continue-on-error once those are cleaned
+      # up to make lint a hard gate too.
+      - name: Lint
+        run: npm run lint
+        continue-on-error: true
+
+      # Build is the hard gate: broken code can't reach main.
+      - name: Build
+        run: npm run build

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,23 @@ Custom patterns are welcome as community work, but official bundled firmware pat
 
 **Licensing — inbound = outbound.** By sharing a pattern (Discord, issue, or PR) you agree to license it under **CC-BY-SA 4.0** — the same commons as the rest of Patternflow — with attribution kept in the code header (`// Author:` and `// SPDX-License-Identifier: CC-BY-SA-4.0`). There is no copyright assignment (no CLA): you keep authorship, and the project just gets the right to bundle and redistribute it. You may set a different license in the header as long as it still lets the project bundle and redistribute the pattern.
 
+## Commit messages
+
+Keep it simple: start with the area, then a short summary in plain present tense.
+
+```
+area: short summary
+
+web: collapse the preset list on mobile
+firmware: fix reversed encoder direction
+docs: clarify the breadboard wiring step
+```
+
+Common areas: `web`, `firmware`, `pcb`, `enclosure`, `docs`, `pattern`. Use
+`wip(area): …` for work that isn't finished yet. That's the whole rule — no
+tooling enforces it, it just keeps the history (and the Discord dev-log)
+readable.
+
 ## Project Rules
 
 Project rules and guidelines are currently under consideration and will be finalized in the future.

--- a/web/public/roadmap.json
+++ b/web/public/roadmap.json
@@ -1,0 +1,212 @@
+{
+  "repo": "engmung/PatternFlow",
+  "fetchedAt": "2026-06-25T04:14:21.843Z",
+  "issues": [
+    {
+      "number": 140,
+      "title": "Pattern Lab: proper AI agent integration (multi-model)",
+      "url": "https://github.com/engmung/PatternFlow/issues/140",
+      "state": "open",
+      "updatedAt": "2026-06-24T23:24:45Z",
+      "comments": 1,
+      "labels": [
+        {
+          "name": "area:web",
+          "color": "868e5f"
+        },
+        {
+          "name": "type:feature",
+          "color": "5b6776"
+        }
+      ],
+      "subIssues": null
+    },
+    {
+      "number": 113,
+      "title": "Enclosure for mass production",
+      "url": "https://github.com/engmung/PatternFlow/issues/113",
+      "state": "open",
+      "updatedAt": "2026-06-24T14:45:01Z",
+      "comments": 4,
+      "labels": [
+        {
+          "name": "area:enclosure",
+          "color": "15ac9f"
+        },
+        {
+          "name": "type:improvement",
+          "color": "6e7a89"
+        }
+      ],
+      "subIssues": null
+    },
+    {
+      "number": 123,
+      "title": "Laser-cut enclosure version + guide (post-launch)",
+      "url": "https://github.com/engmung/PatternFlow/issues/123",
+      "state": "open",
+      "updatedAt": "2026-06-24T05:50:57Z",
+      "comments": 1,
+      "labels": [
+        {
+          "name": "area:enclosure",
+          "color": "15ac9f"
+        },
+        {
+          "name": "type:feature",
+          "color": "5b6776"
+        }
+      ],
+      "subIssues": null
+    },
+    {
+      "number": 139,
+      "title": "Community engagement & retention mechanics (Discord gamification + activity pressure)",
+      "url": "https://github.com/engmung/PatternFlow/issues/139",
+      "state": "open",
+      "updatedAt": "2026-06-23T13:40:24Z",
+      "comments": 0,
+      "labels": [
+        {
+          "name": "area:community",
+          "color": "32b3ca"
+        },
+        {
+          "name": "type:improvement",
+          "color": "6e7a89"
+        },
+        {
+          "name": "type:question",
+          "color": "97a1ae"
+        }
+      ],
+      "subIssues": null
+    },
+    {
+      "number": 131,
+      "title": "Guide: creating and applying your own patterns",
+      "url": "https://github.com/engmung/PatternFlow/issues/131",
+      "state": "open",
+      "updatedAt": "2026-06-22T13:38:36Z",
+      "comments": 0,
+      "labels": [
+        {
+          "name": "area:docs",
+          "color": "d522b4"
+        },
+        {
+          "name": "type:feature",
+          "color": "5b6776"
+        }
+      ],
+      "subIssues": null
+    },
+    {
+      "number": 127,
+      "title": "Set up GitHub Actions automation",
+      "url": "https://github.com/engmung/PatternFlow/issues/127",
+      "state": "open",
+      "updatedAt": "2026-06-22T13:38:22Z",
+      "comments": 0,
+      "labels": [
+        {
+          "name": "area:web",
+          "color": "868e5f"
+        },
+        {
+          "name": "type:feature",
+          "color": "5b6776"
+        }
+      ],
+      "subIssues": null
+    },
+    {
+      "number": 118,
+      "title": "Build guides (\"easy to build\")",
+      "url": "https://github.com/engmung/PatternFlow/issues/118",
+      "state": "open",
+      "updatedAt": "2026-06-21T09:55:07Z",
+      "comments": 0,
+      "labels": [
+        {
+          "name": "area:docs",
+          "color": "d522b4"
+        },
+        {
+          "name": "type:improvement",
+          "color": "6e7a89"
+        },
+        {
+          "name": "type:epic",
+          "color": "0d1117"
+        }
+      ],
+      "subIssues": {
+        "total": 2,
+        "completed": 0,
+        "percent": 0
+      }
+    },
+    {
+      "number": 121,
+      "title": "Breadboard-only version (no custom PCB) + guide (post-launch)",
+      "url": "https://github.com/engmung/PatternFlow/issues/121",
+      "state": "open",
+      "updatedAt": "2026-06-21T07:47:44Z",
+      "comments": 0,
+      "labels": [
+        {
+          "name": "area:pcb",
+          "color": "8f1463"
+        },
+        {
+          "name": "area:docs",
+          "color": "d522b4"
+        },
+        {
+          "name": "type:improvement",
+          "color": "6e7a89"
+        }
+      ],
+      "subIssues": null
+    },
+    {
+      "number": 114,
+      "title": "PCB reliability + production",
+      "url": "https://github.com/engmung/PatternFlow/issues/114",
+      "state": "open",
+      "updatedAt": "2026-06-18T02:35:24Z",
+      "comments": 1,
+      "labels": [
+        {
+          "name": "area:pcb",
+          "color": "8f1463"
+        },
+        {
+          "name": "type:improvement",
+          "color": "6e7a89"
+        }
+      ],
+      "subIssues": null
+    },
+    {
+      "number": 117,
+      "title": "Community + contribution",
+      "url": "https://github.com/engmung/PatternFlow/issues/117",
+      "state": "open",
+      "updatedAt": "2026-06-17T13:35:19Z",
+      "comments": 0,
+      "labels": [
+        {
+          "name": "area:community",
+          "color": "32b3ca"
+        },
+        {
+          "name": "type:improvement",
+          "color": "6e7a89"
+        }
+      ],
+      "subIssues": null
+    }
+  ]
+}

--- a/web/src/app/roadmap/page.tsx
+++ b/web/src/app/roadmap/page.tsx
@@ -24,8 +24,12 @@ export default function RoadmapPage() {
 
   useEffect(() => {
     let active = true;
-    fetch('/api/roadmap')
-      .then((res) => res.json())
+    // Prefer the static snapshot committed by the roadmap-snapshot Action
+    // (no runtime token, no rate limit). Fall back to the live API route if
+    // the snapshot hasn't been generated yet.
+    fetch('/roadmap.json', { cache: 'no-cache' })
+      .then((res) => (res.ok ? res.json() : Promise.reject(new Error('no snapshot'))))
+      .catch(() => fetch('/api/roadmap').then((res) => res.json()))
       .then((payload: RoadmapData) => {
         if (active) setData(payload);
       })


### PR DESCRIPTION
## What
Adds the GitHub Actions automation from #127:
- **Web CI** — lint (report-only for now) + `next build` gate on `web/**` changes
- **Discord notify** — commits → `#dev-log`, releases → `#announcements` (via webhook secrets)
- **Roadmap snapshot** — regenerates `web/public/roadmap.json` on schedule + issue events; `/roadmap` now reads the static file and falls back to `/api/roadmap`

Also adds a PR template, release-notes auto-categories (`.github/release.yml`), and a commit-message convention in CONTRIBUTING.

## Why
Closes #127. Build can't reach `main` broken; project activity flows to Discord automatically; roadmap page needs no runtime token.

## Tested
- `npm run build` passes locally
- `/roadmap` verified loading the static snapshot (10 issues) in preview
- lint left non-blocking — repo has pre-existing lint errors

> Merging this fires the first `#dev-log` Discord post (requires `DISCORD_WEBHOOK_DEV` secret).