### PR TITLE
Mobile section view + contact page, plus recent build/firmware updates

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -55,6 +55,9 @@
     --pf-block-pad-y: 24px;
     --pf-row-pad-y: 18px;
     --pf-marquee-dur: 80s;
+    /* Mobile section view: 3D preview height + divider/nav bar height */
+    --mb-viewer-h: 44vh;
+    --mb-nav-h: 52px;
   }
   * { box-sizing: border-box; margin: 0; padding: 0; }
   html, body {
@@ -102,10 +105,49 @@
 
   @media (max-width: 900px) {
     .app-layout { flex-direction: column; }
-    .mobile-page-links { display: none; }
     .viewer-panel { display: none; }
     .content-panel { width: 100%; }
     .viewer-hint { display: none; }
+
+    /* Page links (Journal / Contact) live as a fixed, layered header in the
+       top-right — independent of the 3D preview, sitting above everything. */
+    .mobile-page-links {
+      display: block;
+      position: fixed;
+      top: 0;
+      right: 0;
+      z-index: 60;
+      padding: 16px 20px;
+      pointer-events: none;
+    }
+    .mobile-page-links .hero-top-links {
+      display: flex;
+      position: static;
+      pointer-events: auto;
+    }
+
+    /* The 3D preview is hidden while the hero is full-screen, then "drops down"
+       and pins to the top once a section tab is opened from the bottom nav.
+       The nav bar (below) rises up to sit just under it as the divider. */
+    .viewer-panel.is-open {
+      display: block;
+      position: fixed;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: var(--mb-viewer-h);
+      z-index: 5;
+      background: var(--cream);
+      animation: viewer-drop 0.5s cubic-bezier(0.22, 1, 0.36, 1) both;
+    }
+    .viewer-panel.is-open .viewer-hint {
+      display: block;
+    }
+  }
+
+  @keyframes viewer-drop {
+    from { transform: translateY(-100%); opacity: 0; }
+    to   { transform: translateY(0); opacity: 1; }
   }
 
   /* ───── Hero ───── */
@@ -220,7 +262,7 @@
       gap: 24px;
       min-height: auto;
     }
-    .hero-top-links {
+    .hero > .hero-top-links {
       display: none;
     }
     .hero-viewer { height: 50vh; min-height: 320px; order: -1; }
@@ -343,8 +385,8 @@
     overflow: hidden;
     opacity: 0;
     pointer-events: none;
-    transform: translateX(20px);
-    transition: opacity 0.6s cubic-bezier(0.4, 0, 0.2, 1), transform 0.6s cubic-bezier(0.4, 0, 0.2, 1);
+    transform: translateY(16px);
+    transition: opacity 0.5s cubic-bezier(0.4, 0, 0.2, 1), transform 0.5s cubic-bezier(0.4, 0, 0.2, 1);
   }
   .panel-wrapper.active {
     position: relative;
@@ -352,7 +394,7 @@
     overflow: visible;
     opacity: 1;
     pointer-events: auto;
-    transform: translateX(0);
+    transform: translateY(0);
   }
   .deck-content::before {
     content: '';
@@ -362,14 +404,13 @@
     right: 0;
     bottom: 0;
     background-color: #ffffff;
-    transform-origin: left;
-    transform: scaleX(0);
-    transition: transform 0.5s cubic-bezier(0.4, 0, 0.2, 1);
+    opacity: 0;
+    transition: opacity 0.4s cubic-bezier(0.4, 0, 0.2, 1);
     z-index: -1;
     pointer-events: none;
   }
   .content-panel.bg-white .deck-content::before {
-    transform: scaleX(1);
+    opacity: 1;
   }
 
   @keyframes fadeIn {
@@ -1427,7 +1468,7 @@
     border-bottom: 1px solid var(--pf-rule);
   }
   .business-hero h1 {
-    margin: 0 0 14px;
+    margin: 0 0 36px;
     color: var(--pf-ink);
     font-size: 64px;
     font-weight: 500;
@@ -1435,11 +1476,12 @@
     line-height: 0.98;
   }
   .business-hero p {
-    max-width: 46ch;
+    max-width: 26ch;
     margin: 0;
-    color: var(--pf-ink-muted);
-    font-size: 18px;
-    line-height: 1.5;
+    color: var(--pf-ink);
+    font-size: clamp(22px, 2.5vw, 32px);
+    line-height: 1.28;
+    letter-spacing: -0.02em;
   }
   .business-contact-link,
   .business-email {
@@ -1492,9 +1534,7 @@
     max-width: 34ch;
   }
   .business-contact-block {
-    margin-top: 56px;
-    padding-top: 34px;
-    border-top: 1px solid var(--pf-rule);
+    margin-top: 44px;
   }
   .business-contact-block .pf-kicker {
     margin-bottom: 22px;
@@ -2309,7 +2349,9 @@
     .business-hero h1 {
       font-size: 42px;
     }
-    .business-hero p,
+    .business-hero p {
+      font-size: 21px;
+    }
     .business-intro-grid p {
       font-size: 15.5px;
     }
@@ -2334,8 +2376,8 @@
       line-height: 1.4;
     }
     .business-email {
-      font-size: 24px;
-      line-height: 1.25;
+      font-size: 17px;
+      line-height: 1.3;
     }
     .journal-lang-switch {
       top: 18px;
@@ -2481,53 +2523,65 @@
     }
   }
 
-  /* ───── Mobile-only: Desktop note ───── */
-  .mobile-desktop-note {
+  /* ───── Mobile-only: Section nav / divider bar ─────
+     Sits at the screen bottom over the full-screen hero. When a section opens,
+     it rides up to pin just below the 3D preview, acting as the partition
+     between the preview scene (above) and the page content (below). */
+  .mobile-bottom-nav {
     display: none;
   }
 
   @media (max-width: 900px) {
-    .mobile-desktop-note {
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-      text-align: center;
-      padding: 40px 24px;
-      font-family: var(--sans);
-      font-size: 14px;
-      color: var(--ink-muted);
-      line-height: 1.6;
+    .mobile-bottom-nav {
+      display: grid;
+      grid-template-columns: repeat(3, 1fr);
+      position: fixed;
+      left: 0;
+      right: 0;
+      top: 0;
+      height: var(--mb-nav-h);
+      z-index: 50;
+      background: var(--cream);
       border-top: 1px solid var(--rule);
       border-bottom: 1px solid var(--rule);
-      background: var(--cream);
+      /* Parked at the bottom of the viewport while the hero is full-screen. */
+      transform: translateY(calc(100dvh - var(--mb-nav-h) - env(safe-area-inset-bottom, 0px)));
+      transition: transform 0.5s cubic-bezier(0.22, 1, 0.36, 1);
     }
-    .mobile-desktop-note a {
-      color: var(--ink);
-      text-decoration: underline;
-      text-underline-offset: 3px;
-      font-weight: 500;
+    /* Risen up to become the divider directly beneath the 3D preview. */
+    .mobile-bottom-nav.is-open {
+      transform: translateY(var(--mb-viewer-h));
     }
-    .mobile-desktop-note .mobile-note-journal-btn {
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      padding: 14px 24px 13px;
+    .mobile-bottom-nav .mb-tab {
+      appearance: none;
+      -webkit-appearance: none;
+      background: none;
+      border: 0;
+      border-right: 1px solid var(--rule);
       font-family: var(--mono);
       font-size: 12px;
       font-weight: 500;
-      letter-spacing: 0.1em;
+      letter-spacing: 0.12em;
       text-transform: uppercase;
-      background: var(--ink);
-      color: var(--cream);
-      border: 1px solid var(--ink);
-      text-decoration: none;
-      transition: background-color 0.15s ease, color 0.15s ease;
-      width: 100%;
-      max-width: 280px;
-      margin-top: 8px;
+      color: var(--ink-muted);
+      cursor: pointer;
+      transition: color 0.2s ease, background-color 0.2s ease;
     }
-    .mobile-desktop-note .mobile-note-journal-btn:hover {
-      background: transparent;
-      color: var(--ink);
+    .mobile-bottom-nav .mb-tab:last-child {
+      border-right: 0;
+    }
+    .mobile-bottom-nav .mb-tab.active {
+      color: var(--cream);
+      background: var(--ink);
+    }
+    /* Hero (closed): keep the footer clear of the parked nav at the bottom. */
+    .content-panel {
+      padding-bottom: calc(var(--mb-nav-h) + env(safe-area-inset-bottom, 0px));
+    }
+    /* Section open: make room for the fixed preview + divider stacked on top. */
+    .content-panel.viewer-open {
+      padding-top: calc(var(--mb-viewer-h) + var(--mb-nav-h));
+      padding-bottom: 40px;
     }
   }
+

--- a/web/src/components/3d/ViewerPanel.tsx
+++ b/web/src/components/3d/ViewerPanel.tsx
@@ -1,0 +1,19 @@
+'use client';
+
+import HeroScene from './HeroScene';
+import { useAppStore } from '@/store/useAppStore';
+
+// Wraps the 3D scene so it can react to the active home tab.
+// On desktop the panel is always shown (sticky left column). On mobile it stays
+// hidden while the hero is full-screen and only "drops down" once a section tab
+// (Build / Pattern / Inside) is opened from the bottom nav.
+export default function ViewerPanel() {
+  const homeTab = useAppStore((state) => state.homeTab);
+  const isOpen = homeTab !== 'hero';
+
+  return (
+    <div className={`viewer-panel ${isOpen ? 'is-open' : ''}`}>
+      <HeroScene />
+    </div>
+  );
+}

--- a/web/src/components/HomeView.tsx
+++ b/web/src/components/HomeView.tsx
@@ -1,5 +1,5 @@
 import RightPanel from "@/components/sections/RightPanel";
-import HeroScene from "@/components/3d/HeroScene";
+import ViewerPanel from "@/components/3d/ViewerPanel";
 import { getSectionContent } from "@/lib/content";
 import HeroJournalLink from "@/components/journal/HeroJournalLink";
 
@@ -15,9 +15,7 @@ export default function HomeView({ initialTab = 'hero' }: { initialTab?: HomeTab
       <div className="mobile-page-links">
         <HeroJournalLink />
       </div>
-      <div className="viewer-panel">
-        <HeroScene />
-      </div>
+      <ViewerPanel />
       <RightPanel
         initialTab={initialTab}
         buildContent={buildContent}

--- a/web/src/components/contact/ContactPage.tsx
+++ b/web/src/components/contact/ContactPage.tsx
@@ -3,51 +3,6 @@ import Link from "next/link";
 const contactEmail = "contact@patternflow.work";
 const instagramUrl = "https://www.instagram.com/patternflow.work/";
 
-const partnershipRows = [
-  {
-    index: "01",
-    title: "Specification & distribution",
-    description:
-      "Small-batch wholesale and project specification for LED designers, interior studios, retailers, and curated maker shops.",
-    active: true,
-  },
-  {
-    index: "02",
-    title: "Installations & integrations",
-    description:
-      "Standalone instrument, embedded in an interactive environment, or a control surface for displays beyond the built-in panel.",
-  },
-  {
-    index: "03",
-    title: "Networked & custom AV",
-    description:
-      "Streaming to larger surfaces and custom interfaces with existing AV systems. Explored on a custom basis.",
-  },
-];
-
-const statusRows = [
-  {
-    index: "01",
-    title: "Now in pre-launch on Crowd Supply",
-    description:
-      "The open-source files are live, and the fully assembled product is in pre-launch on Crowd Supply. Subscribe there to be notified when the campaign opens.",
-    active: true,
-  },
-  {
-    index: "02",
-    title: "Distribution conversations open",
-    description:
-      "Retailers, maker shops, studios, and project specifiers can get in touch before the first batch lands.",
-    active: true,
-  },
-  {
-    index: "03",
-    title: "Longer horizons welcome",
-    description:
-      "Early conversations can still shape what the next Patternflow becomes.",
-  },
-];
-
 export default function ContactPage() {
   return (
     <main className="business-page">
@@ -61,74 +16,29 @@ export default function ContactPage() {
       <section className="business-panel">
         <header className="business-hero">
           <div>
-            <h1>Partnerships.</h1>
+            <h1>Get in touch.</h1>
             <p>
-              Open source, built solo, but open to working with galleries,
-              studios, retailers, and brand activation crews.
+              Open to working with museums, galleries, and fellow artists —
+              exhibitions, collaborations, and commissions are all welcome.
             </p>
           </div>
-          <a className="business-contact-link" href={`mailto:${contactEmail}`}>
-            {contactEmail}
-          </a>
         </header>
 
-        <div className="business-intro-grid">
-          <p>
-            A few conversations are already underway. Here is what those tend to
-            look like, where the project is right now, and how to reach out.
-          </p>
-          <p>
-            Most partnership conversations move at a calm pace. If your project
-            has a longer horizon, this is a good moment to be in touch. Early
-            conversations shape what comes next.
-          </p>
-        </div>
-
-        <div className="business-decks">
-          <section className="pf-block">
-            <div className="pf-head">
-              <span className="pf-kicker">Three ways to work together</span>
-              <span className="pf-count">Open</span>
-            </div>
-            {partnershipRows.map((row) => (
-              <div className={`pf-row${row.active ? " on" : ""}`} key={row.index}>
-                <span className="pf-ghost">{row.index}</span>
-                <div className="pf-row-t">{row.title}</div>
-                <div className="pf-row-d">{row.description}</div>
-              </div>
-            ))}
-          </section>
-
-          <section className="pf-block">
-            <div className="pf-head">
-              <span className="pf-kicker">Where Patternflow is</span>
-              <span className="pf-count">2026</span>
-            </div>
-            {statusRows.map((row) => (
-              <div className={`pf-row${row.active ? " on" : ""}`} key={row.index}>
-                <span className="pf-ghost">{row.index}</span>
-                <div className="pf-row-t">{row.title}</div>
-                <div className="pf-row-d">{row.description}</div>
-              </div>
-            ))}
-          </section>
-        </div>
-
         <section className="business-contact-block">
-          <span className="pf-kicker">Get in touch</span>
-          <p>
-            Patternflow is based in Hongdae, Seoul. Korean and English both
-            welcome.
-          </p>
+          <span className="pf-kicker">Reach out</span>
           <div className="business-contact-links">
             <a className="business-email" href={`mailto:${contactEmail}`}>
               {contactEmail}
             </a>
-            <a className="business-email" href={instagramUrl} target="_blank" rel="noopener noreferrer">
+            <a
+              className="business-email"
+              href={instagramUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
               Instagram
             </a>
           </div>
-          <div className="pf-mono">Usually answered within a few days</div>
         </section>
       </section>
     </main>

--- a/web/src/components/sections/InsidePanel.tsx
+++ b/web/src/components/sections/InsidePanel.tsx
@@ -237,12 +237,19 @@ export default function InsidePanel({ content }: InsidePanelProps) {
                 <strong>BOM cost calculation</strong>, estimating roughly <strong>$120</strong> in pure material cost for the worst-case scenario.
               </span>
             </li>
-            <li className={styles.storyCurrent}>
+            <li>
               <time>26.6</time>
               <span>
-                With the <strong>Crowd Supply contract</strong> signed, prepare the{' '}
-                <strong>crowdfunding campaign</strong> — order the first <strong>PCBA batch</strong>{' '}
-                and get Patternflow ready to sell in a small, practical run.
+                The <strong>Crowd Supply pre-launch page</strong> went live, backed by{' '}
+                <strong>countless refinements toward mass production</strong>. Instagram also passed{' '}
+                <strong>1,000 followers</strong>.
+              </span>
+            </li>
+            <li className={styles.storyCurrent}>
+              <time>26.7</time>
+              <span>
+                Keep <strong>refining the design for mass production</strong>, grow an active{' '}
+                <strong>community</strong>, and push <strong>outreach and promotion</strong>.
               </span>
             </li>
             <li>

--- a/web/src/components/sections/RightPanel.tsx
+++ b/web/src/components/sections/RightPanel.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { useState, useRef, useEffect } from 'react';
-import Link from 'next/link';
 import Hero from './Hero';
 import Sponsor from './Sponsor';
 import BuildPanel from './BuildPanel';
@@ -91,7 +90,14 @@ export default function RightPanel({ initialTab = 'hero', buildContent, patternC
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  // Reset scroll to top on every tab change
+  // Mirror the active tab into the store so the sibling 3D viewer panel knows
+  // whether it should be visible (it "drops down" on mobile when a tab opens).
+  useEffect(() => {
+    useAppStore.getState().setHomeTab(activeTab);
+  }, [activeTab]);
+
+  // Reset scroll to top on every tab change. On mobile the viewer drops in from
+  // the top, so jump the page to the top to reveal it alongside the panel.
   useEffect(() => {
     const panel = contentRef.current;
     if (!panel) return;
@@ -99,14 +105,7 @@ export default function RightPanel({ initialTab = 'hero', buildContent, patternC
     panel.scrollTop = 0;
 
     if (window.matchMedia('(max-width: 900px)').matches) {
-      requestAnimationFrame(() => {
-        const stickyOffset = window.innerHeight * 0.3 + 94;
-        const panelTop = panel.getBoundingClientRect().top + window.scrollY;
-        window.scrollTo({
-          top: Math.max(0, panelTop - stickyOffset),
-          behavior: 'auto',
-        });
-      });
+      window.scrollTo({ top: 0, behavior: 'auto' });
     }
   }, [activeTab]);
 
@@ -137,19 +136,11 @@ export default function RightPanel({ initialTab = 'hero', buildContent, patternC
         </button>
       </div>
 
-      <div className={`content-panel ${activeTab !== 'hero' ? 'bg-white' : ''}`} ref={contentRef}>
+      <div className={`content-panel ${activeTab !== 'hero' ? 'bg-white viewer-open' : ''}`} ref={contentRef}>
         <div className="deck-content">
           <div className={`panel-wrapper ${activeTab === 'hero' ? 'active' : ''}`}>
             <Hero />
             <Sponsor />
-            <div className="mobile-desktop-note">
-              <p style={{ marginBottom: '16px' }}>
-                For the full experience — build guide, interactive patterns, and 3D preview — visit <a href="https://patternflow.work">patternflow.work</a> on desktop.
-              </p>
-              <Link href="/journal" className="mobile-note-journal-btn">
-                Read Journal
-              </Link>
-            </div>
             <Footer />
           </div>
           <div className={`panel-wrapper ${activeTab === 'build' ? 'active' : ''}`}>
@@ -163,6 +154,21 @@ export default function RightPanel({ initialTab = 'hero', buildContent, patternC
           </div>
         </div>
       </div>
+
+      {/* Mobile-only bottom nav. Tapping a section drops the 3D viewer down from
+          the top; tapping the active one again returns to the full-screen hero. */}
+      <nav className={`mobile-bottom-nav ${activeTab !== 'hero' ? 'is-open' : ''}`} aria-label="Sections">
+        {(['build', 'pattern', 'inside'] as const).map((tab) => (
+          <button
+            key={tab}
+            className={`mb-tab ${activeTab === tab ? 'active' : ''}`}
+            aria-pressed={activeTab === tab}
+            onClick={() => handleTabClick(tab)}
+          >
+            {tab === 'build' ? 'Build' : tab === 'pattern' ? 'Pattern' : 'Inside'}
+          </button>
+        ))}
+      </nav>
     </div>
   );
 }

--- a/web/src/store/useAppStore.ts
+++ b/web/src/store/useAppStore.ts
@@ -2,9 +2,15 @@ import { create } from 'zustand';
 
 export type SectionType = 'hero' | 'case' | 'pcb' | 'assembly' | 'firmware' | 'inside';
 
+// Which top-level home tab is open. Mirrored from RightPanel so sibling
+// components (e.g. the 3D viewer panel) can react without prop drilling.
+export type HomeTabType = 'hero' | 'build' | 'pattern' | 'inside';
+
 interface AppState {
   activeSection: SectionType;
   setActiveSection: (section: SectionType) => void;
+  homeTab: HomeTabType;
+  setHomeTab: (tab: HomeTabType) => void;
   knobValues: {
     c1: number;
     c2: number;
@@ -31,6 +37,8 @@ interface AppState {
 export const useAppStore = create<AppState>((set) => ({
   activeSection: 'hero',
   setActiveSection: (section) => set({ activeSection: section }),
+  homeTab: 'hero',
+  setHomeTab: (tab) => set({ homeTab: tab }),
   knobValues: {
     c1: 0.00, // Hue
     c2: 2.00, // Speed


### PR DESCRIPTION
Releases the current `dev` work to `main` (6 commits).

## Web — mobile section view & contact page (this session)
- Restore the 3D preview + Build/Pattern/Inside sections on mobile. Hero is full-screen on load; a section nav parks at the screen bottom and rides up to pin below the 3D preview as the divider when a section opens. Tapping the active tab returns to the full-screen hero.
- New `ViewerPanel` wrapper + active-tab mirrored into the store so the viewer knows when to drop in.
- Replace left/right swipe transitions with a vertical rise + fade.
- Journal/Contact restored as a fixed, layered top-right header on mobile; dropped the redundant "visit on desktop" note.
- Inside timeline updated (Crowd Supply pre-launch, 1k Instagram, new 26.7).
- Contact page pared down to a short invite + email/Instagram.

## Also included (already on dev)
- docs: surface the breadboard build path as available
- chore(pcb): tidy schematic placement to mirror physical layout
- feat(firmware): replace custom slot 2 with Retro Digital Tapestry
- docs(build-guide): sharpen sourcing guidance
- feat(web): add breadboard-only build guide

🤖 Generated with [Claude Code](https://claude.com/claude-code)