### PR TITLE
Crowd Supply intercept modal + Inside viewer fixes

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -233,6 +233,7 @@
     justify-content: center;
     min-height: 48px;
     text-decoration: none;
+    cursor: pointer;
     transition: background-color 0.15s ease, color 0.15s ease, border-color 0.15s ease;
   }
   .hero-cta-waitlist {
@@ -251,6 +252,14 @@
     color: var(--cream);
     border-color: var(--ink);
     text-decoration: none;
+  }
+  .hero-cs-note {
+    font-family: var(--mono);
+    font-size: 11.5px;
+    letter-spacing: 0.02em;
+    line-height: 1.5;
+    color: var(--ink-muted);
+    margin: 12px 0 0;
   }
 
   @media (max-width: 900px) {

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -99,6 +99,16 @@
     width: 100%; height: 100%;
     display: block;
   }
+  /* Fade-through wrapper for swapping the product scene ↔ globe (Inside). */
+  .viewer-fade {
+    width: 100%;
+    height: 100%;
+    opacity: 1;
+    transition: opacity 0.2s ease;
+  }
+  .viewer-fade.is-fading {
+    opacity: 0;
+  }
   .viewer-hint {
     top: 40px;
   }

--- a/web/src/components/3d/ViewerPanel.tsx
+++ b/web/src/components/3d/ViewerPanel.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import dynamic from 'next/dynamic';
+import { useEffect, useState } from 'react';
 import HeroScene from './HeroScene';
 import { useAppStore } from '@/store/useAppStore';
 
@@ -10,6 +11,8 @@ const GlobeViewer = dynamic(
   { ssr: false },
 );
 
+const FADE_MS = 200;
+
 // Wraps the 3D scene so it can react to the active home tab.
 // On desktop the panel is always shown (sticky left column). On mobile it stays
 // hidden while the hero is full-screen and only "drops down" once a section tab
@@ -18,9 +21,31 @@ export default function ViewerPanel() {
   const homeTab = useAppStore((state) => state.homeTab);
   const isOpen = homeTab !== 'hero';
 
+  // Only two distinct scenes exist: the product preview (hero/build/pattern) and
+  // the globe (inside). Switching between build/pattern/hero never swaps the
+  // canvas, so no transition there — we only fade when the scene itself changes.
+  const targetScene = homeTab === 'inside' ? 'globe' : 'product';
+  const [shownScene, setShownScene] = useState(targetScene);
+  const [fading, setFading] = useState(false);
+
+  // Fade the current scene out, swap while invisible, then fade the new one in.
+  // Keeping a single scene mounted at a time preserves the original (cheap)
+  // memory profile — this is a fade-through, not a true overlapping crossfade.
+  useEffect(() => {
+    if (targetScene === shownScene) return;
+    setFading(true);
+    const timer = setTimeout(() => {
+      setShownScene(targetScene);
+      setFading(false);
+    }, FADE_MS);
+    return () => clearTimeout(timer);
+  }, [targetScene, shownScene]);
+
   return (
     <div className={`viewer-panel ${isOpen ? 'is-open' : ''}`}>
-      {homeTab === 'inside' ? <GlobeViewer /> : <HeroScene />}
+      <div className={`viewer-fade ${fading ? 'is-fading' : ''}`}>
+        {shownScene === 'globe' ? <GlobeViewer /> : <HeroScene />}
+      </div>
     </div>
   );
 }

--- a/web/src/components/crowdsupply/CrowdSupplyModal.module.css
+++ b/web/src/components/crowdsupply/CrowdSupplyModal.module.css
@@ -1,0 +1,184 @@
+.overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 200;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  background: rgba(23, 21, 18, 0.6);
+}
+
+.card {
+  position: relative;
+  width: min(620px, 100%);
+  max-height: 92vh;
+  overflow-y: auto;
+  border: 1px solid #171512;
+  background: #fffdf8;
+  color: #171512;
+  font-family: var(--font-jetbrains), monospace;
+}
+
+.close {
+  position: absolute;
+  top: 18px;
+  right: 18px;
+  width: 38px;
+  height: 38px;
+  border: 1px solid rgba(23, 21, 18, 0.22);
+  background: #ffffff;
+  color: #171512;
+  font-size: 22px;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.close:hover {
+  border-color: #171512;
+}
+
+.inner {
+  padding: 44px 44px 40px;
+}
+
+.title {
+  margin: 0 0 20px;
+  padding-right: 44px;
+  font-size: 26px;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  line-height: 1.2;
+}
+
+.lead {
+  margin: 0 0 24px;
+  font-size: 16px;
+  line-height: 1.6;
+}
+
+.lead strong {
+  font-weight: 700;
+}
+
+.subhead {
+  margin: 24px 0 8px;
+  font-size: 14px;
+  line-height: 1.5;
+  opacity: 0.7;
+}
+
+.reasons {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.reasons li {
+  display: flex;
+  gap: 10px;
+  align-items: baseline;
+  padding: 10px 0;
+  font-size: 16px;
+  line-height: 1.55;
+}
+
+.reasons li b {
+  font-weight: 700;
+}
+
+.reasons li em {
+  font-style: italic;
+}
+
+.mark {
+  flex: 0 0 auto;
+  opacity: 0.45;
+}
+
+.actions {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin-top: 28px;
+}
+
+.primary {
+  width: 100%;
+  min-height: 54px;
+  border: 1px solid #171512;
+  background: #e8552e;
+  color: #171512;
+  font: inherit;
+  font-size: 14px;
+  font-weight: 500;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+
+.primary:hover {
+  background: #171512;
+  color: #f7f3ea;
+}
+
+.secondary {
+  width: 100%;
+  min-height: 40px;
+  border: none;
+  background: transparent;
+  color: #171512;
+  font: inherit;
+  font-size: 12px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  opacity: 0.55;
+  cursor: pointer;
+}
+
+.secondary:hover {
+  opacity: 1;
+}
+
+@media (max-width: 640px) {
+  .overlay {
+    padding: 0;
+  }
+  .card {
+    width: 100%;
+    height: 100%;
+    max-height: 100vh;
+    border: none;
+  }
+  .inner {
+    padding: 60px 24px 40px;
+  }
+  .title {
+    font-size: 23px;
+    margin-bottom: 28px;
+  }
+  /* Tight lines within each block … */
+  .lead {
+    line-height: 1.45;
+    margin-bottom: 32px;
+  }
+  .lead,
+  .reasons li {
+    font-size: 15px;
+  }
+  /* … but generous gaps between blocks so each reads as one unit. */
+  .subhead {
+    margin: 0 0 10px;
+  }
+  .reasons li {
+    padding: 5px 0;
+    line-height: 1.45;
+  }
+  .actions {
+    margin-top: 36px;
+  }
+}

--- a/web/src/components/crowdsupply/CrowdSupplyModal.tsx
+++ b/web/src/components/crowdsupply/CrowdSupplyModal.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import { useEffect } from "react";
+import { createPortal } from "react-dom";
+import { captureEvent } from "@/lib/posthogEvents";
+import styles from "./CrowdSupplyModal.module.css";
+
+const CROWD_SUPPLY_URL = "https://www.crowdsupply.com/engmung/patternflow";
+
+type Props = {
+  onClose: () => void;
+};
+
+export default function CrowdSupplyModal({ onClose }: Props) {
+  // Close on Escape and lock background scroll while open.
+  useEffect(() => {
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    const prevOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      window.removeEventListener("keydown", onKey);
+      document.body.style.overflow = prevOverflow;
+    };
+  }, [onClose]);
+
+  const handleContinue = () => {
+    captureEvent("crowd_supply_clicked", {
+      surface: "hero",
+      destination: "crowd_supply",
+      via: "modal_continue",
+    });
+  };
+
+  // Portal to body so the fixed overlay escapes any transformed ancestor
+  // and covers the full viewport (not just the hero panel).
+  if (typeof document === "undefined") return null;
+
+  return createPortal(
+    <div
+      className={styles.overlay}
+      role="dialog"
+      aria-modal="true"
+      aria-label="About Crowd Supply"
+      onClick={onClose}
+    >
+      <div className={styles.card} onClick={(event) => event.stopPropagation()}>
+        <button type="button" className={styles.close} onClick={onClose} aria-label="Close">
+          ×
+        </button>
+
+        <div className={styles.inner}>
+          <h2 className={styles.title}>One quick stop.</h2>
+
+          <p className={styles.lead}>
+            &ldquo;Get One&rdquo; takes you to <strong>Crowd Supply</strong> — run by{" "}
+            <strong>Mouser</strong>, one of the world&apos;s largest electronics distributors. They
+            handle the launch and ship Patternflow worldwide.
+          </p>
+
+          <p className={styles.subhead}>Two quick things before you go:</p>
+
+          <ul className={styles.reasons}>
+            <li>
+              <span className={styles.mark}>—</span>
+              <span>
+                <b>You&apos;re not buying yet.</b>{" "}You&apos;ll tap <em>&ldquo;Subscribe&rdquo;</em>{" "}
+                to follow Patternflow and hear when it&apos;s out. Free, no card.
+              </span>
+            </li>
+            <li>
+              <span className={styles.mark}>—</span>
+              <span>
+                <b>No pressure.</b>{" "}It stays available after launch, too.
+              </span>
+            </li>
+          </ul>
+
+          <div className={styles.actions}>
+            <a
+              className={styles.primary}
+              href={CROWD_SUPPLY_URL}
+              target="_blank"
+              rel="noopener"
+              onClick={handleContinue}
+            >
+              Continue to Crowd Supply →
+            </a>
+            <button type="button" className={styles.secondary} onClick={onClose}>
+              Maybe later
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/web/src/components/sections/Hero.tsx
+++ b/web/src/components/sections/Hero.tsx
@@ -3,10 +3,12 @@
 import { useState, useEffect } from 'react';
 import Link from 'next/link';
 import HeroJournalLink from "@/components/journal/HeroJournalLink";
+import CrowdSupplyModal from "@/components/crowdsupply/CrowdSupplyModal";
 import { captureEvent } from "@/lib/posthogEvents";
 
 export default function Hero() {
   const [isVideoVisible, setIsVideoVisible] = useState(false);
+  const [isCrowdSupplyOpen, setIsCrowdSupplyOpen] = useState(false);
 
   useEffect(() => {
     // Show the video after 3 seconds (allowing it to initialize and hide controls)
@@ -132,20 +134,26 @@ export default function Hero() {
           >
             GitHub
           </a>
-          <a
+          <button
+            type="button"
             className="hero-cta hero-cta-waitlist"
-            href="https://www.crowdsupply.com/engmung/patternflow"
-            target="_blank"
-            rel="noopener"
-            onClick={() => captureEvent('crowd_supply_clicked', {
-              surface: 'hero',
-              destination: 'crowd_supply',
-            })}
+            onClick={() => {
+              setIsCrowdSupplyOpen(true);
+              captureEvent('crowd_supply_modal_opened', {
+                surface: 'hero',
+              });
+            }}
           >
             Get One
-          </a>
+          </button>
         </div>
+        <p className="hero-cs-note">
+          Reserve on Crowd Supply — Mouser&apos;s platform for open hardware.
+        </p>
       </div>
+      {isCrowdSupplyOpen && (
+        <CrowdSupplyModal onClose={() => setIsCrowdSupplyOpen(false)} />
+      )}
     </section>
   );
 }

--- a/web/src/components/sections/InsideGlobe/Globe.tsx
+++ b/web/src/components/sections/InsideGlobe/Globe.tsx
@@ -376,6 +376,11 @@ export default function Globe(props: GlobeProps) {
       camera={{ position: [0, 0, 5], fov: VFOV_DEG }}
       gl={{ alpha: true, antialias: true }}
       dpr={[1, 2]}
+      // Suppress native touch scroll/zoom on the canvas so a drag rotates the
+      // globe instead of also scrolling the page behind it. OrbitControls does
+      // this automatically in the Build/Pattern viewer; this globe rolls its own
+      // drag handler, so it must opt in explicitly.
+      style={{ touchAction: 'none' }}
       onPointerMissed={() => props.onSelectBuild?.(null)}
     >
       <GlobeScene {...props} />

--- a/web/src/components/sections/InsideGlobe/GlobeViewer.module.css
+++ b/web/src/components/sections/InsideGlobe/GlobeViewer.module.css
@@ -4,6 +4,24 @@
   height: 100%;
 }
 
+/* Offscreen image preloader — rendered (so eager <Image> actually fetches the
+   thumbnail variants) but kept out of view and out of the layout/interaction. */
+.preload {
+  position: absolute;
+  left: -99999px;
+  top: 0;
+  width: 0;
+  height: 0;
+  overflow: hidden;
+  pointer-events: none;
+}
+.preloadBox {
+  position: relative;
+  display: block;
+  width: 160px;
+  height: 120px;
+}
+
 /* When open, the whole viewer becomes a click-to-close surface. */
 .overlay {
   position: absolute;

--- a/web/src/components/sections/InsideGlobe/GlobeViewer.tsx
+++ b/web/src/components/sections/InsideGlobe/GlobeViewer.tsx
@@ -20,6 +20,9 @@ export default function GlobeViewer() {
     () => builds.find((build) => build.id === selectedId) ?? null,
     [selectedId],
   );
+
+  // Every build photo across all pins — warmed up front (see preloader below).
+  const allImages = useMemo(() => builds.flatMap((build) => build.images ?? []), []);
   const images = selected?.images;
   const galleryOpen = galleryIndex !== null && !!images?.length;
 
@@ -55,6 +58,17 @@ export default function GlobeViewer() {
 
   return (
     <div className={styles.viewer}>
+      {/* Offscreen preloader: fetch every pin's thumbnail (the same 160px
+          optimized variant the card uses) eagerly the moment the globe mounts,
+          so opening a pin shows its photos instantly instead of lazy-loading. */}
+      <div className={styles.preload} aria-hidden>
+        {allImages.map((image) => (
+          <span key={image.src} className={styles.preloadBox}>
+            <Image src={image.src} alt="" fill sizes="160px" loading="eager" />
+          </span>
+        ))}
+      </div>
+
       <Globe selectedBuildId={selectedId ?? undefined} onSelectBuild={select} />
 
       <div className={`${styles.hint} ${hasSelected ? styles.hintHidden : ''}`}>


### PR DESCRIPTION
## Summary
Three web changes from this session, all on the landing page.

- **Crowd Supply intercept modal** — clicking the hero "Get One" now opens a full-viewport modal (portaled to body) explaining what Crowd Supply is and why Patternflow launches there, before continuing to the campaign page. Lowers the barrier for the ~80% Instagram/mobile audience unfamiliar with the platform. Adds a trust line under the CTA and splits PostHog tracking into `crowd_supply_modal_opened` / `crowd_supply_clicked`.
- **Inside globe: drag vs. scroll** — the globe rolls its own pointer drag instead of using OrbitControls, so it never opted out of native touch gestures; dragging it on mobile also scrolled the page. Set `touch-action: none` on the globe canvas to match the Build/Pattern viewer. Also fade-through the viewer when swapping the product scene ↔ globe (single scene mounted at a time — no added memory cost).
- **Inside thumbnails preload** — pin card thumbnails used next/image lazy loading, so they only fetched on click. Warm the same 160px optimized variants via an offscreen eager preloader when the globe mounts, so pins open instantly.

## Test plan
- Hero → "Get One" opens the modal; "Continue to Crowd Supply →" navigates out; Esc / overlay / "Maybe later" close it. Check mobile full-screen layout.
- Inside on mobile: dragging the globe rotates it without scrolling the page behind.
- Inside: open a pin shortly after entering — thumbnails appear immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)