### PR TITLE
fix(firmware): invert encoder direction for Bourns PEC11R

### DIFF
--- a/firmware/encoder_test/encoder_test.ino
+++ b/firmware/encoder_test/encoder_test.ino
@@ -35,7 +35,7 @@
 #define ENC4_B 18
 #define ENC4_SW 1
 
-#define INVERT_ENCODER 1   // matches main firmware; flip if direction is wrong
+#define INVERT_ENCODER 0   // matches main firmware; flip if direction is wrong
 
 const int ENC_A[4]  = { ENC1_A, ENC2_A, ENC3_A, ENC4_A };
 const int ENC_B[4]  = { ENC1_B, ENC2_B, ENC3_B, ENC4_B };

--- a/firmware/patternflow/config.h
+++ b/firmware/patternflow/config.h
@@ -83,7 +83,10 @@
 #define ENC4_SW  1
 
 // --- Hardware Settings ---
-#define INVERT_ENCODER 1
+// 0 for the official Bourns PEC11R-4220F-S0024 (used on the simplified
+// revision board); set to 1 if rotation reads reversed (e.g. AliExpress
+// clones, or encoders mounted on the back of the PCB).
+#define INVERT_ENCODER 0
 #define DEFAULT_BRIGHTNESS 204  // 80% (0-255)
 
 // --- LED Panel Color Calibration ---


### PR DESCRIPTION
## What
Sets `INVERT_ENCODER` to `0` in `firmware/patternflow/config.h` (and the matching `encoder_test` sketch).

## Why
The simplified revision board uses the official **Bourns PEC11R-4220F-S0024** encoders instead of the previous AliExpress clones. Their A/B phase is opposite, so CW/CCW read reversed. Flipping the invert flag maps rotation correctly.

## Tested
Code-only flag change; needs a flash + on-hardware spin to confirm direction (per the issue's verify step).

Closes #146