### PR TITLE
Journal redesign + web style polish

### DIFF
--- a/firmware/patternflow/custom1.h
+++ b/firmware/patternflow/custom1.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <Arduino.h>
+#include <math.h>
+#include <stdint.h>
 #include "config.h"
 #include "src/core_display.h"
 #include "src/core_encoders.h"
@@ -8,133 +10,129 @@
 #include "src/core_math.h"
 #include "src/core_color.h"
 
-namespace IsometricPillars {
+namespace VectorFieldParticleFlowPattern {
 
-    const char* NAME = "Iso Pillars";
-    const char* const KNOB_LABELS[4] = {"Columns", "Speed", "Max Height", "Color Shift"};
+const char* NAME = "Vector Field Flow";
+const char* const KNOB_LABELS[4] = {"Turbulence", "Velocity", "Density", "Palette"};
 
-    static float knob1 = 0.124f;
-    static float knob2 = 1.598f;
-    static float knob3 = 0.0f;
-    static float knob4 = 0.568f;
-    static float time_state = 0.0f;
+const float VECTOR_FIELD_TURB_MIN = 0.0f;
+const float VECTOR_FIELD_TURB_MAX = 1.0f;
+const float VECTOR_FIELD_TURB_STEP = 0.05f;
 
-    static void drawIsoPillar(int tx, int ty, int sx, int sy, int h, 
-                              uint8_t rT, uint8_t gT, uint8_t bT, 
-                              uint8_t rL, uint8_t gL, uint8_t bL, 
-                              uint8_t rR, uint8_t gR, uint8_t bR) {
-        int w = PANEL_RES_W;
-        int dh = PANEL_RES_H;
+const float VECTOR_FIELD_SPEED_MIN = 0.1f;
+const float VECTOR_FIELD_SPEED_MAX = 10.0f;
+const float VECTOR_FIELD_SPEED_STEP = 0.10f;
 
-        for (int dy = -sy; dy <= sy; dy++) {
-            int span = (int)((1.0f - abs(dy) / (float)sy) * sx);
-            for (int dx = -span; dx <= span; dx++) {
-                int px = tx + dx;
-                int py = ty + dy;
-                if (px >= 0 && px < w && py >= 0 && py < dh) {
-                    PFCanvas::setPixel(px, py, rT, gT, bT);
-                }
-            }
-        }
+const float VECTOR_FIELD_DENSITY_MIN = 0.0f;
+const float VECTOR_FIELD_DENSITY_MAX = 4.9f;
+const float VECTOR_FIELD_DENSITY_STEP = 0.05f;
 
-        for (int dy = 0; dy < h; dy++) {
-            for (int stepY = 0; stepY <= sy; stepY++) {
-                int span = (int)(((float)stepY / sy) * sx);
-                for (int dx = -span; dx < 0; dx++) {
-                    int px = tx + dx;
-                    int py = ty + sy + dy + stepY - sy;
-                    if (px >= 0 && px < w && py >= 0 && py < dh) {
-                        PFCanvas::setPixel(px, py, rL, gL, bL);
-                    }
-                }
-            }
-        }
+const float VECTOR_FIELD_PALETTE_MIN = 0.0f;
+const float VECTOR_FIELD_PALETTE_MAX = 1.0f;
+const float VECTOR_FIELD_PALETTE_STEP = 0.05f;
 
-        for (int dy = 0; dy < h; dy++) {
-            for (int stepY = 0; stepY <= sy; stepY++) {
-                int span = (int)(((float)stepY / sy) * sx);
-                for (int dx = 0; dx <= span; dx++) {
-                    int px = tx + dx;
-                    int py = ty + sy + dy + stepY - sy;
-                    if (px >= 0 && px < w && py >= 0 && py < dh) {
-                        PFCanvas::setPixel(px, py, rR, gR, bR);
-                    }
-                }
-            }
-        }
+struct Params {
+    float turbulence;
+    float speed;
+    float density;
+    float palette;
+    float timeAcc;
+};
+
+Params params;
+
+float norm_x[PANEL_RES_W];
+float norm_y[PANEL_RES_H];
+
+void setup() {
+    PFMath::buildSinLUT();
+
+    params.turbulence = 0.5f;
+    params.speed = 2.0f;
+    params.density = 2.5f;
+    params.palette = 0.1f;
+    params.timeAcc = 0.0f;
+
+    for (int x = 0; x < PANEL_RES_W; x++) {
+        norm_x[x] = (float)x / PANEL_RES_W - 0.5f;
+    }
+    for (int y = 0; y < PANEL_RES_H; y++) {
+        norm_y[y] = (float)y / PANEL_RES_H - 0.5f;
+    }
+}
+
+void update(float dt, const InputFrame& input) {
+    // Knob 1: Turbulence (Wrap)
+    params.turbulence += input.knobDeltas[0] * VECTOR_FIELD_TURB_STEP;
+    while (params.turbulence < VECTOR_FIELD_TURB_MIN) params.turbulence += (VECTOR_FIELD_TURB_MAX - VECTOR_FIELD_TURB_MIN);
+    while (params.turbulence > VECTOR_FIELD_TURB_MAX) params.turbulence -= (VECTOR_FIELD_TURB_MAX - VECTOR_FIELD_TURB_MIN);
+
+    // Knob 2: Speed (Clamp)
+    params.speed += input.knobDeltas[1] * VECTOR_FIELD_SPEED_STEP;
+    params.speed = constrain(params.speed, VECTOR_FIELD_SPEED_MIN, VECTOR_FIELD_SPEED_MAX);
+
+    // Knob 3: Density (Clamp)
+    params.density += input.knobDeltas[2] * VECTOR_FIELD_DENSITY_STEP;
+    params.density = constrain(params.density, VECTOR_FIELD_DENSITY_MIN, VECTOR_FIELD_DENSITY_MAX);
+
+    // Knob 4: Palette (Wrap)
+    params.palette += input.knobDeltas[3] * VECTOR_FIELD_PALETTE_STEP;
+    while (params.palette < VECTOR_FIELD_PALETTE_MIN) params.palette += (VECTOR_FIELD_PALETTE_MAX - VECTOR_FIELD_PALETTE_MIN);
+    while (params.palette > VECTOR_FIELD_PALETTE_MAX) params.palette -= (VECTOR_FIELD_PALETTE_MAX - VECTOR_FIELD_PALETTE_MIN);
+
+    params.timeAcc += dt * params.speed;
+}
+
+void draw() {
+    float density_4 = params.density * 4.0f;
+    float t = params.timeAcc;
+
+    float cos_ny_term[PANEL_RES_H];
+    for (int y = 0; y < PANEL_RES_H; y++) {
+        cos_ny_term[y] = PFMath::fastCos(norm_y[y] * density_4 - t);
     }
 
-    void setup() {
-        PFMath::buildSinLUT();
-        time_state = 0.0f;
+    float sin_nx_term[PANEL_RES_W];
+    for (int x = 0; x < PANEL_RES_W; x++) {
+        sin_nx_term[x] = PFMath::fastSin(norm_x[x] * density_4 + t);
     }
 
-    void update(float dt, const InputFrame& input) {
-        knob1 += input.knobDeltas[0] * 0.05f;
-        if (knob1 < 0.0f) knob1 = 0.0f; if (knob1 > 1.0f) knob1 = 1.0f;
+    for (int y = 0; y < PANEL_RES_H; y++) {
+        float cy = cos_ny_term[y];
+        float ny = norm_y[y];
 
-        knob2 += input.knobDeltas[1] * 0.1f;
-        if (knob2 < 0.1f) knob2 = 0.1f; if (knob2 > 10.0f) knob2 = 10.0f;
+        for (int x = 0; x < PANEL_RES_W; x++) {
+            float nx = norm_x[x];
+            float angle = sin_nx_term[x] + cy;
 
-        knob3 += input.knobDeltas[2] * 0.05f;
-        if (knob3 < 0.0f) knob3 = 0.0f; if (knob3 > 4.9f) knob3 = 4.9f;
+            float turb_5 = angle * params.turbulence * 5.0f;
+            float forceX = PFMath::fastSin(turb_5);
+            float forceY = PFMath::fastCos(turb_5);
 
-        knob4 += input.knobDeltas[3] * 0.05f;
-        if (knob4 < 0.0f) knob4 = 0.0f; if (knob4 > 1.0f) knob4 = 1.0f;
+            float value = PFMath::fastSin((nx * forceX + ny * forceY) * 10.0f + t * 2.0f);
+            float intensity = value * 0.5f + 0.5f;
+            if (intensity < 0.0f) intensity = 0.0f;
 
-        time_state += dt * knob2 * 1.5f;
-    }
+            uint8_t r = 0, g = 0, b = 0;
+            if (intensity > 0.1f) {
+                float adjusted_intensity = constrain(0.05f + intensity * 1.1f, 0.0f, 1.0f);
+                float hue = params.palette + (angle * 0.159154943f) + (forceX * 0.2f);
 
-    void draw() {
-        for (int py = 0; py < PANEL_RES_H; py++) {
-            for (int px = 0; px < PANEL_RES_W; px++) {
-                PFCanvas::setPixel(px, py, 10, 10, 20);
-            }
-        }
-
-        int cols = 8 + (int)(knob1 * 12);
-        int rows = cols;
-        const int sizeX = 8;
-        const int sizeY = 4;
-        float cx = PANEL_RES_W / 2.0f;
-        float cy = PANEL_RES_H / 2.0f - 10.0f;
-        float maxHeight = 10.0f + knob3 * 35.0f;
-
-        for (int sum = 0; sum < rows + cols; sum++) {
-            for (int r = 0; r < rows; r++) {
-                int c = sum - r;
-                if (c < 0 || c >= cols) continue;
-
-                float isoX = cx + (c - r) * sizeX;
-                float isoY = cy + (c + r) * sizeY;
-
-                float dc = c - cols / 2.0f;
-                float dr = r - rows / 2.0f;
-                float dist = sqrtf(dc * dc + dr * dr);
-                
-                float wave = PFMath::fastSin(dist * 0.8f - time_state) * 0.5f + 0.5f;
-                int height = (int)(wave * maxHeight);
-
-                int tx = (int)isoX;
-                int ty = (int)(isoY - height);
-
-                float hue = wave * 0.3f + knob4;
-                hue -= (int)hue;
+                hue = fmodf(hue, 1.0f);
                 if (hue < 0.0f) hue += 1.0f;
 
-                uint8_t rT, gT, bT;
-                uint8_t rL, gL, bL;
-                uint8_t rR, gR, bR;
+                PFColor::hsvToRgb(hue, 0.85f, adjusted_intensity, r, g, b);
 
-                PFColor::hsvToRgb(hue, 0.85f, 0.95f, rT, gT, bT);
-                PFColor::hsvToRgb(hue, 0.90f, 0.60f, rL, gL, bL);
-                PFColor::hsvToRgb(hue, 0.95f, 0.40f, rR, gR, bR);
-
-                drawIsoPillar(tx, ty, sizeX, sizeY, height, rT, gT, bT, rL, gL, bL, rR, gR, bR);
+                if (adjusted_intensity > 0.88f) {
+                    r = 255;
+                    g = 255;
+                    b = 255;
+                }
             }
+            PFCanvas::setPixel(x, y, r, g, b);
         }
-
-        PFCanvas::present();
     }
+    PFCanvas::present();
+}
 
-} // namespace IsometricPillars
+} // namespace VectorFieldParticleFlowPattern

--- a/firmware/patternflow/custom2.h
+++ b/firmware/patternflow/custom2.h
@@ -1,99 +1,119 @@
 #pragma once
 
 #include <Arduino.h>
+#include <math.h>
+#include <stdint.h>
 #include "config.h"
 #include "src/core_display.h"
 #include "src/core_encoders.h"
 #include "src/core_canvas.h"
-#include "src/core_math.h"
-#include "src/core_color.h"
 
-namespace RetroDigitalTapestry {
+namespace CyberpunkCyberGridPattern {
 
-const char* NAME = "Retro Digital Tapestry";
-const char* const KNOB_LABELS[4] = {"Cell Scale", "Speed", "Logic Mode", "Wave Mod"};
+const char* NAME = "Cyber Grid";
+const char* const KNOB_LABELS[4] = {"Grid Spacing", "Velocity", "Pulse Width", "Color Split"};
 
-float cellScale = -0.101f;
-float speed = 1.99f;
-float logicMode = 1.001f;
-float waveMod = 1.346f;
-float timeAcc = 0.0f;
+const float CYBER_GRID_GRIDW_MIN = 0.0f;
+const float CYBER_GRID_GRIDW_MAX = 1.0f;
+const float CYBER_GRID_GRIDW_STEP = 0.05f;
+
+const float CYBER_GRID_SPEED_MIN = 0.1f;
+const float CYBER_GRID_SPEED_MAX = 10.0f;
+const float CYBER_GRID_SPEED_STEP = 0.10f;
+
+const float CYBER_GRID_PULSE_MIN = 0.0f;
+const float CYBER_GRID_PULSE_MAX = 4.9f;
+const float CYBER_GRID_PULSE_STEP = 0.05f;
+
+const float CYBER_GRID_SPLIT_MIN = 0.0f;
+const float CYBER_GRID_SPLIT_MAX = 1.0f;
+const float CYBER_GRID_SPLIT_STEP = 0.05f;
+
+struct Params {
+    float gridW;
+    float speed;
+    float pulse;
+    float split;
+    float timeAcc;
+};
+
+Params params;
 
 void setup() {
-    PFMath::buildSinLUT();
-    cellScale = -0.101f;
-    speed = 1.99f;
-    logicMode = 1.001f;
-    waveMod = 1.346f;
-    timeAcc = 0.0f;
+    params.gridW = 0.4f;
+    params.speed = 2.5f;
+    params.pulse = 1.5f;
+    params.split = 0.5f;
+    params.timeAcc = 0.0f;
 }
 
 void update(float dt, const InputFrame& input) {
-    cellScale += input.knobDeltas[0] * 0.05f;
-    if (cellScale < -0.101f) cellScale = -0.101f;
-    if (cellScale > 0.5f) cellScale = 0.5f;
+    // Knob 1: Grid Spacing (Wrap)
+    params.gridW += input.knobDeltas[0] * CYBER_GRID_GRIDW_STEP;
+    while (params.gridW < CYBER_GRID_GRIDW_MIN) params.gridW += (CYBER_GRID_GRIDW_MAX - CYBER_GRID_GRIDW_MIN);
+    while (params.gridW > CYBER_GRID_GRIDW_MAX) params.gridW -= (CYBER_GRID_GRIDW_MAX - CYBER_GRID_GRIDW_MIN);
 
-    speed += input.knobDeltas[1] * 0.1f;
-    if (speed < 0.1f) speed = 0.1f;
-    if (speed > 5.0f) speed = 5.0f;
+    // Knob 2: Horizon Scroll Velocity (Clamp)
+    params.speed += input.knobDeltas[1] * CYBER_GRID_SPEED_STEP;
+    params.speed = constrain(params.speed, CYBER_GRID_SPEED_MIN, CYBER_GRID_SPEED_MAX);
 
-    logicMode += input.knobDeltas[2] * 0.05f;
-    if (logicMode < 0.0f) logicMode = 0.0f;
-    if (logicMode > 1.001f) logicMode = 1.001f;
+    // Knob 3: Neon Pulse Width Threshold (Clamp)
+    params.pulse += input.knobDeltas[2] * CYBER_GRID_PULSE_STEP;
+    params.pulse = constrain(params.pulse, CYBER_GRID_PULSE_MIN, CYBER_GRID_PULSE_MAX);
 
-    waveMod += input.knobDeltas[3] * 0.05f;
-    if (waveMod < 0.0f) waveMod = 0.0f;
-    if (waveMod > 3.0f) waveMod = 3.0f;
+    // Knob 4: Pink-Cyan Complementary Split (Wrap)
+    params.split += input.knobDeltas[3] * CYBER_GRID_SPLIT_STEP;
+    while (params.split < CYBER_GRID_SPLIT_MIN) params.split += (CYBER_GRID_SPLIT_MAX - CYBER_GRID_SPLIT_MIN);
+    while (params.split > CYBER_GRID_SPLIT_MAX) params.split -= (CYBER_GRID_SPLIT_MAX - CYBER_GRID_SPLIT_MIN);
 
-    timeAcc += dt * speed * 2.0f;
+    params.timeAcc += dt * params.speed * 15.0f;
 }
 
 void draw() {
-    int scale = (int)(4.0f + cellScale * 24.0f);
-    if (scale < 1) scale = 1;
-    int mode = (int)(logicMode * 5.0f);
-    float waveF = 0.02f + waveMod * 0.08f;
-    float t = timeAcc;
+    int w = PANEL_RES_W;
+    int h = PANEL_RES_H;
+    float t = params.timeAcc;
+
+    int spacing = (int)floorf(params.gridW * 14.0f) + 6;
+    if (spacing <= 0) spacing = 1;
     
-    int floorT = (int)floorf(t);
-    int floorT15 = (int)floorf(t * 1.5f);
-    int floorT08 = (int)floorf(t * 0.8f);
+    float pWidth = params.pulse * 0.3f + 0.1f;
+    float spacing_pWidth = (float)spacing * pWidth;
+    int horizon_y = (int)floorf((float)h * 0.4f);
 
-    float minVal = floorf(50.0f * (PFMath::fastSin(t * 2.0f) * 0.5f + 0.5f));
-    float hsv_v = 220.0f / 255.0f;
-    float hsv_s = (220.0f - minVal) / 220.0f;
+    float w_div_2 = (float)w / 2.0f;
+    float t_05 = t * 0.5f;
 
-    for (int y = 0; y < PANEL_RES_H; y++) {
-        int sy = y / scale;
-        float cosY = PFMath::fastCos(y * waveF - t);
+    uint8_t vertical_r = 0;
+    uint8_t vertical_g = (uint8_t)constrain(floorf(200.0f + params.split * 55.0f), 0.0f, 255.0f);
+    uint8_t vertical_b = 255;
 
-        for (int x = 0; x < PANEL_RES_W; x++) {
-            int sx = x / scale;
-            int patternVal = 0;
+    uint8_t horizontal_r = 255;
+    uint8_t horizontal_g = 20;
+    uint8_t horizontal_b = (uint8_t)constrain(floorf(150.0f + (1.0f - params.split) * 105.0f), 0.0f, 255.0f);
 
-            switch (mode) {
-                case 0:  patternVal = (sx ^ sy) + floorT; break;
-                case 1:  patternVal = (sx & sy) * 3 + floorT15; break;
-                case 2:  patternVal = (sx * 7 + sy * 3) ^ floorT; break;
-                case 3:  patternVal = (sx ^ (sy + floorT)) & 15; break;
-                default: patternVal = ((sx * sx + sy * sy) >> 2) + floorT08; break;
-            }
+    for (int y = 0; y < h; y++) {
+        float perspectiveScale = ((float)y / (float)h) * 3.0f + 0.2f;
+        float invPerspectiveScale = 1.0f / perspectiveScale;
+        
+        float y_term = (float)y - t * 0.2f;
+        bool gridY = fabsf(fmodf(y_term, (float)spacing)) < spacing_pWidth;
 
-            float smoothS = PFMath::fastSin(x * waveF + t) * cosY;
-            bool bitActive = (patternVal & 8) != 0;
+        for (int x = 0; x < w; x++) {
+            float skewX = ((float)x - w_div_2) * invPerspectiveScale + w_div_2;
+            float x_term = skewX + t_05;
+            bool gridX = fabsf(fmodf(x_term, (float)spacing)) < spacing_pWidth;
 
             uint8_t r = 0, g = 0, b = 0;
 
-            if (bitActive) {
-                float hu = smoothS * 0.3f + 0.5f + (float)(patternVal % 16) / 32.0f;
-                hu = fmodf(hu, 1.0f);
-                if (hu < 0.0f) hu += 1.0f;
-
-                PFColor::hsvToRgb(hu, hsv_s, hsv_v, r, g, b);
-            } else {
-                if ((x % scale == 0) || (y % scale == 0)) {
-                    r = 20; g = 10; b = 40;
-                }
+            if (gridX && gridY) {
+                r = 255; g = 255; b = 255;
+            } else if (gridX) {
+                r = vertical_r; g = vertical_g; b = vertical_b;
+            } else if (gridY) {
+                r = horizontal_r; g = horizontal_g; b = horizontal_b;
+            } else if (y == horizon_y) {
+                r = 255; g = 255; b = 0;
             }
 
             PFCanvas::setPixel(x, y, r, g, b);
@@ -102,4 +122,4 @@ void draw() {
     PFCanvas::present();
 }
 
-} // namespace RetroDigitalTapestry
+} // namespace CyberpunkCyberGridPattern

--- a/firmware/patternflow/custom3.h
+++ b/firmware/patternflow/custom3.h
@@ -1,9 +1,3 @@
-// SPDX-License-Identifier: CC-BY-SA-4.0
-// Pattern: Cellular Interference
-// Author:  Seunghun LEE
-// Lineage: AI generated and curated
-//
-
 #pragma once
 
 #include <Arduino.h>
@@ -14,34 +8,33 @@
 #include "src/core_encoders.h"
 #include "src/core_canvas.h"
 #include "src/core_math.h"
-#include "src/core_color.h"
 
-namespace Custom3 {
+namespace ChromaticAberrationVortexPattern {
 
-const char* NAME = "Cellular Interference";
-const char* const KNOB_LABELS[4] = {"Lattice Scale", "Speed", "Interfere Mode", "Pulse Width"};
+const char* NAME = "Chromatic Vortex";
+const char* const KNOB_LABELS[4] = {"Split Dist", "Swirl Speed", "Wave Density", "Color Shift"};
 
-const float CELL_INTERFERENCE_SCALE_MIN = 0.0f;
-const float CELL_INTERFERENCE_SCALE_MAX = 1.0f;
-const float CELL_INTERFERENCE_SCALE_STEP = 0.05f;
+const float CHROMATIC_VORTEX_SPLIT_MIN = 0.0f;
+const float CHROMATIC_VORTEX_SPLIT_MAX = 1.0f;
+const float CHROMATIC_VORTEX_SPLIT_STEP = 0.05f;
 
-const float CELL_INTERFERENCE_SPEED_MIN = 0.1f;
-const float CELL_INTERFERENCE_SPEED_MAX = 10.0f;
-const float CELL_INTERFERENCE_SPEED_STEP = 0.10f;
+const float CHROMATIC_VORTEX_SPEED_MIN = 0.1f;
+const float CHROMATIC_VORTEX_SPEED_MAX = 10.0f;
+const float CHROMATIC_VORTEX_SPEED_STEP = 0.10f;
 
-const float CELL_INTERFERENCE_MODE_MIN = 0.0f;
-const float CELL_INTERFERENCE_MODE_MAX = 4.9f;
-const float CELL_INTERFERENCE_MODE_STEP = 0.05f;
+const float CHROMATIC_VORTEX_DENSITY_MIN = 0.0f;
+const float CHROMATIC_VORTEX_DENSITY_MAX = 4.9f;
+const float CHROMATIC_VORTEX_DENSITY_STEP = 0.05f;
 
-const float CELL_INTERFERENCE_PULSE_MIN = 0.0f;
-const float CELL_INTERFERENCE_PULSE_MAX = 1.0f;
-const float CELL_INTERFERENCE_PULSE_STEP = 0.05f;
+const float CHROMATIC_VORTEX_COLOR_BIAS_MIN = 0.0f;
+const float CHROMATIC_VORTEX_COLOR_BIAS_MAX = 1.0f;
+const float CHROMATIC_VORTEX_COLOR_BIAS_STEP = 0.05f;
 
 struct Params {
-    float scale;
+    float split;
     float speed;
-    float interfereMode;
-    float pulseWidth;
+    float density;
+    float colorBias;
     float timeAcc;
 };
 
@@ -49,97 +42,87 @@ Params params;
 
 void setup() {
     PFMath::buildSinLUT();
-    params.scale = 0.5f;
-    params.speed = 2.0f;
-    params.interfereMode = 1.0f;
-    params.pulseWidth = 0.5f;
+    params.split = 0.4f;
+    params.speed = 1.5f;
+    params.density = 2.0f;
+    params.colorBias = 0.5f;
     params.timeAcc = 0.0f;
 }
 
 void update(float dt, const InputFrame& input) {
-    params.scale += input.knobDeltas[0] * CELL_INTERFERENCE_SCALE_STEP;
-    if (params.scale < CELL_INTERFERENCE_SCALE_MIN) params.scale += (CELL_INTERFERENCE_SCALE_MAX - CELL_INTERFERENCE_SCALE_MIN);
-    if (params.scale > CELL_INTERFERENCE_SCALE_MAX) params.scale -= (CELL_INTERFERENCE_SCALE_MAX - CELL_INTERFERENCE_SCALE_MIN);
+    params.split += input.knobDeltas[0] * CHROMATIC_VORTEX_SPLIT_STEP;
+    params.split = fmodf(params.split, 1.0f);
+    if (params.split < 0.0f) params.split += 1.0f;
 
-    params.speed += input.knobDeltas[1] * CELL_INTERFERENCE_SPEED_STEP;
-    params.speed = constrain(params.speed, CELL_INTERFERENCE_SPEED_MIN, CELL_INTERFERENCE_SPEED_MAX);
+    params.speed += input.knobDeltas[1] * CHROMATIC_VORTEX_SPEED_STEP;
+    params.speed = constrain(params.speed, CHROMATIC_VORTEX_SPEED_MIN, CHROMATIC_VORTEX_SPEED_MAX);
 
-    params.interfereMode += input.knobDeltas[2] * CELL_INTERFERENCE_MODE_STEP;
-    params.interfereMode = constrain(params.interfereMode, CELL_INTERFERENCE_MODE_MIN, CELL_INTERFERENCE_MODE_MAX);
+    params.density += input.knobDeltas[2] * CHROMATIC_VORTEX_DENSITY_STEP;
+    params.density = constrain(params.density, CHROMATIC_VORTEX_DENSITY_MIN, CHROMATIC_VORTEX_DENSITY_MAX);
 
-    params.pulseWidth += input.knobDeltas[3] * CELL_INTERFERENCE_PULSE_STEP;
-    if (params.pulseWidth < CELL_INTERFERENCE_PULSE_MIN) params.pulseWidth += (CELL_INTERFERENCE_PULSE_MAX - CELL_INTERFERENCE_PULSE_MIN);
-    if (params.pulseWidth > CELL_INTERFERENCE_PULSE_MAX) params.pulseWidth -= (CELL_INTERFERENCE_PULSE_MAX - CELL_INTERFERENCE_PULSE_MIN);
+    params.colorBias += input.knobDeltas[3] * CHROMATIC_VORTEX_COLOR_BIAS_STEP;
+    params.colorBias = fmodf(params.colorBias, 1.0f);
+    if (params.colorBias < 0.0f) params.colorBias += 1.0f;
 
     params.timeAcc += dt * params.speed;
 }
 
 void draw() {
-    const int w = PANEL_RES_W;
-    const int h = PANEL_RES_H;
-    const float t = params.timeAcc;
+    int w = PANEL_RES_W;
+    int h = PANEL_RES_H;
+    float t = params.timeAcc;
 
-    float cellSize = 8.0f + (1.0f - params.scale) * 24.0f;
-    if (cellSize < 1.0f) cellSize = 1.0f;
-    const int iCellSize = (int)cellSize;
-    const float halfCell = cellSize * 0.5f;
-    
-    const int mode = (int)floorf(params.interfereMode);
-    const float pw = 0.1f + params.pulseWidth * 0.8f;
-    const float invPw = 1.0f / pw;
+    float cx = w / 2.0f;
+    float cy = h / 2.0f;
+    float maxShift = params.split * 8.0f;
+    float densityCalc = params.density * 0.1f + 0.05f;
 
     for (int y = 0; y < h; y++) {
-        const int cellY = y / iCellSize;
-        const float ly = (float)(y % iCellSize) - halfCell;
-        const float absLy = ly < 0.0f ? -ly : ly;
-
+        float dy = (float)y - cy;
         for (int x = 0; x < w; x++) {
-            const int cellX = x / iCellSize;
-            const float lx = (float)(x % iCellSize) - halfCell;
-            const float absLx = lx < 0.0f ? -lx : lx;
-            
-            const float dist = PFMath::approxLength(lx, ly);
+            float dx = (float)x - cx;
 
-            const float phaseA = dist * 0.4f - t;
-            float phaseB = 0.0f;
+            // 완벽한 원형을 위해 실제 sqrtf 사용 (ESP32-S3 FPU 하드웨어 연산 활용)
+            float dist = sqrtf(dx * dx + dy * dy);
+            float angle = atan2f(dy, dx);
 
-            if (mode == 0) {
-                phaseB = (cellX + cellY) * 0.5f + t * 0.5f;
-            } else if (mode == 1) {
-                phaseB = PFMath::fastSin(cellX * 0.3f + t) * 3.0f + PFMath::fastCos(cellY * 0.3f + t);
-            } else if (mode == 2) {
-                const float cx = (float)(cellX - 4);
-                const float cy = (float)(cellY - 2);
-                phaseB = PFMath::approxLength(cx, cy) * 0.8f - t * 0.5f;
-            } else {
-                phaseB = ((cellX ^ cellY) & 7) * 0.6f;
-            }
+            float dist005 = dist * 0.05f;
+            float shiftR = PFMath::fastSin(dist005 - t) * maxShift;
+            float shiftG = PFMath::fastSin(dist005 - t + 1.0f) * maxShift * 0.5f;
+            float shiftB = PFMath::fastSin(dist005 - t + 2.0f) * maxShift * -0.5f;
 
-            const float wave = PFMath::fastSin(phaseA + phaseB);
-            const float signal = (wave + 1.0f) * 0.5f;
+            // Red Channel Matrix
+            float rDist = dist + shiftR;
+            float rWave = PFMath::fastSin(rDist * densityCalc - t * 2.0f + angle);
+            float rInt = rWave * 0.5f + 0.5f;
+            if (rInt < 0.0f) rInt = 0.0f;
 
-            uint8_t r = 0, g = 0, b = 0;
+            // Green Channel Matrix
+            float gDist = dist + shiftG;
+            float gWave = PFMath::fastSin(gDist * densityCalc - t * 2.0f + angle + 1.0f);
+            float gInt = gWave * 0.5f + 0.5f;
+            if (gInt < 0.0f) gInt = 0.0f;
 
-            if (signal > 1.0f - pw) {
-                const int cellHueInt = (cellX * 13 + cellY * 37) % 100;
-                const float cellHue = (float)cellHueInt * 0.01f;
-                float localHue = cellHue + wave * 0.15f + 1.0f;
-                localHue = localHue - floorf(localHue);
-                
-                const float intensity = (signal - (1.0f - pw)) * invPw;
-                if (intensity > 0.75f) {
-                    r = 255; g = 255; b = 255;
-                } else {
-                    uint8_t cr, cg, cb;
-                    PFColor::hsvToRgb(localHue, 0.9f, 1.0f, cr, cg, cb);
-                    r = (uint8_t)(cr * intensity);
-                    g = (uint8_t)(cg * intensity);
-                    b = (uint8_t)(cb * intensity);
-                }
-            } else if (signal > 0.05f) {
-                if (absLx < 0.8f || absLy < 0.8f) {
-                    r = 20; g = 10; b = 35;
-                }
+            // Blue Channel Matrix
+            float bDist = dist + shiftB;
+            float bWave = PFMath::fastSin(bDist * densityCalc - t * 2.0f + angle + 2.0f);
+            float bInt = bWave * 0.5f + 0.5f;
+            if (bInt < 0.0f) bInt = 0.0f;
+
+            // Color Bias Processing
+            float rFloat = rInt * 255.0f * (params.colorBias * 0.5f + 0.5f);
+            float gFloat = gInt * 255.0f * (1.0f - params.colorBias * 0.3f);
+            float bFloat = bInt * 255.0f * (0.3f + params.colorBias * 0.7f);
+
+            uint8_t r = (uint8_t)constrain(floorf(rFloat), 0.0f, 255.0f);
+            uint8_t g = (uint8_t)constrain(floorf(gFloat), 0.0f, 255.0f);
+            uint8_t b = (uint8_t)constrain(floorf(bFloat), 0.0f, 255.0f);
+
+            // White Overlap Peak Correction
+            if (rInt > 0.85f && gInt > 0.85f && bInt > 0.85f) {
+                r = 255;
+                g = 255;
+                b = 255;
             }
 
             PFCanvas::setPixel(x, y, r, g, b);
@@ -148,4 +131,4 @@ void draw() {
     PFCanvas::present();
 }
 
-} // namespace Custom3
+} // namespace ChromaticAberrationVortexPattern

--- a/firmware/patternflow/pattern_registry.h
+++ b/firmware/patternflow/pattern_registry.h
@@ -55,9 +55,9 @@ struct PatternEntry {
 
 // ── CUSTOM (your own — edit these) ──
 PatternEntry customPatterns[] = {
-  PATTERN_ENTRY(IsometricPillars),
-  PATTERN_ENTRY(RetroDigitalTapestry),
-  PATTERN_ENTRY(Custom3),
+  PATTERN_ENTRY(VectorFieldParticleFlowPattern),
+  PATTERN_ENTRY(CyberpunkCyberGridPattern),
+  PATTERN_ENTRY(ChromaticAberrationVortexPattern),
 };
 const int NUM_CUSTOM = sizeof(customPatterns) / sizeof(customPatterns[0]);
 

--- a/web/src/app/build/breadboard/page.tsx
+++ b/web/src/app/build/breadboard/page.tsx
@@ -90,7 +90,7 @@ export default function BreadboardBuildPage() {
             gap: '10px',
             marginTop: '8px',
             fontFamily: 'var(--pf-mono)',
-            fontSize: '11px'
+            fontSize: 'var(--pf-fs-mono)'
           }}>
             <span style={{
               background: 'var(--pf-cream-2)',
@@ -281,7 +281,7 @@ export default function BreadboardBuildPage() {
             </div>
           </div>
 
-          <p style={{ fontSize: '11px', color: 'var(--pf-ink-faint)', fontFamily: 'var(--pf-mono)', margin: 0 }}>
+          <p style={{ fontSize: 'var(--pf-fs-mono)', color: 'var(--pf-ink-faint)', fontFamily: 'var(--pf-mono)', margin: 0 }}>
             * No soldering required if your encoders accept Dupont leads. You will strip two power leads (USB + panel power) — a hot-glue joint is enough.
           </p>
         </section>
@@ -346,7 +346,7 @@ export default function BreadboardBuildPage() {
                   display: 'flex',
                   alignItems: 'center',
                   justifyContent: 'center',
-                  fontSize: '11px'
+                  fontSize: 'var(--pf-fs-mono)'
                 }}>{step.id}</span>
                 <span style={{ borderBottom: '1px solid transparent' }} className="hover:border-current">{step.text}</span>
               </a>
@@ -383,7 +383,7 @@ export default function BreadboardBuildPage() {
           <div style={{ border: '1px solid var(--pf-rule)', borderRadius: '10px', padding: '6px', background: '#fbfaf7' }}>
             <BreadboardDiagram mode="encoders_gnd" />
           </div>
-          <p style={{ fontSize: '11px', color: 'var(--pf-ink-faint)', fontFamily: 'var(--pf-mono)', margin: 0 }}>
+          <p style={{ fontSize: 'var(--pf-fs-mono)', color: 'var(--pf-ink-faint)', fontFamily: 'var(--pf-mono)', margin: 0 }}>
             ↑ Ground (GND) pins on both sides of all four rotary encoders land on the Ground (<strong>−</strong>) rail of the breadboard.
           </p>
           <div className="w-full mt-4 step-photo-right flex flex-col gap-2">
@@ -392,7 +392,7 @@ export default function BreadboardBuildPage() {
               alt="Encoders mounted with GND wires connected to the breadboard rail"
               style={{ width: '100%', display: 'block', borderRadius: '8px', border: '1px solid var(--pf-rule)' }}
             />
-            <p style={{ fontSize: '11px', color: 'var(--pf-ink-faint)', fontFamily: 'var(--pf-mono)', margin: 0 }}>
+            <p style={{ fontSize: 'var(--pf-fs-mono)', color: 'var(--pf-ink-faint)', fontFamily: 'var(--pf-mono)', margin: 0 }}>
               ↑ Encoders fixed, GND wires on the − rail.
             </p>
           </div>
@@ -424,7 +424,7 @@ export default function BreadboardBuildPage() {
           <div style={{ border: '1px solid var(--pf-rule)', borderRadius: '10px', padding: '6px', background: '#fbfaf7' }}>
             <BreadboardDiagram mode="hub_esp" />
           </div>
-          <p style={{ fontSize: '11px', color: 'var(--pf-ink-faint)', fontFamily: 'var(--pf-mono)', margin: 0 }}>
+          <p style={{ fontSize: 'var(--pf-fs-mono)', color: 'var(--pf-ink-faint)', fontFamily: 'var(--pf-mono)', margin: 0 }}>
             ↑ U1 (ESP32-S3) on the left, and J1 (HUB75E) on the right. Wire the pins that share the same color-coded labels (e.g. R1, B1, A, B...).
           </p>
           <div className="w-full mt-4 step-photo-left flex flex-col gap-2">
@@ -433,7 +433,7 @@ export default function BreadboardBuildPage() {
               alt="ESP32-S3 connected to the HUB75E LED matrix via ribbon cable"
               style={{ width: '100%', display: 'block', borderRadius: '8px', border: '1px solid var(--pf-rule)' }}
             />
-            <p style={{ fontSize: '11px', color: 'var(--pf-ink-faint)', fontFamily: 'var(--pf-mono)', margin: 0 }}>
+            <p style={{ fontSize: 'var(--pf-fs-mono)', color: 'var(--pf-ink-faint)', fontFamily: 'var(--pf-mono)', margin: 0 }}>
               ↑ ESP32-S3 with HUB75E jumpers connected.
             </p>
           </div>
@@ -465,7 +465,7 @@ export default function BreadboardBuildPage() {
           <div style={{ border: '1px solid var(--pf-rule)', borderRadius: '10px', padding: '6px', background: '#fbfaf7' }}>
             <BreadboardDiagram mode="encoders_esp" />
           </div>
-          <p style={{ fontSize: '11px', color: 'var(--pf-ink-faint)', fontFamily: 'var(--pf-mono)', margin: 0 }}>
+          <p style={{ fontSize: 'var(--pf-fs-mono)', color: 'var(--pf-ink-faint)', fontFamily: 'var(--pf-mono)', margin: 0 }}>
             ↑ Four rotary encoders on the left, and ESP32 on the right. Wire the signal channels (A, B, SW) to their matching colored tags (e.g. 1A, 2A...).
           </p>
           <div className="w-full mt-4 step-photo-right flex flex-col gap-2">
@@ -474,7 +474,7 @@ export default function BreadboardBuildPage() {
               alt="All encoder signal wires routed routed into the case alongside the LED panel"
               style={{ width: '100%', display: 'block', borderRadius: '8px', border: '1px solid var(--pf-rule)' }}
             />
-            <p style={{ fontSize: '11px', color: 'var(--pf-ink-faint)', fontFamily: 'var(--pf-mono)', margin: 0 }}>
+            <p style={{ fontSize: 'var(--pf-fs-mono)', color: 'var(--pf-ink-faint)', fontFamily: 'var(--pf-mono)', margin: 0 }}>
               ↑ Encoder A, B, SW wires all connected.
             </p>
           </div>
@@ -512,7 +512,7 @@ export default function BreadboardBuildPage() {
               alt="Stripped USB and LED panel power wires being twisted onto jumpers"
               style={{ width: '100%', display: 'block', borderRadius: '8px', border: '1px solid var(--pf-rule)' }}
             />
-            <p style={{ fontSize: '11px', color: 'var(--pf-ink-faint)', fontFamily: 'var(--pf-mono)', margin: 0 }}>
+            <p style={{ fontSize: 'var(--pf-fs-mono)', color: 'var(--pf-ink-faint)', fontFamily: 'var(--pf-mono)', margin: 0 }}>
               ↑ Power leads stripped and twisted onto jumpers.
             </p>
           </div>
@@ -588,7 +588,7 @@ export default function BreadboardBuildPage() {
           flexDirection: 'column',
           gap: '12px',
           fontFamily: 'var(--pf-mono)',
-          fontSize: '11px',
+          fontSize: 'var(--pf-fs-mono)',
           color: 'var(--pf-ink-muted)'
         }}>
           <div style={{ display: 'flex', justifyContent: 'space-between', flexWrap: 'wrap', gap: '12px' }}>

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -259,7 +259,7 @@
       display: flex;
       flex-direction: column;
       align-items: stretch;
-      padding: 54px 0 60px;
+      padding: 36px 0 60px;
       gap: 24px;
       min-height: auto;
     }
@@ -1620,15 +1620,13 @@
   }
   .journal-masthead {
     display: flex;
-    justify-content: space-between;
-    align-items: baseline;
-    gap: 28px;
+    flex-direction: column;
+    gap: 0;
     margin-bottom: 56px;
     padding-bottom: 18px;
     border-bottom: 1px solid var(--pf-rule);
   }
   .journal-lockup,
-  .journal-entry-count,
   .journal-featured-meta,
   .journal-archive-label,
   .journal-list-number,
@@ -1645,10 +1643,11 @@
   .journal-lockup {
     display: inline-block;
     text-decoration: none;
-    font-family: var(--sans);
-    font-size: 18px;
-    font-weight: 500;
-    letter-spacing: -0.01em;
+    font-family: var(--pretendard);
+    font-size: 88px;
+    font-weight: 700;
+    line-height: 1;
+    letter-spacing: -0.035em;
     text-transform: none;
     color: var(--ink);
   }
@@ -1656,9 +1655,13 @@
     color: var(--pf-ink-muted);
     text-decoration: none;
   }
-  .journal-entry-count {
+  .journal-section-label {
+    font-family: var(--pretendard);
+    font-size: 44px;
+    font-weight: 700;
+    line-height: 1.1;
+    letter-spacing: -0.035em;
     color: var(--pf-ink-muted);
-    letter-spacing: var(--pf-track-mono);
   }
   .journal-featured {
     display: grid;
@@ -2344,7 +2347,7 @@
       right: 22px;
     }
     .journal-shell {
-      padding: 48px 18px 96px;
+      padding: 36px 24px 96px;
     }
     .journal-index {
       width: 100%;
@@ -2358,12 +2361,17 @@
       position: static;
       margin-bottom: 40px;
     }
-    .journal-masthead,
     .journal-dateline,
     .journal-index-footer {
       flex-direction: column;
       align-items: flex-start;
       gap: 12px;
+    }
+    .journal-lockup {
+      font-size: 50px;
+    }
+    .journal-section-label {
+      font-size: 25px;
     }
     .journal-featured h1 {
       font-size: 36px;
@@ -2396,50 +2404,60 @@
       font-size: 16px;
     }
     .journal-post-list a {
-      grid-template-columns: 1fr;
-      gap: 10px;
-      align-items: start;
-      padding: 20px 70px 58px 0;
-      min-height: 190px;
+      display: block;
+      position: relative;
+      padding: 14px 54px 14px 0;
+      min-height: auto;
     }
     .journal-post-list a .pf-ghost {
-      right: -2px;
-      top: auto;
-      bottom: 18px;
-      transform: none;
-      font-size: 58px;
+      position: absolute;
+      right: 0;
+      top: 50%;
+      bottom: auto;
+      transform: translateY(-50%);
+      font-size: 42px;
+      line-height: 1;
       color: var(--pf-ink-ghost);
     }
     .journal-list-body {
-      max-width: calc(100% - 58px);
+      max-width: calc(100% - 10px);
     }
     .journal-list-body strong {
-      max-width: 16ch;
-      font-size: 19px;
-      line-height: 1.18;
+      display: block;
+      max-width: 100%;
+      font-size: 18px;
+      line-height: 1.25;
     }
     .journal-list-body .pf-row-d {
-      max-width: 22ch;
-      margin-top: 10px;
-      font-size: var(--pf-fs-mono);
-      line-height: 1.45;
+      display: block;
+      max-width: 100%;
+      margin-top: 6px;
+      font-size: var(--pf-fs-row-d);
+      line-height: 1.4;
       white-space: normal;
     }
     .journal-new-badge {
-      display: block;
-      margin: 8px 0 0;
-      font-size: var(--pf-fs-mono);
+      display: inline-block;
+      margin: 0 0 0 8px;
+      font-size: 11px;
+      vertical-align: middle;
     }
     .journal-list-meta {
-      grid-column: auto;
-      text-align: left;
-      font-size: 10px;
-      line-height: 1.4;
+      display: inline-block;
+      margin-top: 8px;
+      font-size: 10.5px;
+      line-height: 1;
+      text-transform: uppercase;
+      color: var(--ink-muted);
     }
     .journal-list-meta + .journal-list-meta {
-      position: absolute;
-      left: 0;
-      bottom: 20px;
+      position: static;
+      margin-left: 12px;
+    }
+    .journal-list-meta + .journal-list-meta::before {
+      content: "·";
+      margin-right: 12px;
+      color: var(--pf-ink-muted);
     }
     .journal-figure-wide,
     .journal-figure-full {

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -2204,54 +2204,62 @@
     gap: 18px;
     color: var(--ink-muted);
   }
-  .journal-more-writing {
-    border-top: 1px solid var(--pf-rule);
-  }
-  .journal-more-writing ol {
+  .journal-context-list {
     list-style: none;
-    display: grid;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: 0 42px;
+    border-top: 1px solid var(--pf-rule);
+    /* Undo the footer's mono/uppercase label styling so titles and dates
+       render like the journal index list. */
+    font-family: var(--pf-sans);
+    letter-spacing: normal;
+    text-transform: none;
   }
-  .journal-more-writing a {
+  .journal-context-list .pf-row {
     display: grid;
-    grid-template-columns: 86px minmax(0, 1fr);
-    gap: 8px 18px;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 24px;
     align-items: baseline;
-    min-height: 92px;
-    padding: 18px 0;
-    border-bottom: 1px solid var(--pf-rule);
+    padding-right: 56px;
+    border-top: 0;
     color: var(--ink-muted);
     text-decoration: none;
   }
-  .journal-more-writing a:hover strong,
-  .journal-more-writing a:focus-visible strong,
+  /* Title + date inherit uppercase/mono from .journal-article-footer; reset
+     them directly so they read like the journal index list. */
+  .journal-context-list .pf-row-t {
+    font-family: var(--pf-sans);
+    font-size: var(--pf-fs-row);
+    letter-spacing: -0.01em;
+    text-transform: none;
+  }
+  .journal-context-list .pf-ghost {
+    right: 0;
+  }
+  .journal-context-list a.pf-row:hover,
+  .journal-context-list a.pf-row:focus-visible {
+    color: var(--pf-ink);
+  }
+  .journal-context-list a.pf-row:hover .pf-row-t,
+  .journal-context-list a.pf-row:focus-visible .pf-row-t,
   .journal-all-writing-link:hover,
   .journal-all-writing-link:focus-visible {
     text-decoration: underline;
     text-underline-offset: 4px;
     text-decoration-thickness: 1px;
   }
-  .journal-more-kicker,
-  .journal-more-writing time {
-    font-family: var(--mono);
-    font-size: var(--pf-fs-mono);
-    letter-spacing: 0.08em;
-    text-transform: uppercase;
-    color: var(--ink-muted);
-  }
-  .journal-more-writing time {
-    white-space: nowrap;
-    grid-column: 2;
-  }
-  .journal-more-writing strong {
-    font-family: var(--mono);
-    font-size: 12px;
-    font-weight: 400;
-    line-height: 1.35;
-    letter-spacing: 0.08em;
+  .journal-context-list .is-current-row {
     color: var(--ink);
-    text-transform: uppercase;
+    cursor: default;
+  }
+  .journal-context-list .is-current .pf-ghost {
+    color: var(--ink);
+  }
+  .journal-context-list .journal-list-meta {
+    text-align: right;
+    white-space: nowrap;
+    font-family: var(--pf-sans);
+    font-size: var(--pf-fs-row-d);
+    letter-spacing: normal;
+    text-transform: none;
   }
   .journal-all-writing-link {
     width: fit-content;
@@ -2487,16 +2495,12 @@
     .journal-md-figure:has(+ .journal-md-figure) + .journal-md-figure img {
       max-height: min(70vh, 544px);
     }
-    .journal-more-writing ol {
-      grid-template-columns: 1fr;
+    .journal-context-list .pf-row {
+      display: block;
+      padding: 14px 54px 14px 0;
     }
-    .journal-more-writing a {
-      grid-template-columns: 1fr;
-      min-height: 0;
-      gap: 8px;
-    }
-    .journal-more-writing time {
-      grid-column: auto;
+    .journal-context-list .journal-list-meta {
+      text-align: left;
     }
   }
 

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -1622,7 +1622,7 @@
     display: flex;
     flex-direction: column;
     gap: 0;
-    margin-bottom: 56px;
+    margin-bottom: 24px;
     padding-bottom: 18px;
     border-bottom: 1px solid var(--pf-rule);
   }
@@ -1878,7 +1878,7 @@
     background: #ffffff;
   }
   .journal-back-link {
-    margin-bottom: 56px;
+    margin-bottom: 32px;
     color: var(--ink-muted);
   }
   .journal-back-link a::before {
@@ -1887,7 +1887,7 @@
   }
   .journal-article-header {
     width: 100%;
-    margin-bottom: 64px;
+    margin-bottom: 36px;
   }
   .journal-article-header h1 {
     font-family: var(--serif);
@@ -1900,7 +1900,7 @@
   }
   .journal-article-header > p {
     max-width: 691px;
-    margin: 0 0 64px;
+    margin: 0 0 32px;
     font-family: var(--serif);
     font-size: 22px;
     font-style: italic;
@@ -1917,7 +1917,7 @@
   }
   .journal-hero-cover {
     width: min(100%, 608px);
-    margin: 0 auto 64px;
+    margin: 0 auto 40px;
     text-align: center;
   }
   .journal-hero-cover .journal-cover-slot {
@@ -2355,13 +2355,12 @@
     .journal-panel,
     .journal-article {
       width: 100%;
-      padding: 40px 24px 72px;
+      padding: 24px 24px 72px;
     }
     .journal-panel .journal-lang-switch {
       position: static;
-      margin-bottom: 40px;
+      margin-bottom: 20px;
     }
-    .journal-dateline,
     .journal-index-footer {
       flex-direction: column;
       align-items: flex-start;

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -40,11 +40,11 @@
     --pf-mono: 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
     --pf-serif: 'Newsreader', Georgia, serif;
     --pf-fs-h2: 34px;
-    --pf-fs-sub: 14px;
-    --pf-fs-body: 13.5px;
-    --pf-fs-row: 16px;
-    --pf-fs-row-d: 12.5px;
-    --pf-fs-mono: 11px;
+    --pf-fs-sub: 16px;
+    --pf-fs-body: 15px;
+    --pf-fs-row: 18px;
+    --pf-fs-row-d: 14px;
+    --pf-fs-mono: 13px;
     --pf-fs-card: 15.5px;
     --pf-fs-ghost: 96px;
     --pf-fs-ghost-row: 64px;
@@ -72,7 +72,7 @@
   }
   a { color: inherit; text-decoration: none; }
   a:hover { text-decoration: underline; text-underline-offset: 3px; text-decoration-thickness: 1px; }
-  .mono { font-family: var(--mono); font-size: 11px; letter-spacing: 0.06em; text-transform: uppercase; color: var(--ink-muted); }
+  .mono { font-family: var(--mono); font-size: var(--pf-fs-mono); letter-spacing: 0.06em; text-transform: uppercase; color: var(--ink-muted); }
   em.wordmark { font-family: var(--pretendard); font-style: normal; font-weight: 700; }
 
   /* header removed */
@@ -122,18 +122,7 @@
     /* Page links (Journal / Contact) live as a fixed, layered header in the
        top-right — independent of the 3D preview, sitting above everything. */
     .mobile-page-links {
-      display: block;
-      position: fixed;
-      top: 0;
-      right: 0;
-      z-index: 60;
-      padding: 16px 20px;
-      pointer-events: none;
-    }
-    .mobile-page-links .hero-top-links {
-      display: flex;
-      position: static;
-      pointer-events: auto;
+      display: none;
     }
 
     /* The 3D preview is hidden while the hero is full-screen, then "drops down"
@@ -263,27 +252,18 @@
     border-color: var(--ink);
     text-decoration: none;
   }
-  .hero-cs-note {
-    font-family: var(--mono);
-    font-size: 11.5px;
-    letter-spacing: 0.02em;
-    line-height: 1.5;
-    color: var(--ink-muted);
-    margin: 12px 0 0;
-  }
+
 
   @media (max-width: 900px) {
     .hero {
       display: flex;
       flex-direction: column;
       align-items: stretch;
-      padding: 32px 24px 60px;
+      padding: 54px 0 60px;
       gap: 24px;
       min-height: auto;
     }
-    .hero > .hero-top-links {
-      display: none;
-    }
+
     .hero-viewer { height: 50vh; min-height: 320px; order: -1; }
     .hero-copy h1 { font-size: 50px; margin-bottom: 12px; }
     .hero-copy .kicker { font-size: 20px; margin-bottom: 28px; }
@@ -523,7 +503,7 @@
     max-width: 560px;
     border-top: 1px solid var(--rule);
     font-family: var(--mono);
-    font-size: 13px;
+    font-size: var(--pf-fs-mono);
     letter-spacing: 0.01em;
   }
   .spec-row {
@@ -548,7 +528,7 @@
   .stack {
     margin-top: 18px;
     max-width: 560px;
-    font-family: var(--mono); font-size: 13px;
+    font-family: var(--mono); font-size: var(--pf-fs-mono);
   }
   .stack-layer {
     display: grid;
@@ -593,7 +573,7 @@
   }
   .track-dot.is-now::before { background: var(--ink); }
   .track-dot .v {
-    font-size: 13px; color: var(--ink); font-weight: 500;
+    font-size: var(--pf-fs-mono); color: var(--ink); font-weight: 500;
     letter-spacing: -0.005em; margin-bottom: 4px;
   }
   .track-dot .when {
@@ -921,7 +901,7 @@
     margin-top: 3px;
     text-transform: none;
     letter-spacing: 0.02em;
-    font-size: 11px;
+    font-size: var(--pf-fs-mono);
   }
   @media (max-width: 540px) {
     .steps { grid-template-columns: repeat(2, 1fr); gap: 24px; }
@@ -931,7 +911,7 @@
   .inside-list {
     display: flex; gap: 32px;
     font-family: var(--mono);
-    font-size: 11px;
+    font-size: var(--pf-fs-mono);
     letter-spacing: 0.08em;
     text-transform: uppercase;
     margin-top: 60px;
@@ -1070,7 +1050,7 @@
     color: var(--ink);
     border-bottom: 1px solid currentColor;
     font-family: var(--mono);
-    font-size: 13px;
+    font-size: var(--pf-fs-mono);
     letter-spacing: 0;
     text-transform: uppercase;
   }
@@ -1107,7 +1087,7 @@
   }
   .inside-globe-tooltip strong {
     font-family: var(--pf-sans);
-    font-size: 13px;
+    font-size: var(--pf-fs-mono);
     font-weight: 500;
     letter-spacing: 0;
   }
@@ -1186,7 +1166,7 @@
     letter-spacing: 0;
   }
   .inside-image-placeholder span {
-    font-size: 13px;
+    font-size: var(--pf-fs-mono);
     color: var(--inside-heading);
   }
   .inside-image-placeholder small {
@@ -1260,7 +1240,7 @@
     gap: 1rem;
     margin: 1.5rem 0 10vh;
     font-family: var(--mono);
-    font-size: 13px;
+    font-size: var(--pf-fs-mono);
     letter-spacing: 0;
     text-transform: uppercase;
   }
@@ -1285,7 +1265,7 @@
       font-size: 17px;
     }
     .inside-stats span {
-      font-size: 11px;
+      font-size: var(--pf-fs-mono);
     }
     .reddit-comment-band {
       width: 100%;
@@ -1318,7 +1298,7 @@
   }
   .sponsor-label {
     font-family: var(--mono);
-    font-size: 11px;
+    font-size: var(--pf-fs-mono);
     letter-spacing: 0.08em;
     text-transform: uppercase;
     color: var(--ink-muted);
@@ -1358,7 +1338,7 @@
   }
   footer .series {
     font-family: var(--mono);
-    font-size: 11px;
+    font-size: var(--pf-fs-mono);
     letter-spacing: 0.08em;
     text-transform: uppercase;
     margin-top: 60px;
@@ -1377,7 +1357,7 @@
     border: 1px solid var(--ink);
     padding: 14px 16px;
     font-family: var(--mono);
-    font-size: 11px;
+    font-size: var(--pf-fs-mono);
     letter-spacing: 0.06em;
     text-transform: uppercase;
     display: none;
@@ -1408,13 +1388,14 @@
   }
   .hero-top-links {
     position: absolute;
-    top: 32px;
+    top: 24px;
     right: 42px;
     z-index: 3;
     display: flex;
+    align-items: flex-end;
     gap: 18px;
     font-family: var(--mono);
-    font-size: 11px;
+    font-size: var(--pf-fs-mono);
     letter-spacing: 0.08em;
     text-transform: uppercase;
     color: var(--ink-muted);
@@ -1427,6 +1408,20 @@
   .hero-top-links a:hover {
     color: var(--ink);
     text-decoration: underline;
+  }
+  .hero-top-links .instagram-link {
+    display: inline-flex;
+    align-items: center;
+    padding-bottom: 0;
+  }
+  .hero-top-links .instagram-link:hover {
+    text-decoration: none;
+  }
+  .hero-top-links .instagram-link svg {
+    width: 28px;
+    height: 28px;
+    fill: currentColor;
+    display: block;
   }
 
   /* Business */
@@ -1585,7 +1580,7 @@
     display: flex;
     gap: 10px;
     font-family: var(--mono);
-    font-size: 11px;
+    font-size: var(--pf-fs-mono);
     letter-spacing: 0.08em;
     text-transform: uppercase;
     color: var(--ink-faint);
@@ -1643,7 +1638,7 @@
   .journal-dateline,
   .journal-article-footer {
     font-family: var(--mono);
-    font-size: 11px;
+    font-size: var(--pf-fs-mono);
     letter-spacing: 0.08em;
     text-transform: uppercase;
   }
@@ -1948,7 +1943,7 @@
     display: block;
     margin-top: 10px;
     font-family: var(--mono);
-    font-size: 11px;
+    font-size: var(--pf-fs-mono);
     letter-spacing: 0.06em;
     color: var(--ink-muted);
     text-align: center;
@@ -2011,7 +2006,7 @@
     background: var(--ink);
     color: var(--cream);
     font-family: var(--mono);
-    font-size: 13px;
+    font-size: var(--pf-fs-mono);
     line-height: 1.55;
   }
   .journal-md-figure {
@@ -2033,7 +2028,7 @@
   .journal-md-figure figcaption {
     margin-top: 10px;
     font-family: var(--mono);
-    font-size: 11px;
+    font-size: var(--pf-fs-mono);
     letter-spacing: 0.06em;
     color: var(--ink-muted);
     text-align: center;
@@ -2085,7 +2080,7 @@
     border-top: 1px solid var(--rule);
     border-bottom: 1px solid var(--rule);
     font-family: var(--mono);
-    font-size: 11px;
+    font-size: var(--pf-fs-mono);
     letter-spacing: 0.04em;
   }
   .journal-reading th,
@@ -2156,7 +2151,7 @@
   }
   .journal-lightbox figcaption {
     font-family: var(--mono);
-    font-size: 11px;
+    font-size: var(--pf-fs-mono);
     letter-spacing: 0.08em;
     color: var(--cream);
     text-align: center;
@@ -2169,7 +2164,7 @@
     background: transparent;
     color: var(--cream);
     font-family: var(--mono);
-    font-size: 11px;
+    font-size: var(--pf-fs-mono);
     letter-spacing: 0.08em;
     text-transform: uppercase;
     cursor: pointer;
@@ -2177,7 +2172,7 @@
   .journal-figure figcaption {
     margin-top: 10px;
     font-family: var(--mono);
-    font-size: 11px;
+    font-size: var(--pf-fs-mono);
     letter-spacing: 0.06em;
     color: var(--ink-muted);
   }
@@ -2188,7 +2183,7 @@
     align-items: center;
     gap: 12px;
     font-family: var(--mono);
-    font-size: 11px;
+    font-size: var(--pf-fs-mono);
     letter-spacing: 0.08em;
     text-transform: uppercase;
     color: var(--ink-muted);
@@ -2237,7 +2232,7 @@
   .journal-more-kicker,
   .journal-more-writing time {
     font-family: var(--mono);
-    font-size: 11px;
+    font-size: var(--pf-fs-mono);
     letter-spacing: 0.08em;
     text-transform: uppercase;
     color: var(--ink-muted);
@@ -2258,7 +2253,7 @@
   .journal-all-writing-link {
     width: fit-content;
     font-family: var(--mono);
-    font-size: 11px;
+    font-size: var(--pf-fs-mono);
     letter-spacing: 0.08em;
     text-transform: uppercase;
     color: var(--ink-muted);
@@ -2285,16 +2280,13 @@
     left: 50%;
     transform: translateX(-50%);
     font-family: var(--mono);
-    font-size: 11px;
+    font-size: var(--pf-fs-mono);
     letter-spacing: 0.08em;
     text-transform: uppercase;
     color: var(--ink-muted);
   }
 
   @media (max-width: 720px) {
-    .hero > .hero-top-links {
-      display: none;
-    }
     .business-page { padding: 48px 18px 96px; }
     .business-head {
       margin-bottom: 32px;
@@ -2429,14 +2421,14 @@
     .journal-list-body .pf-row-d {
       max-width: 22ch;
       margin-top: 10px;
-      font-size: 13px;
+      font-size: var(--pf-fs-mono);
       line-height: 1.45;
       white-space: normal;
     }
     .journal-new-badge {
       display: block;
       margin: 8px 0 0;
-      font-size: 11px;
+      font-size: var(--pf-fs-mono);
     }
     .journal-list-meta {
       grid-column: auto;
@@ -2550,6 +2542,19 @@
     .content-panel.viewer-open {
       padding-top: calc(var(--mb-viewer-h) + var(--mb-nav-h));
       padding-bottom: 40px;
+    }
+
+    /* Force mobile override for top header links by placing it at the end of the file */
+    .hero-top-links {
+      position: absolute !important;
+      top: 14px !important;
+      right: -8px !important;
+      font-size: 11px !important;
+      gap: 12px !important;
+    }
+    .hero-top-links .instagram-link svg {
+      width: 20px !important;
+      height: 20px !important;
     }
   }
 

--- a/web/src/app/journal/[slug]/en/page.tsx
+++ b/web/src/app/journal/[slug]/en/page.tsx
@@ -55,10 +55,11 @@ export default async function EnglishJournalPostPage({
     notFound();
   }
 
+  const allPosts = getAllJournalPosts({ lang });
   const { previous, next } = getAdjacentJournalPosts(slug, lang);
 
   return (
-    <ArticleLayout post={post} lang={lang} previous={previous} next={next}>
+    <ArticleLayout post={post} lang={lang} previous={previous} next={next} allPosts={allPosts}>
       <MdxContent source={post.content} />
     </ArticleLayout>
   );

--- a/web/src/app/journal/[slug]/page.tsx
+++ b/web/src/app/journal/[slug]/page.tsx
@@ -55,10 +55,11 @@ export default async function JournalPostPage({
     notFound();
   }
 
+  const allPosts = getAllJournalPosts({ lang });
   const { previous, next } = getAdjacentJournalPosts(slug, lang);
 
   return (
-    <ArticleLayout post={post} lang={lang} previous={previous} next={next}>
+    <ArticleLayout post={post} lang={lang} previous={previous} next={next} allPosts={allPosts}>
       <MdxContent source={post.content} />
     </ArticleLayout>
   );

--- a/web/src/app/pattern-lab/PatternLab.module.css
+++ b/web/src/app/pattern-lab/PatternLab.module.css
@@ -181,7 +181,7 @@
   padding: 0 10px;
   font: inherit;
   font-family: var(--font-jetbrains), monospace;
-  font-size: 11px;
+  font-size: var(--pf-fs-mono);
   text-transform: uppercase;
   cursor: pointer;
   user-select: none;
@@ -461,7 +461,7 @@
   color: rgba(23, 21, 18, 0.62) !important;
   border-color: rgba(23, 21, 18, 0.22) !important;
   padding: 0 10px;
-  font-size: 11px;
+  font-size: var(--pf-fs-mono);
 }
 
 .editorHeader .keyButton:hover {
@@ -480,7 +480,7 @@
   gap: 6px;
   color: rgba(23, 21, 18, 0.62);
   font-family: var(--font-jetbrains), monospace;
-  font-size: 11px;
+  font-size: var(--pf-fs-mono);
   text-transform: uppercase;
 }
 
@@ -531,7 +531,7 @@
   padding: 0 10px;
   font: inherit;
   font-family: var(--font-jetbrains), monospace;
-  font-size: 11px;
+  font-size: var(--pf-fs-mono);
   text-transform: uppercase;
   cursor: pointer;
 }
@@ -613,7 +613,7 @@
   text-overflow: ellipsis;
   white-space: nowrap;
   color: #b42318;
-  font-size: 11px;
+  font-size: var(--pf-fs-mono);
 }
 
 .jobTime {
@@ -639,7 +639,7 @@
   padding: 0 10px;
   font: inherit;
   font-family: var(--font-jetbrains), monospace;
-  font-size: 11px;
+  font-size: var(--pf-fs-mono);
   text-transform: uppercase;
   cursor: pointer;
 }
@@ -663,7 +663,7 @@
   margin-left: auto;
   color: rgba(23, 21, 18, 0.55);
   font-family: var(--font-jetbrains), monospace;
-  font-size: 11px;
+  font-size: var(--pf-fs-mono);
   text-transform: uppercase;
 }
 
@@ -716,7 +716,7 @@
   height: 18px;
   background: #171512;
   color: #f7f3ea;
-  font-size: 11px;
+  font-size: var(--pf-fs-mono);
   line-height: 1;
 }
 
@@ -819,7 +819,7 @@
   color: #171512;
   font: inherit;
   font-family: var(--font-jetbrains), monospace;
-  font-size: 11px;
+  font-size: var(--pf-fs-mono);
   text-transform: uppercase;
   cursor: pointer;
 }

--- a/web/src/app/video-baker/VideoBaker.module.css
+++ b/web/src/app/video-baker/VideoBaker.module.css
@@ -119,7 +119,7 @@
 
 .trimTime {
   font-family: var(--font-jetbrains), monospace;
-  font-size: 11px;
+  font-size: var(--pf-fs-mono);
   color: #171512;
   text-align: right;
 }
@@ -149,7 +149,7 @@
   gap: 12px;
   margin-top: 10px;
   font-family: var(--font-jetbrains), monospace;
-  font-size: 11px;
+  font-size: var(--pf-fs-mono);
   color: rgba(23, 21, 18, 0.45);
   text-transform: uppercase;
 }
@@ -187,7 +187,7 @@
   height: 100%;
   color: rgba(255, 255, 255, 0.2);
   font-family: var(--font-jetbrains), monospace;
-  font-size: 11px;
+  font-size: var(--pf-fs-mono);
   text-transform: uppercase;
   letter-spacing: 0.14em;
 }
@@ -299,7 +299,7 @@
 }
 
 .dropZone span {
-  font-size: 11px;
+  font-size: var(--pf-fs-mono);
   color: rgba(23, 21, 18, 0.3);
   font-family: var(--font-jetbrains), monospace;
 }
@@ -435,7 +435,7 @@
   background: #ffffff;
   color: #171512;
   font-family: var(--font-jetbrains), monospace;
-  font-size: 11px;
+  font-size: var(--pf-fs-mono);
   text-transform: uppercase;
   letter-spacing: 0.06em;
   cursor: pointer;
@@ -536,7 +536,7 @@
   color: #b42318;
   padding: 10px 12px;
   font-family: var(--font-jetbrains), monospace;
-  font-size: 11px;
+  font-size: var(--pf-fs-mono);
   line-height: 1.5;
 }
 
@@ -554,7 +554,7 @@
   background: #1a3a1a;
   color: #b8e6b8;
   font-family: var(--font-jetbrains), monospace;
-  font-size: 11px;
+  font-size: var(--pf-fs-mono);
   text-transform: uppercase;
   letter-spacing: 0.06em;
   cursor: pointer;
@@ -588,7 +588,7 @@
   background: #f0faf0;
   color: #1a5a1a;
   font-family: var(--font-jetbrains), monospace;
-  font-size: 11px;
+  font-size: var(--pf-fs-mono);
 }
 
 /* ── Size warning ── */
@@ -600,7 +600,7 @@
   background: #fffbf0;
   color: #8a5d00;
   font-family: var(--font-jetbrains), monospace;
-  font-size: 11px;
+  font-size: var(--pf-fs-mono);
   line-height: 1.5;
 }
 

--- a/web/src/components/3d/HeroScene.tsx
+++ b/web/src/components/3d/HeroScene.tsx
@@ -533,7 +533,7 @@ export default function HeroScene() {
           color: '#6B655A',
           fontFamily: 'var(--mono)',
           fontWeight: 500,
-          fontSize: '11px',
+          fontSize: 'var(--pf-fs-mono)',
           letterSpacing: '0.14em',
           textTransform: 'uppercase',
           pointerEvents: 'none',

--- a/web/src/components/journal/ArticleLayout.tsx
+++ b/web/src/components/journal/ArticleLayout.tsx
@@ -10,22 +10,39 @@ type ArticleLayoutProps = {
   lang: JournalLang;
   previous: JournalPost | null;
   next: JournalPost | null;
+  allPosts: JournalPost[];
   children: ReactNode;
 };
 
 export default function ArticleLayout({
   post,
   lang,
-  previous,
-  next,
+  allPosts,
   children,
 }: ArticleLayoutProps) {
   const indexHref = lang === "en" ? "/journal/en" : "/journal";
   const getPostHref = (slug: string) => lang === "en" ? `/journal/${slug}/en` : `/journal/${slug}`;
-  const adjacentPosts = [
-    previous ? { label: "Previous", post: previous } : null,
-    next ? { label: "Next", post: next } : null,
-  ].filter((item): item is { label: string; post: JournalPost } => Boolean(item));
+
+  // Stable post numbers, oldest = 01, matching the journal index page.
+  const postNumbers = new Map(
+    [...allPosts]
+      .sort((a, b) => Date.parse(a.date) - Date.parse(b.date))
+      .map((p, index) => [p.slug, String(index + 1).padStart(2, "0")]),
+  );
+
+  // Build a 5-item window centered on the current post
+  const currentIndex = allPosts.findIndex((p) => p.slug === post.slug);
+  const totalPosts = allPosts.length;
+
+  let windowStart: number;
+  if (currentIndex <= 1) {
+    windowStart = 0;
+  } else if (currentIndex >= totalPosts - 2) {
+    windowStart = Math.max(0, totalPosts - 5);
+  } else {
+    windowStart = currentIndex - 2;
+  }
+  const windowPosts = allPosts.slice(windowStart, windowStart + 5);
 
   return (
     <>
@@ -71,21 +88,37 @@ export default function ArticleLayout({
       </article>
 
       <footer className="journal-article-footer">
-        {adjacentPosts.length > 0 && (
-          <section className="journal-more-writing" aria-label="More writing">
-            <ol>
-              {adjacentPosts.map(({ label, post: adjacentPost }) => (
-                <li key={adjacentPost.slug}>
-                  <Link href={getPostHref(adjacentPost.slug)}>
-                    <span className="journal-more-kicker">{label}</span>
-                    <strong>{adjacentPost.title}</strong>
-                    <time>{formatJournalDate(adjacentPost.date, lang)}</time>
+        <ol className="journal-context-list">
+          {windowPosts.map((p) => {
+            const globalNum = postNumbers.get(p.slug);
+            const isCurrent = p.slug === post.slug;
+            return (
+              <li key={p.slug} className={isCurrent ? "is-current" : ""}>
+                {isCurrent ? (
+                  <span className="pf-row is-current-row">
+                    <span className="pf-ghost">{globalNum}</span>
+                    <span className="journal-list-body">
+                      <strong className="pf-row-t">{p.title}</strong>
+                    </span>
+                    <span className="journal-list-meta">
+                      {formatJournalDate(p.date, lang)}
+                    </span>
+                  </span>
+                ) : (
+                  <Link className="pf-row" href={getPostHref(p.slug)}>
+                    <span className="pf-ghost">{globalNum}</span>
+                    <span className="journal-list-body">
+                      <strong className="pf-row-t">{p.title}</strong>
+                    </span>
+                    <span className="journal-list-meta">
+                      {formatJournalDate(p.date, lang)}
+                    </span>
                   </Link>
-                </li>
-              ))}
-            </ol>
-          </section>
-        )}
+                )}
+              </li>
+            );
+          })}
+        </ol>
         <Link className="journal-all-writing-link" href={indexHref}>
           All writing
         </Link>
@@ -93,3 +126,4 @@ export default function ArticleLayout({
     </>
   );
 }
+

--- a/web/src/components/journal/HeroJournalLink.tsx
+++ b/web/src/components/journal/HeroJournalLink.tsx
@@ -1,10 +1,27 @@
 import Link from "next/link";
 
+function InstagramIcon() {
+  return (
+    <svg viewBox="0 0 24 24">
+      <path d="M7.6 2h8.8A5.6 5.6 0 0 1 22 7.6v8.8a5.6 5.6 0 0 1-5.6 5.6H7.6A5.6 5.6 0 0 1 2 16.4V7.6A5.6 5.6 0 0 1 7.6 2Zm0 2A3.6 3.6 0 0 0 4 7.6v8.8A3.6 3.6 0 0 0 7.6 20h8.8a3.6 3.6 0 0 0 3.6-3.6V7.6A3.6 3.6 0 0 0 16.4 4H7.6Zm8.9 2.7a1.1 1.1 0 1 1 0 2.2 1.1 1.1 0 0 1 0-2.2ZM12 7a5 5 0 1 1 0 10 5 5 0 0 1 0-10Zm0 2a3 3 0 1 0 0 6 3 3 0 0 0 0-6Z" />
+    </svg>
+  );
+}
+
 export default function HeroJournalLink() {
   return (
     <nav className="hero-top-links" aria-label="Patternflow pages">
       <Link href="/journal">Journal</Link>
       <Link href="/contact" className="contact-link">Contact</Link>
+      <a
+        href="https://www.instagram.com/patternflow.work/"
+        target="_blank"
+        rel="noopener noreferrer"
+        className="instagram-link"
+        aria-label="Patternflow Instagram"
+      >
+        <InstagramIcon />
+      </a>
     </nav>
   );
 }

--- a/web/src/components/journal/JournalIndex.tsx
+++ b/web/src/components/journal/JournalIndex.tsx
@@ -31,7 +31,7 @@ export default function JournalIndex({ posts, lang }: JournalIndexProps) {
         <Link className="journal-lockup" href="/">
           Patternflow
         </Link>
-        <div className="journal-entry-count">Blog</div>
+        <div className="journal-section-label">Journal</div>
       </header>
 
       <div className="journal-panel">

--- a/web/src/components/sections/Hero.tsx
+++ b/web/src/components/sections/Hero.tsx
@@ -147,9 +147,6 @@ export default function Hero() {
             Get One
           </button>
         </div>
-        <p className="hero-cs-note">
-          Reserve on Crowd Supply — Mouser&apos;s platform for open hardware.
-        </p>
       </div>
       {isCrowdSupplyOpen && (
         <CrowdSupplyModal onClose={() => setIsCrowdSupplyOpen(false)} />

--- a/web/src/components/sections/InsideGlobe/GlobeViewer.module.css
+++ b/web/src/components/sections/InsideGlobe/GlobeViewer.module.css
@@ -49,7 +49,7 @@
   color: var(--pf-ink-muted);
   font-family: var(--pf-mono);
   font-weight: 500;
-  font-size: 11px;
+  font-size: var(--pf-fs-mono);
   letter-spacing: 0.14em;
   text-transform: uppercase;
   transition: opacity 1.2s ease;

--- a/web/src/components/sections/InsidePanel.module.css
+++ b/web/src/components/sections/InsidePanel.module.css
@@ -201,7 +201,7 @@
   background: transparent;
   color: var(--cream);
   font-family: var(--pf-mono);
-  font-size: 11px;
+  font-size: var(--pf-fs-mono);
   letter-spacing: 0.08em;
   text-transform: uppercase;
   cursor: pointer;

--- a/web/src/components/sections/PatternPanel.module.css
+++ b/web/src/components/sections/PatternPanel.module.css
@@ -138,7 +138,7 @@
 .presetLink {
   display: inline;
   margin-left: 8px;
-  font-size: 11px;
+  font-size: var(--pf-fs-mono);
   font-family: var(--pf-mono);
   color: var(--pf-ink-muted);
   text-decoration: none;

--- a/web/src/components/share/SharePatternModal.module.css
+++ b/web/src/components/share/SharePatternModal.module.css
@@ -83,7 +83,7 @@
 .label {
   display: block;
   margin: 0 0 4px;
-  font-size: 11px;
+  font-size: var(--pf-fs-mono);
   text-transform: uppercase;
   letter-spacing: 0.04em;
   opacity: 0.7;
@@ -132,7 +132,7 @@
   background: #ffffff;
   color: #171512;
   font: inherit;
-  font-size: 11px;
+  font-size: var(--pf-fs-mono);
   text-transform: uppercase;
   letter-spacing: 0.04em;
   cursor: pointer;

--- a/web/src/components/ui/TweaksPanel.tsx
+++ b/web/src/components/ui/TweaksPanel.tsx
@@ -38,7 +38,7 @@ export default function TweaksPanel() {
         style={{
           position: 'fixed', bottom: '20px', right: '20px', zIndex: 99,
           padding: '8px 12px', background: 'var(--ink)', color: 'var(--cream)',
-          fontFamily: 'var(--mono)', fontSize: '11px', border: 'none', cursor: 'pointer',
+          fontFamily: 'var(--mono)', fontSize: 'var(--pf-fs-mono)', border: 'none', cursor: 'pointer',
           textTransform: 'uppercase'
         }}
         className={isOpen ? 'hidden' : ''}

--- a/web/src/lib/journal.ts
+++ b/web/src/lib/journal.ts
@@ -57,7 +57,8 @@ function getReadingTime(content: string, lang: JournalLang) {
     return `${minutes} min`;
   }
 
-  return readingTime(content).text;
+  const minutes = Math.max(1, Math.ceil(readingTime(content).minutes));
+  return `${minutes} min`;
 }
 
 function readPost(slug: string, lang: JournalLang): JournalPost {


### PR DESCRIPTION
Bundles the journal article/index refresh and assorted web style detail work that has accumulated on `dev`.

## Changes
- **feat(journal):** article footer now shows a contextual 5-item post list centered on the current post (highlighting the current entry), replacing the previous/next links. Numbering matches the journal index, and the list resets the footer's inherited mono/uppercase styling.
- **style(journal):** tighten spacing across index and article pages.
- **style(journal):** redesign masthead with stacked Patternflow + Journal layout.
- **feat(web,firmware):** scale monospaced typography, remove CS note, fix mobile navigation layout.
- **chore(web):** track modal drop-off, retire waitlist thank-you page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)