### PR TITLE
Build guide cleanup (SMD-free BOM, v2.1 Gerbers), one-piece enclosure promotion, OSC bridge

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,7 @@ Patternflow is an open-source hardware instrument: four rotary encoders controll
 - `hardware/` — Hardware designs. Contains `case/` (Blender source, STLs in `case/print-ready/`) and `pcb/` (KiCad 10.0 source, Gerbers, schematic PDF).
 - `web/` — Next.js site at patternflow.work: landing page, Live Editor, browser flasher, journal, roadmap, and internal tools (`/pattern-lab`, `/video-baker`). Architecture doc: `web/ARCHITECTURE.md`. The JS presets in `web/src/lib/presets/` are the source of truth for firmware preset headers.
 - `tools/` — desktop-side helpers, including the experimental audio-react browser extension (`tools/patternflow-audio-extension`).
+- `integrations/` — host-software integrations. `integrations/ableton/` is the Max for Live bridge (knobs → Live parameters over OSC) with its own README and guides; the OSC wire protocol lives in `docs/osc-spec.md` and is the contract for all integrations.
 - `.agents/` — AI harness configuration (skills, workflows, rules).
 
 ## Hard rules (do not violate)

--- a/BUILD_GUIDE.md
+++ b/BUILD_GUIDE.md
@@ -1,6 +1,6 @@
 # Patternflow v2.0.0 -- Build Guide
 
-This guide walks you through building a Patternflow v2.0.0 from scratch. It assumes basic familiarity with soldering (through-hole + simple SMD) and 3D printing.
+This guide walks you through building a Patternflow v2.0.0 from scratch. It assumes basic familiarity with through-hole soldering and 3D printing.
 
 This is the current detailed path for a hand-soldered official PCB plus a PLA 3D printed enclosure. For the broader assembly map, including the laser-cut path still in preparation, see [docs/assembly/README.md](docs/assembly/README.md).
 
@@ -8,7 +8,9 @@ This is the current detailed path for a hand-soldered official PCB plus a PLA 3D
 
 **Estimated build time:** 4-6 hours of active work, plus ~11 hours of 3D printing.
 
-**Skill level:** Intermediate. If you've assembled a mechanical keyboard or built an Arduino project with SMD components, you're ready.
+**Skill level:** Beginner-to-intermediate. If you've assembled a mechanical keyboard or built a basic Arduino project, you're ready — this is an all through-hole build.
+
+> **Heads-up — photos may differ slightly, and a v3.0 refresh is coming.** The images throughout this guide were shot on an early build, so small cosmetic details may not match the current files exactly. Where a photo looks slightly off, follow the written steps. A full **v3.0** revision is in progress — improved 3D-printed enclosure (snap-fit + minor refinements), a USB-C power adapter, and a fully cleaned-up BOM. This guide will be reorganized around v3.0 once it lands.
 
 > **What changed in v2.0.0.** PCB now includes a 10k pullup on GPIO0 (resolves the v1 cold-boot issue), silkscreen cleaned up to clearly mark R vs. C designators and the correct encoder solder side, firmware ships with a built-in custom-pattern template usable with any AI coding assistant, and the case source/print-ready files now include a 15mm encoder knob variant. Most of the case geometry is unchanged from v1; see Section 10 for the issues still open and the deliberate design notes worth knowing.
 
@@ -44,9 +46,6 @@ This is the current detailed path for a hand-soldered official PCB plus a PLA 3D
 | J1 | Box Header (2x8, 2.54mm) | Vertical, for HUB75 ribbon | 1 | LED matrix data |
 | J2 | Screw Terminal | 2-pin, 5mm pitch | 1 | +5V input from power bank |
 | J3 | Screw Terminal | 2-pin, 5mm pitch | 1 | +5V output to LED matrix |
-| R1-R12 | Resistor 10k 1% | 0805 SMD | 12 | Encoder pull-ups (3 per encoder x 4) |
-| R13 | Resistor 10k 1% | 0805 SMD | 1 | GPIO0 pull-up (boot strap stabilization) |
-| C1-C10, C12-C15 | Capacitor 100nF X7R | 0805 SMD | 14 | 12 for encoders (3 per encoder x 4), 2 for ESP32 decoupling |
 | C11 | Electrolytic Cap 1000uF / 16V | Radial D10xL13 | 1 | Main bulk decoupling |
 | - | M4 Screws | ~10mm length | 6 | LED matrix mounting |
 | - | USB Cable (sacrificial) | Any USB cable, will be cut | 1 | For 5V power input |
@@ -67,7 +66,9 @@ This is the current detailed path for a hand-soldered official PCB plus a PLA 3D
 >
 > **The safe move:** before buying, ask the seller which driver IC the panel uses. If they say *FM6363C/FM6373C*, *3840Hz*, or *"needs a receiving card"*, pick a different panel — ideally one explicitly advertised as *"hzeller / ESP32-HUB75-MatrixPanel-DMA compatible."* The linked panel above is a known-good one.
 
-PCB: order from your preferred fab using the KiCad files in `hardware/pcb/`. I used PCBway (sponsored).
+PCB: order from your preferred fab using the **`patternflow_v2.1_gerber.zip`** Gerbers in [`hardware/pcb/gerber/`](hardware/pcb/gerber/) (or the KiCad source in `hardware/pcb/kicad/`). I used PCBway (sponsored).
+
+> ⚠️ **Use v2.1 — not v2.2.** `patternflow_v2.2_test_gerber.zip` is an unverified test revision and should **not** be ordered. `patternflow_v2.1_gerber.zip` is the current recommended board.
 
 If you want to order the PCB without manually uploading Gerbers, the Patternflow PCB is also listed as a PCBWay open-source project:
 
@@ -82,7 +83,6 @@ If you want to order the PCB without manually uploading Gerbers, the Patternflow
 - 3D printer (I used Bambu P1S)
 - White and black PLA filament
 - Soldering iron, solder, flux, tweezers
-- (Optional) solder paste + hot air rework station — see SMD section
 - Wire cutters or strong nippers (for trimming the LED matrix back)
 - Cyanoacrylate glue (super glue)
 - Phillips screwdriver, small flathead for screw terminals
@@ -153,41 +153,13 @@ Allow ~5 minutes after every bond step for the glue to fully cure before handlin
 
 ## 4. PCB Assembly
 
-Solder SMD parts first, then through-hole. Work small-to-tall — that's why SMD goes before any tall through-hole component.
+This is an all through-hole build. Work small-to-tall — shortest parts first, tallest last.
+
+> **No SMD required.** The PCB has footprints for optional 0805 passives (encoder pull-ups, filter caps, ESP32 decoupling caps) and an R13 GPIO0 pull-up, but they are **not populated** — a unit runs fine without any of them. See the design note in Section 10 for the rationale and the on-module cold-boot fix if you ever need it.
 
 <img src="docs/build-guide/images/pcb_assembly_setup.jpg" width="70%">
 
-### 4.1 SMD Pass (R1-R13, C1-C10, C12-C15)
-
-> **⚠️ Temporary note — you can skip the SMD 0805 passives (verified working).** In bench testing, a board runs fine **without** the 0805 SMD resistors and capacitors populated — the encoder pull-ups (R1–R12), encoder filter caps (C1–C10, C12–C13), and the ESP32 decoupling caps (C14–C15) are not required to get a working unit. The ESP32-S3's internal pull-ups and firmware debouncing cover the encoders. If you'd rather not deal with the SMD pass at all, you can skip this whole section and still end up with a functioning board.
->
-> **R13 (GPIO0 pull-up) — leave it off, fix on the module only if needed.** R13 only matters for the cold-boot strapping issue, which mostly affects clone/AliExpress ESP32-S3 modules; **genuine Espressif modules boot fine without it.** The intended direction is to drop R13 entirely and **not** populate it on the board. If you *do* hit the cold-boot symptom (board fails to start after being unplugged for a few minutes), the simplest fix is to solder a 10kΩ leaded (through-hole) resistor **directly on the ESP32 module, between GPIO0 and 3.3V** — no board rework, no extra part to source if you have a 10kΩ on hand. For reference photos of this on-module fix and the full root-cause write-up, see [issue #16 (GPIO0 strapping pin resolution)](https://github.com/engmung/Patternflow/issues/16#issuecomment-4379612470). (The PCB still has R13 pads for now, so you *could* populate it there instead, but the on-module fix is easier and is the recommended path.)
->
-> This is a temporary note pending a PCB revision that removes these SMD parts. The full SMD build below is kept intact for anyone who wants to populate everything. See Section 10 / the GPIO0 root-cause notes for background.
-
-> **Hand-solder vs. paste + hot air.** I hand-soldered with an iron because I didn't have solder paste or a hot air station. If you do, by all means use them — apply paste to the pads, place all parts, then reflow. The board is small enough that either approach is fine. The procedure below is for the iron-only path.
-
-**Order: by component type.** Do all capacitors first, then all resistors (or vice versa). Mixing types makes it easier to mis-place parts.
-
-**Hand-solder technique (batched):**
-
-1. Pre-tin **one pad** at every SMD position you're about to populate in this pass — i.e. dab a small amount of solder onto the same side of every cap location, all at once.
-2. Pick up the first capacitor with tweezers. Slide it onto its pre-tinned pad while reflowing that pad with the iron. Release. Move to the next capacitor.
-3. Repeat for every capacitor. At this point all caps are tacked down on one side.
-4. Go back and solder the **opposite** pad of every capacitor to lock them in.
-5. Switch to resistors and repeat steps 1–4.
-
-**Iron temperature:** ~350°C. Default works fine.
-
-**Keep parts flat and centered.** Slight tilt will not affect function but looks bad.
-
-> **Silkscreen.** On v2.0 PCB, R and C designators are clearly marked. Place each part according to its silkscreen designator. (On v1.0 boards, the 0805 closest to each encoder pad was a cap; this rule still works as a sanity check on v2.0.)
-
-SMD placement close-up, then the board after the non-encoder through-hole parts are installed:
-
-<img src="docs/build-guide/images/smd_tweezers_closeup.jpg" width="45%"> <img src="docs/build-guide/images/pcb_before_encoders.jpg" width="45%">
-
-### 4.2 Through-Hole Pass
+### Through-Hole Pass
 
 Solder, in order (small/short to tall):
 
@@ -267,7 +239,7 @@ Numbering is top-to-bottom with the USB connector at the top.
 | 33 | IO37 | NC (PSRAM internal) |
 | 34 | IO36 | NC (PSRAM internal) |
 | 35 | IO35 | NC (PSRAM internal) |
-| 36 | IO0 | GPIO0 boot strap pull-up via R13 |
+| 36 | IO0 | GPIO0 boot strap (R13 pad unpopulated — see Section 10) |
 | 37 | IO45 | Not connected (NC) |
 | 38 | IO48 | HUB_C |
 | 39 | IO47 | HUB_LAT |
@@ -493,6 +465,10 @@ With flashing complete and the USB cable disconnected, plug the ESP32-S3 module 
 - **Issue #4 -- LED matrix back has alignment bumps.** The matrix manufacturer leaves two small alignment bumps on the back of the panel. Current workaround: cut them off during assembly (see Section 5.1). They cut easily. A future case revision (planned to land with the LED diffuser variant) will add recesses to accommodate them.
 
 ### Design notes (not bugs)
+
+- **0805 passives left unpopulated.** The board carries footprints for encoder pull-ups (R1–R12), encoder filter caps (C1–C10, C12–C13), and ESP32 decoupling caps (C14–C15), but bench testing confirmed a unit runs fine with none of them populated — the ESP32-S3's internal pull-ups plus firmware debouncing cover the encoders. They're dropped from the BOM and build steps to keep this an all through-hole build. The pads are still there if you're spinning a derivative and want the belt-and-suspenders version.
+
+- **R13 (GPIO0 pull-up) not populated — on-module fix if needed.** R13 addressed the cold-boot strapping issue, which mostly affects clone/AliExpress ESP32-S3 modules; genuine Espressif modules boot fine without it. If you do hit the symptom (board fails to start after being unplugged for a few minutes), solder a 10kΩ leaded resistor directly on the ESP32 module between GPIO0 and 3.3V — no board rework, no extra part to source if you have a 10kΩ on hand. Root-cause write-up and reference photos in [Issue #16](https://github.com/engmung/Patternflow/issues/16#issuecomment-4379612470).
 
 - **Encoder direction handled in firmware** (was Issue #2). The encoder PCB footprint is rotated relative to the natural CW=increment direction. Rather than re-spinning the PCB, the firmware inverts the sign. This is transparent to the user. If you fork the firmware or design a derivative PCB, mind this.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to Patternflow will be documented in this file.
 
+## [Unreleased]
+
+### Added
+- **Ableton Live integration** (`integrations/ableton/`). A Max for Live bridge device maps the four hardware knobs to any Live parameters over OSC (relative encoder deltas, per-slot sweep sensitivity, mappings saved with the Live set), plus guides for M4L/OSC pitfalls and a filming-with-synced-sound workflow.
+- **OSC spec** (`docs/osc-spec.md`): the wire protocol as a versioned contract for third-party integrations.
+- **OSC `/patternflow/ping`**: any host can request a full announce (hello/version/ip + current pattern/state) — hosts that start after the device no longer miss the current state.
+- **OSC auto-learned remote host.** The device now replies to whichever host sent the last valid OSC packet; `PF_OSC_REMOTE_HOST` is optional (default empty) and only needed for send-only setups.
+- **OSC `/patternflow/version`** sent alongside `hello`.
+
+### Changed
+- **OSC receive robustness**: up to 8 datagrams drained per frame (was 1 — fast Live automation used to build up seconds of queue lag), and numeric arguments are accepted as int *or* float (Max patches commonly send floats; they were silently dropped before).
+
 ## [2.0.0] - 2026-05
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Custom patterns require a local Arduino IDE compile/upload step for now.
 
 ## OSC & audio-react
 
-**Bidirectional OSC.** Over Wi-Fi, Patternflow speaks OSC in both directions: knob turns, button presses, and pattern switches stream out to a remote host (Ableton Live, Max/MSP, TouchDesigner — anything that speaks OSC), and incoming OSC messages drive the device exactly like physical encoder motion. Play Patternflow as a controller for your set, let your set drive the light, or both at once. If you play MIDI instruments, this will feel like home.
+**Bidirectional OSC.** Over Wi-Fi, Patternflow speaks OSC in both directions: knob turns, button presses, and pattern switches stream out to a remote host (Ableton Live, Max/MSP, TouchDesigner — anything that speaks OSC), and incoming OSC messages drive the device exactly like physical encoder motion. Play Patternflow as a controller for your set, let your set drive the light, or both at once. If you play MIDI instruments, this will feel like home. For Ableton Live Suite there's a ready-made Max for Live bridge in [`integrations/ableton`](integrations/ableton) — click Connect, map the four knobs to any Live parameters, done. The wire protocol is documented in [`docs/osc-spec.md`](docs/osc-spec.md).
 
 **Audio-react.** Patternflow can also react to browser audio: the experimental Chrome/Edge extension in [`tools/patternflow-audio-extension`](tools/patternflow-audio-extension) captures the current tab's audio, analyzes four FFT bands, and sends lightweight WebSocket knob values to the device. The firmware converts those into virtual encoder motion, so every encoder-driven pattern responds — no audio code needed in the patterns themselves.
 
@@ -123,6 +123,7 @@ Patternflow is therefore not a single luminous object. It is a living system in 
 | `web/` | Next.js site (landing, browser flasher, Live Editor, journal) |
 | `docs/` | Assembly map, build-guide media, manifesto, license summary |
 | `tools/` | Desktop-side helpers, including the audio-react browser extension |
+| `integrations/` | Host-software bridges — Ableton Live / Max for Live (OSC knob mapping) |
 
 **Docs:** [Full Build Guide](BUILD_GUIDE.md) · [Assembly Map](docs/assembly/README.md) · [Custom Patterns](firmware/CUSTOM_PATTERNS.md) · [Changelog](CHANGELOG.md) · [License Summary](docs/LICENSE-SUMMARY.md)
 

--- a/docs/assembly/enclosure/3d-print.md
+++ b/docs/assembly/enclosure/3d-print.md
@@ -17,6 +17,10 @@ For full print settings, bonding steps, and assembly photos, follow the current 
 
 [Open the 3D print build steps](../../../BUILD_GUIDE.md#2-3d-printing)
 
+## One-Piece Option (Large Bed)
+
+If you have a large-format printer (~330 mm+ bed, e.g. Bambu H2S-class), `hardware/case/print-ready/oneshot/` contains a single-piece snap-fit version of the enclosure — no bonding step. A 5-part split for 256 mm beds is in testing. See [hardware/case/README.md](../../../hardware/case/README.md) for details.
+
 ## Planned Alternative
 
 A laser-cut enclosure path is planned. The goal is to keep the same overall external shape and dimensions while making the build cheaper and more accessible for people without a large 3D printer.

--- a/docs/osc-spec.md
+++ b/docs/osc-spec.md
@@ -1,0 +1,59 @@
+# Patternflow OSC Specification
+
+**Spec version: 1.0** · applies to firmware ≥ 2.1.0
+
+Patternflow speaks plain OSC over UDP on the local Wi-Fi network. This document is the contract between the firmware and any host software (the Max for Live bridge in `integrations/ableton/`, TouchDesigner, VCV Rack, Processing, custom scripts…). If you build a new integration, build it against this file, not against the firmware source.
+
+## Transport
+
+| | |
+|---|---|
+| Device → host | UDP to the host, port **9000** (`PF_OSC_REMOTE_PORT`) |
+| Host → device | UDP to the device, port **9001** (`PF_OSC_LOCAL_PORT`) |
+| Encoding | Plain OSC 1.0 messages. **No `#bundle` support** — send bare messages. |
+| Max packet size | 256 bytes each direction |
+| Host discovery | The device is reachable as `patternflow.local` (mDNS, when OTA is enabled). |
+| Device→host addressing | The device **learns the host automatically**: it replies to whichever IP sent it the last valid OSC packet. Send `/patternflow/ping` once and everything flows back to you. A static `PF_OSC_REMOTE_HOST` can be set in the secrets file for send-only setups. |
+
+Numeric arguments may be sent as OSC `int32` (`i`) or `float32` (`f`); the device accepts both and rounds floats.
+
+## Device → host
+
+| Address | Args | When |
+|---|---|---|
+| `/patternflow/knob/N/delta` | int | Encoder N (1–4) turned; signed detent delta for this frame (acceleration applied) |
+| `/patternflow/knob/N/clicks` | int | Same event; absolute accumulated click count |
+| `/patternflow/button/N/press` | int (1) | Encoder button N pressed |
+| `/patternflow/button/N/held` | int (0/1) | Hold state changed |
+| `/patternflow/pattern/index` | int | Pattern changed (or announce) |
+| `/patternflow/pattern/name` | string | Pattern changed (or announce) |
+| `/patternflow/content/mode` | int | Announce (reserved; currently always 0) |
+| `/patternflow/app/mode` | int | App mode changed (or announce) |
+| `/patternflow/heartbeat` | int (uptime s) | Every 1 s while connected |
+| `/patternflow/hello` | string ("Patternflow") | On connect / announce |
+| `/patternflow/version` | string (firmware version) | On connect / announce |
+| `/patternflow/ip` | string (device IP) | On connect / announce |
+
+"Announce" = the burst sent on Wi-Fi connect, in reply to `/patternflow/ping`, and whenever the learned host changes.
+
+## Host → device
+
+| Address | Args | Effect |
+|---|---|---|
+| `/patternflow/ping` | none | Learn/refresh sender as the remote host and reply with a full announce (hello, version, ip, pattern index/name, modes). Send this on host startup. |
+| `/patternflow/knob/N/delta` | int or float | Virtual rotation on knob N (1–4), applied on top of physical motion at raw 1×-per-detent rate (no acceleration) |
+| `/patternflow/pattern/index` | int or float | Switch to the pattern at this registry index |
+| `/patternflow/content/toggle` | none | Toggle content mode |
+
+Unknown addresses are ignored silently. The device drains up to 8 datagrams per frame (~60 fps), so sustained control streams above ~480 msg/s will queue.
+
+## Conventions for future additions
+
+- Everything lives under `/patternflow/`.
+- Indices in addresses are 1-based (`knob/1` = leftmost encoder K1).
+- New host→device commands must be safe to receive at any time; the firmware buffers them and applies them at a safe point in the main loop.
+- Planned (not yet implemented): `/patternflow/slate` (host→device one-frame white flash for A/V sync), `/patternflow/param/...` (absolute pattern parameter values).
+
+## Version history
+
+- **1.0** — knob/button/pattern/status out; ping/knob/pattern/content in; auto-learned remote host; int+float args accepted.

--- a/firmware/README.md
+++ b/firmware/README.md
@@ -265,6 +265,8 @@ Keep this page for file playback, microphone input, and local experiments. Brows
 
 Patternflow can send lightweight OSC control messages over Wi-Fi for performance setups such as Ableton Live Suite with Max for Live. This is meant for knobs, buttons, pattern status, and heartbeat messages, not for streaming rendered pixels.
 
+The full wire protocol is specified in [`docs/osc-spec.md`](../docs/osc-spec.md). A ready-made Max for Live bridge device (knobs → any Live parameters) lives in [`integrations/ableton/`](../integrations/ableton/).
+
 OSC has two switches: **compile-time** (whether OSC code is linked into the firmware at all) and **runtime** (whether the linked-in code is currently sending/receiving). The K2 longpress info screen only controls the runtime switch — if the compile-time switch is off, the runtime toggle is inert.
 
 ### Compile-time: enable the build flag and provide Wi-Fi credentials
@@ -274,6 +276,12 @@ Copy `patternflow/patternflow_secrets.example.h` to `patternflow/patternflow_sec
 #define PF_OSC_ENABLED 1
 #define PF_WIFI_SSID "your-wifi-name"
 #define PF_WIFI_PASS "your-wifi-password"
+```
+
+You normally do **not** need to configure the laptop's IP: the device learns the remote host from the first valid OSC packet it receives (send `/patternflow/ping` — the M4L bridge's Connect button does this). Until then the K2 info screen shows `WAIT HOST`. For send-only setups where the host never sends anything, a static target can still be set:
+
+```cpp
+// optional, send-only setups
 #define PF_OSC_REMOTE_HOST "192.168.0.10"  // laptop IP
 #define PF_OSC_REMOTE_PORT 9000
 ```
@@ -297,6 +305,9 @@ Then put the laptop and Patternflow on the same Wi-Fi network. OSC is a sidechan
 /patternflow/content/mode
 /patternflow/app/mode
 /patternflow/heartbeat
+/patternflow/hello          (on connect / announce)
+/patternflow/version        (on connect / announce)
+/patternflow/ip             (on connect / announce)
 ```
 
 In a Max patch, the receiving side is typically `udpreceive 9000` followed by `oscparse`, then route the address parts and map values to Live parameters with Max for Live devices such as `live.remote~`, `live.object`, or your own mapping patch.
@@ -306,12 +317,13 @@ In a Max patch, the receiving side is typically `udpreceive 9000` followed by `o
 The device also listens on `PF_OSC_LOCAL_PORT` (default 9001) so an external host can drive it back. Send any of these addresses from Ableton/Max:
 
 ```text
-/patternflow/knob/N/delta      (int)   — virtual rotation on logical knob N (1..4)
-/patternflow/pattern/index     (int)   — switch to pattern at this registry index
-/patternflow/content/toggle    (—)     — toggle PATTERN ↔ VIDEO
+/patternflow/ping              (—)             — learn sender as remote host + reply with full announce
+/patternflow/knob/N/delta      (int or float)  — virtual rotation on logical knob N (1..4)
+/patternflow/pattern/index     (int or float)  — switch to pattern at this registry index
+/patternflow/content/toggle    (—)             — toggle PATTERN ↔ VIDEO
 ```
 
-Knob deltas are applied on top of any physical encoder motion in the same frame, at the raw 1×-per-detent rate (no acceleration). Useful for Ableton automation lanes that drive a pattern parameter from a Live track. Unknown addresses are ignored silently. Receive buffer is 256 bytes per packet.
+Numeric arguments may be int or float (floats are rounded) — Max patches commonly send floats, and silently dropping them was a debugging trap. Knob deltas are applied on top of any physical encoder motion in the same frame, at the raw 1×-per-detent rate (no acceleration). Useful for Ableton automation lanes that drive a pattern parameter from a Live track. Unknown addresses (and `#bundle` packets) are ignored silently. Receive buffer is 256 bytes per packet; up to 8 datagrams are drained per frame so fast automation streams don't build up queue latency.
 
 ## OTA Updates (For Developers)
 

--- a/firmware/patternflow/net_config.h
+++ b/firmware/patternflow/net_config.h
@@ -81,8 +81,12 @@
 #ifndef PF_OSC_ENABLED
 #define PF_OSC_ENABLED 0
 #endif
+// Where outgoing OSC goes. Leave EMPTY (the default) to auto-learn: the
+// device locks onto whoever sends it the first valid OSC packet — the M4L
+// bridge's Connect button (/patternflow/ping) does exactly that. Set a
+// static IP here only if the host side can't send ("send-only" setups).
 #ifndef PF_OSC_REMOTE_HOST
-#define PF_OSC_REMOTE_HOST "192.168.0.10"
+#define PF_OSC_REMOTE_HOST ""
 #endif
 #ifndef PF_OSC_REMOTE_PORT
 #define PF_OSC_REMOTE_PORT 9000

--- a/firmware/patternflow/patternflow_secrets.example.h
+++ b/firmware/patternflow/patternflow_secrets.example.h
@@ -28,9 +28,13 @@
 
 // ── OSC (Ableton/Max sidechannel) ──
 // Off by default. Set to 1 to send/receive OSC.
-#define PF_OSC_ENABLED 0
-#define PF_OSC_REMOTE_HOST "192.168.0.10"
-#define PF_OSC_REMOTE_PORT 9000
+#define PF_OSC_ENABLED 1
+// Remote host is normally LEARNED automatically: leave this line commented
+// out and let the M4L bridge (or any host) send /patternflow/ping — the
+// device replies to wherever the ping came from. Only set a static IP for
+// send-only setups where the host never sends anything back.
+// #define PF_OSC_REMOTE_HOST "192.168.0.10"
+// #define PF_OSC_REMOTE_PORT 9000
 // #define PF_OSC_LOCAL_PORT 9001
 
 // ── Audio-react WebSocket ──

--- a/firmware/patternflow/src/core_osc.h
+++ b/firmware/patternflow/src/core_osc.h
@@ -16,7 +16,6 @@ enum Status {
   STATUS_DISABLED,
   STATUS_WIFI_CONNECTING,
   STATUS_WIFI_TIMEOUT,
-  STATUS_BAD_HOST,
   STATUS_READY,
   STATUS_WIFI_LOST
 };
@@ -24,6 +23,10 @@ enum Status {
 #if PF_OSC_ENABLED
 WiFiUDP udp;
 IPAddress remoteIp;
+// True once we have somewhere to send: either PF_OSC_REMOTE_HOST parsed as
+// a static IP, or the sender of the first valid incoming OSC packet was
+// learned. Until then outgoing messages are dropped silently.
+bool remoteValid = false;
 bool ready = false;
 Status status = STATUS_DISABLED;
 uint32_t lastStatusMs = 0;
@@ -45,7 +48,18 @@ bool runtimeEnabled = true;
 int32_t pendingKnobDelta[4] = {0, 0, 0, 0};
 int pendingPatternIdx = -1;
 bool pendingContentToggle = false;
+// Set by /patternflow/ping (and whenever the learned remote changes):
+// update() answers with a full announce (hello/version/ip + status) so a
+// host that starts AFTER the device still gets the current state.
+bool pendingAnnounce = false;
 uint8_t rxBuf[256];
+
+// How many datagrams pollReceive() drains per frame. Ableton automation
+// can easily send hundreds of messages per second; handling only one per
+// frame would let the socket queue grow and the device lag seconds behind.
+#ifndef PF_OSC_RX_BUDGET
+#define PF_OSC_RX_BUDGET 8
+#endif
 
 inline void appendByte(uint8_t value) {
   if (packetLen < sizeof(packet)) packet[packetLen++] = value;
@@ -99,22 +113,47 @@ inline int32_t readInt32BE(const uint8_t* buf, size_t off) {
          ((int32_t)buf[off + 2] << 8) | (int32_t)buf[off + 3];
 }
 
+// Read one numeric OSC argument as an int. Max/M4L patches frequently emit
+// floats where the spec says int ('f' instead of 'i'); silently dropping
+// those was a debugging trap, so both tags are accepted and floats are
+// rounded to the nearest integer.
+inline bool readNumericArg(char type, const uint8_t* buf, size_t len,
+                           size_t off, int32_t& out) {
+  if (off + 4 > (size_t)len) return false;
+  if (type == 'i') {
+    out = readInt32BE(buf, off);
+    return true;
+  }
+  if (type == 'f') {
+    union {
+      float f;
+      uint32_t u;
+    } packed;
+    packed.u = (uint32_t)readInt32BE(buf, off);
+    out = (int32_t)lroundf(packed.f);
+    return true;
+  }
+  return false;
+}
+
 inline void handleIncomingMessage(const char* addr, const char* types,
                                   const uint8_t* buf, size_t len, size_t argOff) {
-  // /patternflow/knob/N/delta i
+  int32_t arg = 0;
+  // /patternflow/knob/N/delta (int or float)
   if (strncmp(addr, "/patternflow/knob/", 18) == 0) {
     int n = addr[18] - '1';
     if (n < 0 || n > 3) return;
     const char* suffix = addr + 19;
-    if (strcmp(suffix, "/delta") == 0 && types[0] == 'i' && argOff + 4 <= len) {
-      pendingKnobDelta[n] += readInt32BE(buf, argOff);
+    if (strcmp(suffix, "/delta") == 0 &&
+        readNumericArg(types[0], buf, len, argOff, arg)) {
+      pendingKnobDelta[n] += arg;
     }
     return;
   }
-  // /patternflow/pattern/index i
+  // /patternflow/pattern/index (int or float)
   if (strcmp(addr, "/patternflow/pattern/index") == 0 &&
-      types[0] == 'i' && argOff + 4 <= len) {
-    pendingPatternIdx = readInt32BE(buf, argOff);
+      readNumericArg(types[0], buf, len, argOff, arg)) {
+    pendingPatternIdx = arg;
     return;
   }
   // /patternflow/content/toggle (no args needed)
@@ -122,26 +161,60 @@ inline void handleIncomingMessage(const char* addr, const char* types,
     pendingContentToggle = true;
     return;
   }
+  // /patternflow/ping (no args needed) — host asks for a full announce.
+  // Sending this on host startup solves the "Ableton opened after the
+  // device booted and never learns the current pattern" problem, and is
+  // also the handshake that lets the device learn the host's IP.
+  if (strcmp(addr, "/patternflow/ping") == 0) {
+    pendingAnnounce = true;
+    return;
+  }
+}
+
+// Parse and dispatch one datagram already read into rxBuf. Returns true if
+// it looked like a valid OSC message (used to decide whether the sender is
+// worth learning as the remote host).
+inline bool handleDatagram(int n) {
+  const char* addr = nullptr;
+  size_t off = readPaddedString(rxBuf, n, 0, addr);
+  if (off == 0 || !addr || addr[0] != '/') return false;
+
+  const char* types = nullptr;
+  off = readPaddedString(rxBuf, n, off, types);
+  if (off == 0 || !types || types[0] != ',') return false;
+
+  handleIncomingMessage(addr, types + 1, rxBuf, n, off);
+  return true;
 }
 
 inline void pollReceive() {
   if (!ready) return;
-  int size = udp.parsePacket();
-  if (size <= 0) return;
-  if (size > (int)sizeof(rxBuf)) { udp.flush(); return; }
+  // Drain up to PF_OSC_RX_BUDGET datagrams per frame so a fast sender
+  // (Live automation, LFO devices) can't build up queue latency. The
+  // budget caps worst-case frame cost when someone floods the port.
+  for (int i = 0; i < PF_OSC_RX_BUDGET; i++) {
+    int size = udp.parsePacket();
+    if (size <= 0) return;
+    if (size > (int)sizeof(rxBuf)) { udp.flush(); continue; }
 
-  int n = udp.read(rxBuf, sizeof(rxBuf));
-  if (n <= 0) return;
+    int n = udp.read(rxBuf, sizeof(rxBuf));
+    if (n <= 0) continue;
 
-  const char* addr = nullptr;
-  size_t off = readPaddedString(rxBuf, n, 0, addr);
-  if (off == 0 || !addr) return;
+    if (!handleDatagram(n)) continue;
 
-  const char* types = nullptr;
-  off = readPaddedString(rxBuf, n, off, types);
-  if (off == 0 || !types || types[0] != ',') return;
-
-  handleIncomingMessage(addr, types + 1, rxBuf, n, off);
+    // Learn (or follow) the remote host from any valid OSC sender. This
+    // removes the need to hardcode the laptop's IP in the secrets file:
+    // the M4L device just sends /patternflow/ping and the reply goes back
+    // to wherever the ping came from. A changed sender re-announces so the
+    // new host gets the hello/status it missed.
+    IPAddress sender = udp.remoteIP();
+    if (!remoteValid || sender != remoteIp) {
+      remoteIp = sender;
+      remoteValid = true;
+      pendingAnnounce = true;
+      Serial.printf("[OSC] Remote host learned: %s\n", sender.toString().c_str());
+    }
+  }
 }
 
 inline bool beginMessage(const char* address, const char* types) {
@@ -156,7 +229,7 @@ inline bool beginMessage(const char* address, const char* types) {
 }
 
 inline void flushMessage() {
-  if (!ready || packetLen == 0) return;
+  if (!ready || !remoteValid || packetLen == 0) return;
   udp.beginPacket(remoteIp, PF_OSC_REMOTE_PORT);
   udp.write(packet, packetLen);
   udp.endPacket();
@@ -200,14 +273,25 @@ inline void sendStatus(const char* contentName, int patternIdx, int contentMode,
   sendInt("/patternflow/content/mode", contentMode);
   sendInt("/patternflow/app/mode", appMode);
 }
+
+// Identity messages: who we are, which firmware, where to reach us.
+// Sent on connect and as the first half of a /patternflow/ping reply.
+inline void sendHello() {
+  sendString("/patternflow/hello", "Patternflow");
+  sendString("/patternflow/version", PF_IMPROV_FW_VERSION);
+  sendString("/patternflow/ip", WiFi.localIP().toString().c_str());
+}
 #endif
 
 inline const char* statusText() {
 #if PF_OSC_ENABLED
   if (!runtimeEnabled) return "OFF (runtime)";
-  if (status == STATUS_BAD_HOST) return "BAD HOST";
   if (WiFi.status() != WL_CONNECTED) return PatternflowWifi::statusText();
   if (!ready) return "WIFI OK";
+  // Listening, but nobody to send to yet: no static PF_OSC_REMOTE_HOST and
+  // no incoming packet to learn a sender from. Send /patternflow/ping from
+  // the host (the M4L bridge's Connect button does this) to pair.
+  if (!remoteValid) return "WAIT HOST";
   return "READY";
 #else
   return "OFF (compile-time)";
@@ -257,11 +341,15 @@ inline String localIpString() {
 #endif
 }
 
-inline const char* remoteHost() {
+// Current remote host for the info screen: the learned sender IP once a
+// host has pinged us, the static PF_OSC_REMOTE_HOST before that, or "—".
+inline String remoteHostString() {
 #if PF_OSC_ENABLED
-  return PF_OSC_REMOTE_HOST;
+  if (remoteValid) return remoteIp.toString();
+  if (PF_OSC_REMOTE_HOST[0] != '\0') return String(PF_OSC_REMOTE_HOST);
+  return String("—");
 #else
-  return "—";
+  return String("—");
 #endif
 }
 
@@ -280,20 +368,22 @@ inline void begin() {
 #if PF_OSC_ENABLED
   if (WiFi.status() != WL_CONNECTED) return;
 
-  if (!remoteIp.fromString(PF_OSC_REMOTE_HOST)) {
-    Serial.println("[OSC] Invalid PF_OSC_REMOTE_HOST; OSC disabled");
-    status = STATUS_BAD_HOST;
-    return;
-  }
-
   udp.begin(PF_OSC_LOCAL_PORT);
   ready = true;
   status = STATUS_READY;
+  Serial.printf("[OSC] Local IP: %s, listening on :%d\n",
+                WiFi.localIP().toString().c_str(), PF_OSC_LOCAL_PORT);
 
-  Serial.printf("[OSC] Local IP: %s\n", WiFi.localIP().toString().c_str());
-  Serial.printf("[OSC] Sending to %s:%d\n", PF_OSC_REMOTE_HOST, PF_OSC_REMOTE_PORT);
-  sendString("/patternflow/hello", "Patternflow");
-  sendString("/patternflow/ip", WiFi.localIP().toString().c_str());
+  // A static remote host is optional. Leave PF_OSC_REMOTE_HOST empty (the
+  // default) and the device instead learns the host from the first valid
+  // OSC packet it receives — typically the M4L bridge's /patternflow/ping.
+  if (remoteIp.fromString(PF_OSC_REMOTE_HOST)) {
+    remoteValid = true;
+    Serial.printf("[OSC] Sending to %s:%d (static)\n", PF_OSC_REMOTE_HOST, PF_OSC_REMOTE_PORT);
+    sendHello();
+  } else if (!remoteValid) {
+    Serial.println("[OSC] No static remote host; waiting for /patternflow/ping to learn one");
+  }
 #endif
 }
 
@@ -347,6 +437,18 @@ inline void update(const InputFrame& input, const char* contentName, int pattern
   // Drain any incoming OSC messages first so the main loop sees them
   // on this frame. Returns immediately if no packet is waiting.
   pollReceive();
+
+  // Answer /patternflow/ping (or a newly learned host) with the full
+  // identity + current state, so a host that connects mid-session doesn't
+  // have to wait for the next pattern change to know where things stand.
+  if (pendingAnnounce) {
+    pendingAnnounce = false;
+    sendHello();
+    sendStatus(contentName, patternIdx, contentMode, appMode);
+    lastPatternIdx = patternIdx;
+    lastContentMode = contentMode;
+    lastAppMode = appMode;
+  }
 
   for (int i = 0; i < 4; i++) {
     if (input.knobDeltas[i] != 0) {

--- a/hardware/case/README.md
+++ b/hardware/case/README.md
@@ -27,6 +27,24 @@ Naming: a variant keeps its base plate's name plus a descriptive suffix (e.g. `0
 
 > **⚠️ Known issue — `01_plate_main_easyfit.stl`.** This variant is missing the internal slot that the LED matrix divider wall slides into, so the divider does not seat properly. A fixed STL will be uploaded later. Until then, use the standard `01_plate_main.stl` if you need the divider to fit correctly.
 
+## One-piece enclosure (large-format printers)
+
+`print-ready/oneshot/` is an alternative to the standard split-and-glue body: the enclosure prints as a **single-piece body plus a snap-fit closing part** — no bonding step at all. This is the mass-production-oriented design from [Issue #113](https://github.com/engmung/Patternflow/issues/113).
+
+| File | Contents | Color |
+|---|---|---|
+| `print-ready/oneshot/oneshot_1.stl` + `oneshot_2.stl` | Full enclosure as two snap-fit parts | White PLA |
+
+- **Bed requirement: ~330 mm+ (Bambu H2S-class or similar large-format).** It does **not** fit a 256 mm bed (P1S/X1C/A1 class) — for those printers, use the standard plates above, or watch the divided variant below.
+- Knobs are printed separately as usual (`03_plate_knobs*.stl`).
+- Status: core design complete and printing reliably. Minor refinements (vent holes, anti-warp ribs) are planned for the v3.0 revision.
+
+## Experiments
+
+`print-ready/experiment/` holds unvalidated work-in-progress. Currently:
+
+- `divided_test_1.stl` … `divided_test_5.stl` — the one-piece enclosure split into **5 parts that fit a 256 mm bed** (P1S-class), so community printers can build the snap-fit design too. Modeled but **not yet print-tested** — do not build from these yet. Once validated, they will be promoted next to the one-piece files.
+
 ## Print settings
 
 - **Printer:** Bambu P1S (default profile works as-is)

--- a/hardware/case/print-ready/experiment/divided_test_1.stl
+++ b/hardware/case/print-ready/experiment/divided_test_1.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:560d85fbb05dc82de42123ceab7cea39929034b528426ce5ef67342743cbd390
+size 13134

--- a/hardware/case/print-ready/experiment/divided_test_2.stl
+++ b/hardware/case/print-ready/experiment/divided_test_2.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bef9aed3a7b4aac31a5fb9a1536a5c6f4834baf1dca3fd39a0916e3d10b2eff5
+size 53484

--- a/hardware/case/print-ready/experiment/divided_test_3.stl
+++ b/hardware/case/print-ready/experiment/divided_test_3.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ba4c9d0a2ae76c9f762d1392d585caa0803c960d9e80a9245c173cc7ebbba91b
+size 18384

--- a/hardware/case/print-ready/experiment/divided_test_4.stl
+++ b/hardware/case/print-ready/experiment/divided_test_4.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b068262b840be6c9bb4788d091f77afec186f7a02c76ae9d28db7c67e22c62ee
+size 36084

--- a/hardware/case/print-ready/experiment/divided_test_5.stl
+++ b/hardware/case/print-ready/experiment/divided_test_5.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cf9e7ae34db1c6aaa477d83948860a1c2e31c5c357bd4959b198bcf1135987a7
+size 274484

--- a/hardware/case/print-ready/experiment/oneshot_test_1.stl
+++ b/hardware/case/print-ready/experiment/oneshot_test_1.stl
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:620ce6da252d2f51d18fcd67f317cb17fd87037fabda26cc9901f7039ef71fc2
-size 203584

--- a/hardware/case/print-ready/experiment/oneshot_test_2.stl
+++ b/hardware/case/print-ready/experiment/oneshot_test_2.stl
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8146e420c229a5d266c496b269890eae11c93ef396eb788b2b31765d2e432905
-size 51184

--- a/hardware/case/print-ready/oneshot/oneshot_1.stl
+++ b/hardware/case/print-ready/oneshot/oneshot_1.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:420166ece5c1e94ad2d26292ffc09bc386bb45af34df77cf3ebeff5319fedddb
+size 203584

--- a/hardware/case/print-ready/oneshot/oneshot_2.stl
+++ b/hardware/case/print-ready/oneshot/oneshot_2.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:406c058af64f913e23dedfc927a58fa2f6de2d02fa9a303f1e1d62ce4ffeaeb4
+size 57984

--- a/hardware/case/source/patternflow_v1.blend
+++ b/hardware/case/source/patternflow_v1.blend
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4205f19c90f7a5484621b42e4c667169c8106a6e4a4e603fe1f1933d75b4b51a
-size 40298553
+oid sha256:b7f71d39eede4283efecd7ec2a6e15ec7dba68eebba17ce0616995c00d27885c
+size 40358548

--- a/integrations/ableton/README.md
+++ b/integrations/ableton/README.md
@@ -1,0 +1,65 @@
+# Patternflow ⇄ Ableton Live (Max for Live)
+
+Turn a knob on Patternflow and hear the sound change: this folder connects the device's four encoders to any four parameters in your Live set, over Wi-Fi, using OSC and a small Max for Live device — the **Patternflow Bridge**.
+
+The wire protocol is documented in [docs/osc-spec.md](../../docs/osc-spec.md). The firmware side is built in (see below); everything in this folder runs on the computer.
+
+```
+integrations/ableton/
+├── max/
+│   ├── patternflow-bridge.maxpat   # the M4L device patch (open in Max, save as .amxd)
+│   └── patternflow.bridge.js       # all device logic (loaded by the patch)
+└── docs/
+    ├── m4l-osc-guide.md            # OSC in Max for Live: the parts that bite
+    └── recording-sync.md           # filming with synced sound
+```
+
+## Requirements
+
+- Ableton Live Suite (or Live + Max for Live), Live 11/12
+- Patternflow flashed with OSC enabled (below) on the **same Wi-Fi network** as the computer
+- First run on Windows: allow Max through the firewall when prompted (UDP 9000 must be able to reach Max)
+
+## 1. Enable OSC in the firmware (one-time)
+
+Copy `firmware/patternflow/patternflow_secrets.example.h` to `patternflow_secrets.h` and set:
+
+```cpp
+#define PF_WIFI_SSID "your-wifi-name"
+#define PF_WIFI_PASS "your-wifi-password"
+#define PF_OSC_ENABLED 1
+```
+
+You do **not** need to set your computer's IP — the device learns it from the bridge's ping. Flash, then check the K2-longpress info screen: OSC should read `READY` or `WAIT HOST`.
+
+## 2. Install the bridge device
+
+The device ships as a `.maxpat` (plain text, diff-able) rather than a binary `.amxd`, so you build the `.amxd` once locally:
+
+1. In Live, drag a **Max Audio Effect** onto any audio track (the pass-through default is fine).
+2. Click its **edit button** (the leftmost icon on the device title bar) — Max opens.
+3. In Max: **File → Open** → `integrations/ableton/max/patternflow-bridge.maxpat`. Select all (Ctrl/Cmd-A), copy, close it, and paste into the Max Audio Effect patcher (replace its default contents but keep nothing — our patch already includes `plugin~`/`plugout~`).
+4. Copy `patternflow.bridge.js` into the same folder where you'll save the device (Max looks for it next to the `.amxd`), or add its folder to Max's search path (Options → File Preferences).
+5. **Save** the device as `Patternflow Bridge.amxd`. Close the Max editor.
+
+## 3. Connect and map
+
+1. The bridge pings `patternflow.local` automatically on load. Status shows **connected · P0 …** when the device answers. If not, type the device's IP (shown on the K2 info screen) into the host field and press Enter, or click **Connect**.
+2. Click any parameter in your Live set (a synth macro, a filter cutoff…), then click **Map 1**. Knob K1 on Patternflow now drives it.
+3. **Sweep** = how many encoder clicks cover the parameter's full range. 24 clicks = one physical turn; default 48 = two turns. Lower is more sensitive.
+4. Mappings, sweep values, and the host name are saved with your Live set.
+
+Notes:
+
+- A mapped parameter is taken over by `live.remote~`: it appears greyed out in Live and can't be moved by mouse until you click **Clear**. This is normal M4L behavior.
+- The status line shows the current pattern (index + name) and goes **offline** if the heartbeat stops (device off, Wi-Fi drop). It re-pings by itself every few seconds.
+
+## Troubleshooting
+
+Work through [docs/m4l-osc-guide.md](docs/m4l-osc-guide.md) — it covers every failure mode we've hit ourselves (firewall, mDNS on Windows, greyed parameters, float-vs-int OSC args, port conflicts).
+
+## Roadmap
+
+- Per-pattern mapping banks (the device already broadcasts pattern changes)
+- Button → clip launch mapping
+- `/patternflow/slate`: one-frame white flash + audio tone for automatic video/audio alignment (see [docs/recording-sync.md](docs/recording-sync.md))

--- a/integrations/ableton/docs/m4l-osc-guide.md
+++ b/integrations/ableton/docs/m4l-osc-guide.md
@@ -1,0 +1,61 @@
+# OSC in Max for Live — the parts that bite
+
+Everything in this guide was learned the hard way while wiring Patternflow into Ableton. It applies to any OSC hardware, not just Patternflow. Read this before debugging for an hour.
+
+## Receiving OSC in Max
+
+`[udpreceive 9000]` is all you need. It decodes incoming OSC automatically: a packet with address `/patternflow/knob/1/delta` and one int argument comes out of the outlet as the Max message `/patternflow/knob/1/delta 3`. Route it with `[route /patternflow/knob/1/delta ...]` or feed everything into a `[js]` and dispatch in `anything()` (what the bridge does).
+
+Things that go wrong:
+
+- **Nothing arrives at all → it's almost never Max.** Check, in order:
+  1. **Firewall.** On Windows, the first time Max opens a UDP port a firewall prompt appears — if it was dismissed, incoming packets are dropped silently. Windows Security → Firewall → Allow an app → make sure *Max* (and *Ableton Live*) are allowed on private networks.
+  2. **Same network.** Phone hotspots and guest Wi-Fi networks often isolate clients from each other (AP/client isolation). Both the computer and the device must be on the same normal LAN.
+  3. **Port already taken.** Only one process can bind UDP 9000. A second `[udpreceive 9000]` — including one in a *second instance of the same device* on another track — silently gets nothing. One bridge per Live set.
+- **`oscparse` is not needed** for plain messages. It's for working with OSC as dicts. If you see tutorials chaining `udpreceive → oscparse → ...`, that's an alternative style, not a requirement.
+- **`#bundle` packets**: Max's `udpsend` sends bare messages, which is what Patternflow expects. If you use CNMAT's `o.` externals or python-osc's bundle mode, disable bundling — the device ignores bundles.
+
+## Sending OSC from Max
+
+`[udpsend patternflow.local 9001]`, then send it the message `/patternflow/ping`. Change target at runtime with `host <name-or-ip>` and `port <n>` messages.
+
+- **mDNS (`patternflow.local`)** resolves fine on macOS and on Windows 10/11. If it doesn't (some corporate networks block mDNS), use the raw IP from the device's K2-longpress info screen.
+- **Int vs float**: Max number boxes emit floats unless you're careful, and a float where an int is expected is the classic "silently ignored" OSC bug. Patternflow's firmware accepts both and rounds — but other OSC devices you'll meet won't. When in doubt, force ints in Max before `udpsend`.
+
+## Driving Live parameters: `live.remote~`
+
+`live.remote~` is the only object that can move a Live parameter continuously without creating undo history and without automation-lane fighting. The gotchas:
+
+- **Bind by id**: send it `id 42` where 42 is a `LiveAPI` object id for a parameter (`DeviceParameter`). Send `id 0` to unbind.
+- **The parameter locks.** While bound, the parameter is greyed out in Live's UI, shows "Mapped", and the mouse can't move it. This scares people into thinking something broke. Unbind to release it.
+- **Values are in the parameter's native range**, not 0–1. Read `min` and `max` from the parameter via `LiveAPI` and scale yourself: `out = min + v * (max - min)`. (This is what the M4L LFO does internally.)
+- **Zipper noise**: `live.remote~` accepts both signals and floats. Float messages at encoder-event rate are fine for filter sweeps; for very zipper-sensitive targets (gain on a sustained pad), interpolate with `line~ → live.remote~` at signal rate.
+
+## The Live API from `[js]`
+
+- **You cannot touch `LiveAPI` in global code or `loadbang`.** The API isn't ready; calls fail or return id 0. Wait for the `[live.thisdevice]` bang — that is the "Live is ready" signal.
+- **Ids are session-local; paths are not stable either.** A parameter's numeric id changes between Live sessions, and its canonical path (`live_set tracks 0 devices 1 parameters 3`) changes when tracks/devices are reordered. Persist the *path*, re-resolve to an id on load, and accept that reordering tracks may require re-mapping. (Robust tracking needs id-remap observers — v2 territory.)
+- **`selected_parameter`** (`live_set view`) is how "click a param, then click Map" works. Clicking controls *inside* an M4L device does not change Live's selected parameter, so your own Map button won't steal the selection.
+- **Getting values**: `api.get("value")` returns an array — take `[0]`. Same for `min`, `max`, `name`.
+
+## Persistence (mappings that survive save/reload)
+
+M4L devices don't save arbitrary `[js]` state. The pattern that works:
+
+1. Implement `getvalueof()` / `setvalueof()` in the js.
+2. Put `[pattr something @bindto <js-varname> @autorestore 1]` in the patch.
+3. `pattr` contents are stored in the Live set; `setvalueof()` runs on load.
+
+Two traps: `setvalueof()` may run **before** the `live.thisdevice` bang (so don't touch LiveAPI from it — stash and bind later), and multi-word symbols get flattened in pattr lists (the bridge dodges this by storing paths with dots instead of spaces).
+
+## Feedback loops in the patch
+
+Any UI object you both *read from* and *write to* (number boxes, textedit) will re-emit what you send to its inlet — through your `prepend`, back into your js, forever. Write to displays with a `set`-prefixed message (`set 48`), which updates silently.
+
+## Debugging checklist
+
+1. Device K2 info screen: OSC `READY`/`WAIT HOST`? IP shown?
+2. Max console (`Max window`): put `[print rx]` on `udpreceive`'s outlet — do packets arrive when you turn a knob?
+3. Nothing? Firewall → same-network → port-conflict, in that order.
+4. Packets arrive but the param doesn't move? Is the slot mapped (param greyed in Live)? Is the value scaled to the param's min/max?
+5. Worked yesterday, dead today? The laptop's IP changed and the device was on a *static* remote host — click Connect (ping re-teaches the device), or stop using a static host.

--- a/integrations/ableton/docs/recording-sync.md
+++ b/integrations/ableton/docs/recording-sync.md
@@ -1,0 +1,31 @@
+# Filming Patternflow with synced sound
+
+Goal: film the device (hands + LEDs) while the mapped Ableton sound is recorded cleanly, and end up with video and audio locked together in the edit — with as little ceremony as possible, so it actually happens every time.
+
+## The v1 workflow (no custom tools)
+
+**Principle: the camera records scratch audio of the same sound the room hears; Live records the clean version; the editor aligns them by waveform.**
+
+1. **Live set**: keep a dedicated **Record bus** — one audio track whose input is *Resampling*, armed. Everything you hear goes to it.
+2. Play the speakers out loud (or at least a click/tone at the start) so the camera mic picks up *something* correlated with the clean audio.
+3. Roll camera → hit Live's global record → perform (turn knobs, switch patterns) → stop both.
+4. Export the Record bus clip as WAV, drop camera file + WAV into **DaVinci Resolve** → select both in the media pool → right-click → **Auto Sync Audio → Based on Waveform**. Resolve aligns them; mute the camera track.
+
+That's the whole system. Premiere ("Synchronize → Audio") and Final Cut ("Synchronize Clips") do the same thing.
+
+### Make it foolproof
+
+- **One take = one Live recording.** Don't pause Live's transport mid-take; a single continuous WAV per camera file keeps sync trivial.
+- **Clap once on camera** before performing if the speaker level is low — a transient gives the waveform matcher (and you, as manual fallback) an anchor.
+- **Name by take**: `pf-take03.wav` next to `pf-take03.mp4`. Future-you will thank present-you.
+- Camera and Live sample clocks drift ~1 frame per several minutes at worst; for takes under ~10 minutes, ignore it.
+
+## v2 (planned): the device as its own clapperboard
+
+The plan on the firmware roadmap (see [osc-spec.md](../../../docs/osc-spec.md), planned addresses):
+
+1. A **Slate** button in the M4L bridge sends `/patternflow/slate`.
+2. The firmware flashes the full matrix white for one frame; simultaneously the bridge plays a short tone into the Record bus and starts Live's transport recording via the Live API.
+3. The video then contains a single white-flash frame and the audio a tone burst — an exact alignment pair. A small ffmpeg/python script (planned under `tools/`) finds both and muxes automatically.
+
+Until then, Resolve's waveform sync covers 100% of the need with zero maintenance — which is the point of v1.

--- a/integrations/ableton/max/patternflow-bridge.maxpat
+++ b/integrations/ableton/max/patternflow-bridge.maxpat
@@ -1,0 +1,687 @@
+{
+	"patcher": {
+		"fileversion": 1,
+		"appversion": {
+			"major": 8,
+			"minor": 6,
+			"revision": 0,
+			"architecture": "x64",
+			"modernui": 1
+		},
+		"classnamespace": "box",
+		"rect": [59.0, 106.0, 860.0, 700.0],
+		"bglocked": 0,
+		"openinpresentation": 1,
+		"default_fontsize": 12.0,
+		"default_fontface": 0,
+		"default_fontname": "Arial",
+		"gridonopen": 1,
+		"gridsize": [15.0, 15.0],
+		"gridsnaponopen": 1,
+		"objectsnaponopen": 1,
+		"statusbarvisible": 2,
+		"toolbarvisible": 1,
+		"boxes": [
+			{
+				"box": {
+					"id": "obj-61",
+					"maxclass": "comment",
+					"numinlets": 1,
+					"numoutlets": 0,
+					"patching_rect": [24.0, 16.0, 220.0, 20.0],
+					"presentation": 1,
+					"presentation_rect": [4.0, 2.0, 220.0, 18.0],
+					"text": "PATTERNFLOW BRIDGE"
+				}
+			},
+			{
+				"box": {
+					"id": "obj-62",
+					"maxclass": "comment",
+					"fontsize": 10.0,
+					"numinlets": 1,
+					"numoutlets": 0,
+					"patching_rect": [260.0, 16.0, 460.0, 20.0],
+					"presentation": 1,
+					"presentation_rect": [4.0, 124.0, 452.0, 40.0],
+					"text": "Select a parameter in Live, then click Map. Turn a Patternflow knob to move it. Sweep = encoder clicks for the full range (24 = one physical turn)."
+				}
+			},
+			{
+				"box": {
+					"id": "obj-1",
+					"maxclass": "newobj",
+					"numinlets": 1,
+					"numoutlets": 1,
+					"outlettype": [""],
+					"patching_rect": [24.0, 60.0, 120.0, 22.0],
+					"text": "udpreceive 9000"
+				}
+			},
+			{
+				"box": {
+					"id": "obj-2",
+					"maxclass": "newobj",
+					"numinlets": 1,
+					"numoutlets": 11,
+					"outlettype": ["", "", "", "", "", "", "", "", "", "", ""],
+					"patching_rect": [24.0, 130.0, 300.0, 22.0],
+					"text": "js patternflow.bridge.js",
+					"varname": "pf_bridge"
+				}
+			},
+			{
+				"box": {
+					"id": "obj-3",
+					"maxclass": "newobj",
+					"numinlets": 1,
+					"numoutlets": 1,
+					"outlettype": [""],
+					"patching_rect": [24.0, 210.0, 80.0, 22.0],
+					"text": "live.remote~"
+				}
+			},
+			{
+				"box": {
+					"id": "obj-4",
+					"maxclass": "newobj",
+					"numinlets": 1,
+					"numoutlets": 1,
+					"outlettype": [""],
+					"patching_rect": [114.0, 210.0, 80.0, 22.0],
+					"text": "live.remote~"
+				}
+			},
+			{
+				"box": {
+					"id": "obj-5",
+					"maxclass": "newobj",
+					"numinlets": 1,
+					"numoutlets": 1,
+					"outlettype": [""],
+					"patching_rect": [204.0, 210.0, 80.0, 22.0],
+					"text": "live.remote~"
+				}
+			},
+			{
+				"box": {
+					"id": "obj-6",
+					"maxclass": "newobj",
+					"numinlets": 1,
+					"numoutlets": 1,
+					"outlettype": [""],
+					"patching_rect": [294.0, 210.0, 80.0, 22.0],
+					"text": "live.remote~"
+				}
+			},
+			{
+				"box": {
+					"id": "obj-7",
+					"maxclass": "newobj",
+					"numinlets": 1,
+					"numoutlets": 0,
+					"patching_rect": [404.0, 210.0, 190.0, 22.0],
+					"text": "udpsend patternflow.local 9001"
+				}
+			},
+			{
+				"box": {
+					"id": "obj-8",
+					"maxclass": "newobj",
+					"numinlets": 1,
+					"numoutlets": 3,
+					"outlettype": ["bang", "int", "int"],
+					"patching_rect": [480.0, 60.0, 100.0, 22.0],
+					"text": "live.thisdevice"
+				}
+			},
+			{
+				"box": {
+					"id": "obj-9",
+					"maxclass": "message",
+					"numinlets": 2,
+					"numoutlets": 1,
+					"outlettype": [""],
+					"patching_rect": [480.0, 96.0, 40.0, 22.0],
+					"text": "init"
+				}
+			},
+			{
+				"box": {
+					"id": "obj-10",
+					"maxclass": "newobj",
+					"numinlets": 1,
+					"numoutlets": 2,
+					"outlettype": ["signal", "signal"],
+					"patching_rect": [660.0, 60.0, 60.0, 22.0],
+					"text": "plugin~"
+				}
+			},
+			{
+				"box": {
+					"id": "obj-11",
+					"maxclass": "newobj",
+					"numinlets": 2,
+					"numoutlets": 2,
+					"outlettype": ["signal", "signal"],
+					"patching_rect": [660.0, 110.0, 68.0, 22.0],
+					"text": "plugout~"
+				}
+			},
+			{
+				"box": {
+					"id": "obj-12",
+					"maxclass": "textedit",
+					"numinlets": 1,
+					"numoutlets": 4,
+					"outlettype": ["", "", "", ""],
+					"patching_rect": [24.0, 300.0, 150.0, 22.0],
+					"presentation": 1,
+					"presentation_rect": [4.0, 24.0, 140.0, 20.0],
+					"text": "patternflow.local",
+					"varname": "host_field"
+				}
+			},
+			{
+				"box": {
+					"id": "obj-13",
+					"maxclass": "newobj",
+					"numinlets": 1,
+					"numoutlets": 1,
+					"outlettype": [""],
+					"patching_rect": [24.0, 336.0, 110.0, 22.0],
+					"text": "prepend sethost"
+				}
+			},
+			{
+				"box": {
+					"id": "obj-14",
+					"maxclass": "textbutton",
+					"numinlets": 1,
+					"numoutlets": 3,
+					"outlettype": ["", "", ""],
+					"parameter_enable": 0,
+					"patching_rect": [190.0, 300.0, 70.0, 22.0],
+					"presentation": 1,
+					"presentation_rect": [148.0, 24.0, 64.0, 20.0],
+					"text": "Connect"
+				}
+			},
+			{
+				"box": {
+					"id": "obj-15",
+					"maxclass": "message",
+					"numinlets": 2,
+					"numoutlets": 1,
+					"outlettype": [""],
+					"patching_rect": [190.0, 336.0, 60.0, 22.0],
+					"text": "connect"
+				}
+			},
+			{
+				"box": {
+					"id": "obj-16",
+					"maxclass": "message",
+					"numinlets": 2,
+					"numoutlets": 1,
+					"outlettype": [""],
+					"patching_rect": [290.0, 300.0, 240.0, 22.0],
+					"presentation": 1,
+					"presentation_rect": [216.0, 24.0, 240.0, 20.0],
+					"text": "offline"
+				}
+			},
+			{
+				"box": {
+					"id": "obj-21",
+					"maxclass": "comment",
+					"numinlets": 1,
+					"numoutlets": 0,
+					"patching_rect": [24.0, 390.0, 40.0, 20.0],
+					"presentation": 1,
+					"presentation_rect": [4.0, 52.0, 40.0, 18.0],
+					"text": "K1"
+				}
+			},
+			{
+				"box": {
+					"id": "obj-22",
+					"maxclass": "textbutton",
+					"numinlets": 1,
+					"numoutlets": 3,
+					"outlettype": ["", "", ""],
+					"parameter_enable": 0,
+					"patching_rect": [24.0, 414.0, 52.0, 22.0],
+					"presentation": 1,
+					"presentation_rect": [4.0, 70.0, 52.0, 20.0],
+					"text": "Map 1"
+				}
+			},
+			{
+				"box": {
+					"id": "obj-23",
+					"maxclass": "message",
+					"numinlets": 2,
+					"numoutlets": 1,
+					"outlettype": [""],
+					"patching_rect": [24.0, 444.0, 50.0, 22.0],
+					"text": "map 1"
+				}
+			},
+			{
+				"box": {
+					"id": "obj-24",
+					"maxclass": "textbutton",
+					"numinlets": 1,
+					"numoutlets": 3,
+					"outlettype": ["", "", ""],
+					"parameter_enable": 0,
+					"patching_rect": [80.0, 414.0, 52.0, 22.0],
+					"presentation": 1,
+					"presentation_rect": [60.0, 70.0, 52.0, 20.0],
+					"text": "Clear"
+				}
+			},
+			{
+				"box": {
+					"id": "obj-25",
+					"maxclass": "message",
+					"numinlets": 2,
+					"numoutlets": 1,
+					"outlettype": [""],
+					"patching_rect": [80.0, 444.0, 54.0, 22.0],
+					"text": "clear 1"
+				}
+			},
+			{
+				"box": {
+					"id": "obj-26",
+					"maxclass": "number",
+					"numinlets": 1,
+					"numoutlets": 2,
+					"outlettype": ["", "bang"],
+					"patching_rect": [24.0, 478.0, 52.0, 22.0],
+					"presentation": 1,
+					"presentation_rect": [4.0, 96.0, 52.0, 20.0]
+				}
+			},
+			{
+				"box": {
+					"id": "obj-27",
+					"maxclass": "newobj",
+					"numinlets": 1,
+					"numoutlets": 1,
+					"outlettype": [""],
+					"patching_rect": [24.0, 508.0, 110.0, 22.0],
+					"text": "prepend sweep 1"
+				}
+			},
+			{
+				"box": {
+					"id": "obj-28",
+					"maxclass": "comment",
+					"fontsize": 10.0,
+					"numinlets": 1,
+					"numoutlets": 0,
+					"patching_rect": [80.0, 478.0, 50.0, 20.0],
+					"presentation": 1,
+					"presentation_rect": [60.0, 98.0, 50.0, 18.0],
+					"text": "sweep"
+				}
+			},
+			{
+				"box": {
+					"id": "obj-31",
+					"maxclass": "comment",
+					"numinlets": 1,
+					"numoutlets": 0,
+					"patching_rect": [164.0, 390.0, 40.0, 20.0],
+					"presentation": 1,
+					"presentation_rect": [118.0, 52.0, 40.0, 18.0],
+					"text": "K2"
+				}
+			},
+			{
+				"box": {
+					"id": "obj-32",
+					"maxclass": "textbutton",
+					"numinlets": 1,
+					"numoutlets": 3,
+					"outlettype": ["", "", ""],
+					"parameter_enable": 0,
+					"patching_rect": [164.0, 414.0, 52.0, 22.0],
+					"presentation": 1,
+					"presentation_rect": [118.0, 70.0, 52.0, 20.0],
+					"text": "Map 2"
+				}
+			},
+			{
+				"box": {
+					"id": "obj-33",
+					"maxclass": "message",
+					"numinlets": 2,
+					"numoutlets": 1,
+					"outlettype": [""],
+					"patching_rect": [164.0, 444.0, 50.0, 22.0],
+					"text": "map 2"
+				}
+			},
+			{
+				"box": {
+					"id": "obj-34",
+					"maxclass": "textbutton",
+					"numinlets": 1,
+					"numoutlets": 3,
+					"outlettype": ["", "", ""],
+					"parameter_enable": 0,
+					"patching_rect": [220.0, 414.0, 52.0, 22.0],
+					"presentation": 1,
+					"presentation_rect": [174.0, 70.0, 52.0, 20.0],
+					"text": "Clear"
+				}
+			},
+			{
+				"box": {
+					"id": "obj-35",
+					"maxclass": "message",
+					"numinlets": 2,
+					"numoutlets": 1,
+					"outlettype": [""],
+					"patching_rect": [220.0, 444.0, 54.0, 22.0],
+					"text": "clear 2"
+				}
+			},
+			{
+				"box": {
+					"id": "obj-36",
+					"maxclass": "number",
+					"numinlets": 1,
+					"numoutlets": 2,
+					"outlettype": ["", "bang"],
+					"patching_rect": [164.0, 478.0, 52.0, 22.0],
+					"presentation": 1,
+					"presentation_rect": [118.0, 96.0, 52.0, 20.0]
+				}
+			},
+			{
+				"box": {
+					"id": "obj-37",
+					"maxclass": "newobj",
+					"numinlets": 1,
+					"numoutlets": 1,
+					"outlettype": [""],
+					"patching_rect": [164.0, 508.0, 110.0, 22.0],
+					"text": "prepend sweep 2"
+				}
+			},
+			{
+				"box": {
+					"id": "obj-38",
+					"maxclass": "comment",
+					"fontsize": 10.0,
+					"numinlets": 1,
+					"numoutlets": 0,
+					"patching_rect": [220.0, 478.0, 50.0, 20.0],
+					"presentation": 1,
+					"presentation_rect": [174.0, 98.0, 50.0, 18.0],
+					"text": "sweep"
+				}
+			},
+			{
+				"box": {
+					"id": "obj-41",
+					"maxclass": "comment",
+					"numinlets": 1,
+					"numoutlets": 0,
+					"patching_rect": [304.0, 390.0, 40.0, 20.0],
+					"presentation": 1,
+					"presentation_rect": [232.0, 52.0, 40.0, 18.0],
+					"text": "K3"
+				}
+			},
+			{
+				"box": {
+					"id": "obj-42",
+					"maxclass": "textbutton",
+					"numinlets": 1,
+					"numoutlets": 3,
+					"outlettype": ["", "", ""],
+					"parameter_enable": 0,
+					"patching_rect": [304.0, 414.0, 52.0, 22.0],
+					"presentation": 1,
+					"presentation_rect": [232.0, 70.0, 52.0, 20.0],
+					"text": "Map 3"
+				}
+			},
+			{
+				"box": {
+					"id": "obj-43",
+					"maxclass": "message",
+					"numinlets": 2,
+					"numoutlets": 1,
+					"outlettype": [""],
+					"patching_rect": [304.0, 444.0, 50.0, 22.0],
+					"text": "map 3"
+				}
+			},
+			{
+				"box": {
+					"id": "obj-44",
+					"maxclass": "textbutton",
+					"numinlets": 1,
+					"numoutlets": 3,
+					"outlettype": ["", "", ""],
+					"parameter_enable": 0,
+					"patching_rect": [360.0, 414.0, 52.0, 22.0],
+					"presentation": 1,
+					"presentation_rect": [288.0, 70.0, 52.0, 20.0],
+					"text": "Clear"
+				}
+			},
+			{
+				"box": {
+					"id": "obj-45",
+					"maxclass": "message",
+					"numinlets": 2,
+					"numoutlets": 1,
+					"outlettype": [""],
+					"patching_rect": [360.0, 444.0, 54.0, 22.0],
+					"text": "clear 3"
+				}
+			},
+			{
+				"box": {
+					"id": "obj-46",
+					"maxclass": "number",
+					"numinlets": 1,
+					"numoutlets": 2,
+					"outlettype": ["", "bang"],
+					"patching_rect": [304.0, 478.0, 52.0, 22.0],
+					"presentation": 1,
+					"presentation_rect": [232.0, 96.0, 52.0, 20.0]
+				}
+			},
+			{
+				"box": {
+					"id": "obj-47",
+					"maxclass": "newobj",
+					"numinlets": 1,
+					"numoutlets": 1,
+					"outlettype": [""],
+					"patching_rect": [304.0, 508.0, 110.0, 22.0],
+					"text": "prepend sweep 3"
+				}
+			},
+			{
+				"box": {
+					"id": "obj-48",
+					"maxclass": "comment",
+					"fontsize": 10.0,
+					"numinlets": 1,
+					"numoutlets": 0,
+					"patching_rect": [360.0, 478.0, 50.0, 20.0],
+					"presentation": 1,
+					"presentation_rect": [288.0, 98.0, 50.0, 18.0],
+					"text": "sweep"
+				}
+			},
+			{
+				"box": {
+					"id": "obj-51",
+					"maxclass": "comment",
+					"numinlets": 1,
+					"numoutlets": 0,
+					"patching_rect": [444.0, 390.0, 40.0, 20.0],
+					"presentation": 1,
+					"presentation_rect": [346.0, 52.0, 40.0, 18.0],
+					"text": "K4"
+				}
+			},
+			{
+				"box": {
+					"id": "obj-52",
+					"maxclass": "textbutton",
+					"numinlets": 1,
+					"numoutlets": 3,
+					"outlettype": ["", "", ""],
+					"parameter_enable": 0,
+					"patching_rect": [444.0, 414.0, 52.0, 22.0],
+					"presentation": 1,
+					"presentation_rect": [346.0, 70.0, 52.0, 20.0],
+					"text": "Map 4"
+				}
+			},
+			{
+				"box": {
+					"id": "obj-53",
+					"maxclass": "message",
+					"numinlets": 2,
+					"numoutlets": 1,
+					"outlettype": [""],
+					"patching_rect": [444.0, 444.0, 50.0, 22.0],
+					"text": "map 4"
+				}
+			},
+			{
+				"box": {
+					"id": "obj-54",
+					"maxclass": "textbutton",
+					"numinlets": 1,
+					"numoutlets": 3,
+					"outlettype": ["", "", ""],
+					"parameter_enable": 0,
+					"patching_rect": [500.0, 414.0, 52.0, 22.0],
+					"presentation": 1,
+					"presentation_rect": [402.0, 70.0, 52.0, 20.0],
+					"text": "Clear"
+				}
+			},
+			{
+				"box": {
+					"id": "obj-55",
+					"maxclass": "message",
+					"numinlets": 2,
+					"numoutlets": 1,
+					"outlettype": [""],
+					"patching_rect": [500.0, 444.0, 54.0, 22.0],
+					"text": "clear 4"
+				}
+			},
+			{
+				"box": {
+					"id": "obj-56",
+					"maxclass": "number",
+					"numinlets": 1,
+					"numoutlets": 2,
+					"outlettype": ["", "bang"],
+					"patching_rect": [444.0, 478.0, 52.0, 22.0],
+					"presentation": 1,
+					"presentation_rect": [346.0, 96.0, 52.0, 20.0]
+				}
+			},
+			{
+				"box": {
+					"id": "obj-57",
+					"maxclass": "newobj",
+					"numinlets": 1,
+					"numoutlets": 1,
+					"outlettype": [""],
+					"patching_rect": [444.0, 508.0, 110.0, 22.0],
+					"text": "prepend sweep 4"
+				}
+			},
+			{
+				"box": {
+					"id": "obj-58",
+					"maxclass": "comment",
+					"fontsize": 10.0,
+					"numinlets": 1,
+					"numoutlets": 0,
+					"patching_rect": [500.0, 478.0, 50.0, 20.0],
+					"presentation": 1,
+					"presentation_rect": [402.0, 98.0, 50.0, 18.0],
+					"text": "sweep"
+				}
+			},
+			{
+				"box": {
+					"id": "obj-60",
+					"maxclass": "newobj",
+					"numinlets": 1,
+					"numoutlets": 3,
+					"outlettype": ["", "", ""],
+					"patching_rect": [480.0, 130.0, 290.0, 22.0],
+					"text": "pattr mappings @bindto pf_bridge @autorestore 1"
+				}
+			}
+		],
+		"lines": [
+			{ "patchline": { "source": ["obj-1", 0], "destination": ["obj-2", 0] } },
+			{ "patchline": { "source": ["obj-2", 0], "destination": ["obj-3", 0] } },
+			{ "patchline": { "source": ["obj-2", 1], "destination": ["obj-4", 0] } },
+			{ "patchline": { "source": ["obj-2", 2], "destination": ["obj-5", 0] } },
+			{ "patchline": { "source": ["obj-2", 3], "destination": ["obj-6", 0] } },
+			{ "patchline": { "source": ["obj-2", 4], "destination": ["obj-16", 0] } },
+			{ "patchline": { "source": ["obj-2", 5], "destination": ["obj-7", 0] } },
+			{ "patchline": { "source": ["obj-2", 6], "destination": ["obj-26", 0] } },
+			{ "patchline": { "source": ["obj-2", 7], "destination": ["obj-36", 0] } },
+			{ "patchline": { "source": ["obj-2", 8], "destination": ["obj-46", 0] } },
+			{ "patchline": { "source": ["obj-2", 9], "destination": ["obj-56", 0] } },
+			{ "patchline": { "source": ["obj-2", 10], "destination": ["obj-12", 0] } },
+			{ "patchline": { "source": ["obj-8", 0], "destination": ["obj-9", 0] } },
+			{ "patchline": { "source": ["obj-9", 0], "destination": ["obj-2", 0] } },
+			{ "patchline": { "source": ["obj-10", 0], "destination": ["obj-11", 0] } },
+			{ "patchline": { "source": ["obj-10", 1], "destination": ["obj-11", 1] } },
+			{ "patchline": { "source": ["obj-12", 0], "destination": ["obj-13", 0] } },
+			{ "patchline": { "source": ["obj-13", 0], "destination": ["obj-2", 0] } },
+			{ "patchline": { "source": ["obj-14", 0], "destination": ["obj-15", 0] } },
+			{ "patchline": { "source": ["obj-15", 0], "destination": ["obj-2", 0] } },
+			{ "patchline": { "source": ["obj-22", 0], "destination": ["obj-23", 0] } },
+			{ "patchline": { "source": ["obj-23", 0], "destination": ["obj-2", 0] } },
+			{ "patchline": { "source": ["obj-24", 0], "destination": ["obj-25", 0] } },
+			{ "patchline": { "source": ["obj-25", 0], "destination": ["obj-2", 0] } },
+			{ "patchline": { "source": ["obj-26", 0], "destination": ["obj-27", 0] } },
+			{ "patchline": { "source": ["obj-27", 0], "destination": ["obj-2", 0] } },
+			{ "patchline": { "source": ["obj-32", 0], "destination": ["obj-33", 0] } },
+			{ "patchline": { "source": ["obj-33", 0], "destination": ["obj-2", 0] } },
+			{ "patchline": { "source": ["obj-34", 0], "destination": ["obj-35", 0] } },
+			{ "patchline": { "source": ["obj-35", 0], "destination": ["obj-2", 0] } },
+			{ "patchline": { "source": ["obj-36", 0], "destination": ["obj-37", 0] } },
+			{ "patchline": { "source": ["obj-37", 0], "destination": ["obj-2", 0] } },
+			{ "patchline": { "source": ["obj-42", 0], "destination": ["obj-43", 0] } },
+			{ "patchline": { "source": ["obj-43", 0], "destination": ["obj-2", 0] } },
+			{ "patchline": { "source": ["obj-44", 0], "destination": ["obj-45", 0] } },
+			{ "patchline": { "source": ["obj-45", 0], "destination": ["obj-2", 0] } },
+			{ "patchline": { "source": ["obj-46", 0], "destination": ["obj-47", 0] } },
+			{ "patchline": { "source": ["obj-47", 0], "destination": ["obj-2", 0] } },
+			{ "patchline": { "source": ["obj-52", 0], "destination": ["obj-53", 0] } },
+			{ "patchline": { "source": ["obj-53", 0], "destination": ["obj-2", 0] } },
+			{ "patchline": { "source": ["obj-54", 0], "destination": ["obj-55", 0] } },
+			{ "patchline": { "source": ["obj-55", 0], "destination": ["obj-2", 0] } },
+			{ "patchline": { "source": ["obj-56", 0], "destination": ["obj-57", 0] } },
+			{ "patchline": { "source": ["obj-57", 0], "destination": ["obj-2", 0] } }
+		],
+		"dependency_cache": [],
+		"autosave": 0
+	}
+}

--- a/integrations/ableton/max/patternflow.bridge.js
+++ b/integrations/ableton/max/patternflow.bridge.js
@@ -1,0 +1,261 @@
+// ═══════════════════════════════════════════════════════════
+// Patternflow Bridge — Max for Live logic
+//
+// All device logic lives here; the .maxpat around it is just wiring.
+// Receives Patternflow OSC (via [udpreceive 9000]) and drives up to four
+// Live parameters through [live.remote~], one per hardware knob.
+//
+// Knobs arrive as RELATIVE deltas (the hardware has endless encoders), so
+// each slot keeps its own 0..1 accumulator. "Sweep" is how many encoder
+// clicks cover the full parameter range (24 clicks = 1 physical turn).
+//
+// Runs in the classic [js] object: ES5 only (no let/const/arrow).
+// License: MIT
+// ═══════════════════════════════════════════════════════════
+
+autowatch = 1;
+inlets = 1;
+outlets = 11;
+// 0..3  → [live.remote~] slot 1..4 ("id <n>" to bind, floats in the
+//          parameter's native min..max range to drive it)
+// 4     → status message box ("set <text>")
+// 5     → [udpsend] ("host <h>", "port <p>", outgoing OSC)
+// 6..9  → sweep number boxes ("set <n>", display only — no feedback loop)
+// 10    → host textedit ("set <hostname>")
+
+var NUM_SLOTS = 4;
+var DEVICE_RX_PORT = 9001;      // the device listens here (PF_OSC_LOCAL_PORT)
+var DEFAULT_SWEEP = 48;         // clicks for a full 0..1 sweep (2 turns)
+var HEARTBEAT_TIMEOUT_MS = 3500;
+
+var host = "patternflow.local";
+var paths = ["", "", "", ""];   // persisted Live parameter paths (dotted)
+var ids = [0, 0, 0, 0];         // resolved LiveAPI ids (session-local)
+var mins = [0, 0, 0, 0];
+var maxs = [1, 1, 1, 1];
+var acc = [0, 0, 0, 0];         // 0..1 accumulators
+var sweeps = [DEFAULT_SWEEP, DEFAULT_SWEEP, DEFAULT_SWEEP, DEFAULT_SWEEP];
+
+var initialized = false;        // true after live.thisdevice bang
+var lastBeat = 0;               // ms timestamp of last message from device
+var online = false;
+var patIdx = -1;
+var patName = "";
+
+var watchTask = new Task(watchdog);
+var watchTicks = 0;
+
+// ── status line ──────────────────────────────────────────────
+
+function setStatus(text) {
+  outlet(4, "set", text);
+}
+
+function refreshStatus() {
+  if (!online) {
+    setStatus("offline — click Connect (device on same Wi-Fi?)");
+    return;
+  }
+  var label = "connected";
+  if (patIdx >= 0) label += " · P" + patIdx;
+  if (patName !== "") label += " " + patName;
+  setStatus(label);
+}
+
+// ── init / persistence ───────────────────────────────────────
+
+// Bang from [live.thisdevice]: the Live API is only usable from here on.
+function init() {
+  initialized = true;
+  for (var i = 0; i < NUM_SLOTS; i++) {
+    bindSlot(i);
+    outlet(6 + i, "set", sweeps[i]);
+  }
+  outlet(10, "set", host);
+  watchTask.interval = 2000;
+  watchTask.repeat();
+  connect();
+}
+
+// pattr integration: [pattr mappings @bindto pf_bridge] persists this value
+// with the Live set. Paths are dotted ("live_set.tracks.0...") so each one
+// stays a single symbol; "-" marks an empty slot.
+function getvalueof() {
+  var v = [];
+  for (var i = 0; i < NUM_SLOTS; i++) v.push(paths[i] === "" ? "-" : paths[i]);
+  v.push(host);
+  for (var j = 0; j < NUM_SLOTS; j++) v.push(sweeps[j]);
+  return v;
+}
+
+function setvalueof() {
+  var v = arrayfromargs(arguments);
+  if (v.length < NUM_SLOTS + 1) return;
+  for (var i = 0; i < NUM_SLOTS; i++) {
+    paths[i] = (String(v[i]) === "-") ? "" : String(v[i]);
+  }
+  host = String(v[NUM_SLOTS]);
+  for (var j = 0; j < NUM_SLOTS; j++) {
+    var s = parseInt(v[NUM_SLOTS + 1 + j], 10);
+    if (!isNaN(s) && s > 0) sweeps[j] = s;
+  }
+  // Restore can arrive before OR after the live.thisdevice bang; if init
+  // already ran, rebind now with the restored paths.
+  if (initialized) {
+    for (var k = 0; k < NUM_SLOTS; k++) {
+      bindSlot(k);
+      outlet(6 + k, "set", sweeps[k]);
+    }
+    outlet(10, "set", host);
+  }
+}
+
+// ── connection ───────────────────────────────────────────────
+
+function sethost() {
+  var words = arrayfromargs(arguments);
+  if (words.length === 0) return;
+  host = words.join("");
+  notifyclients(); // keep pattr in sync
+  connect();
+}
+
+function connect() {
+  if (!initialized) return;
+  outlet(5, "port", DEVICE_RX_PORT);
+  outlet(5, "host", host);
+  outlet(5, "/patternflow/ping", 1);
+  setStatus("pinging " + host + " ...");
+}
+
+function watchdog() {
+  watchTicks++;
+  var now = Date.now();
+  if (online && now - lastBeat > HEARTBEAT_TIMEOUT_MS) {
+    online = false;
+    refreshStatus();
+  }
+  // While offline, quietly re-ping every other tick (4 s) so the link
+  // comes back by itself after a device reboot or Wi-Fi hiccup.
+  if (!online && initialized && (watchTicks % 2 === 0)) {
+    outlet(5, "/patternflow/ping", 1);
+  }
+}
+
+function markAlive() {
+  lastBeat = Date.now();
+  if (!online) {
+    online = true;
+    refreshStatus();
+  }
+}
+
+// ── mapping ──────────────────────────────────────────────────
+
+// UX: click the target parameter in Live first (it becomes the "selected
+// parameter"), then click Map N here.
+function map(slot) {
+  var i = slot - 1;
+  if (i < 0 || i >= NUM_SLOTS) return;
+  if (!initialized) return;
+  var view = new LiveAPI("live_set view");
+  var sel = view.get("selected_parameter");
+  var selId = (sel && sel.length >= 2) ? sel[1] : 0;
+  if (!selId) {
+    setStatus("click a Live parameter first, then Map " + slot);
+    return;
+  }
+  var param = new LiveAPI("id " + selId);
+  paths[i] = String(param.unquotedpath).split(" ").join(".");
+  notifyclients();
+  bindSlot(i);
+}
+
+function clear(slot) {
+  var i = slot - 1;
+  if (i < 0 || i >= NUM_SLOTS) return;
+  paths[i] = "";
+  ids[i] = 0;
+  notifyclients();
+  outlet(i, "id", 0); // unbind live.remote~, parameter is released
+  setStatus("slot " + slot + " cleared");
+}
+
+// Resolve a stored path to a live id, bind live.remote~, and pick up the
+// parameter's current value so the first knob move doesn't jump.
+function bindSlot(i) {
+  if (paths[i] === "") {
+    ids[i] = 0;
+    outlet(i, "id", 0);
+    return;
+  }
+  var livePath = paths[i].split(".").join(" ");
+  var param = new LiveAPI(livePath);
+  if (!param || param.id == 0) {
+    setStatus("slot " + (i + 1) + ": saved target not found — re-map");
+    ids[i] = 0;
+    outlet(i, "id", 0);
+    return;
+  }
+  ids[i] = parseInt(param.id, 10);
+  mins[i] = parseFloat(param.get("min"));
+  maxs[i] = parseFloat(param.get("max"));
+  var value = parseFloat(param.get("value"));
+  var range = maxs[i] - mins[i];
+  acc[i] = range !== 0 ? (value - mins[i]) / range : 0;
+  outlet(i, "id", ids[i]);
+  setStatus("slot " + (i + 1) + " → " + param.get("name"));
+}
+
+function sweep(slot, value) {
+  var i = slot - 1;
+  if (i < 0 || i >= NUM_SLOTS) return;
+  var s = parseInt(value, 10);
+  if (isNaN(s) || s < 1) return;
+  sweeps[i] = s;
+  notifyclients();
+}
+
+function knobDelta(i, delta) {
+  if (ids[i] === 0) return;
+  acc[i] += delta / sweeps[i];
+  if (acc[i] < 0) acc[i] = 0;
+  if (acc[i] > 1) acc[i] = 1;
+  outlet(i, mins[i] + acc[i] * (maxs[i] - mins[i]));
+}
+
+// ── incoming OSC (from [udpreceive]) ─────────────────────────
+
+function anything() {
+  var addr = String(messagename);
+  if (addr.charAt(0) !== "/") return; // not OSC — ignore unknown UI messages
+  var args = arrayfromargs(arguments);
+  markAlive();
+
+  // /patternflow/knob/N/delta <int>
+  if (addr.indexOf("/patternflow/knob/") === 0) {
+    var rest = addr.substring(18); // "N/delta" or "N/clicks"
+    var n = parseInt(rest.charAt(0), 10);
+    if (rest.substring(1) === "/delta" && n >= 1 && n <= NUM_SLOTS && args.length > 0) {
+      knobDelta(n - 1, parseFloat(args[0]));
+    }
+    return;
+  }
+  if (addr === "/patternflow/pattern/name" && args.length > 0) {
+    patName = String(args[0]);
+    refreshStatus();
+    return;
+  }
+  if (addr === "/patternflow/pattern/index" && args.length > 0) {
+    patIdx = parseInt(args[0], 10);
+    refreshStatus();
+    return;
+  }
+  // /patternflow/heartbeat, /hello, /version, /ip, /button/... — nothing to
+  // do beyond markAlive() above (buttons are a v2 feature).
+}
+
+// Plain bang (e.g. from a button while testing) re-pings.
+function bang() {
+  connect();
+}


### PR DESCRIPTION
## Summary

**Build guide (BUILD_GUIDE.md)**
- BOM is now all through-hole: removed the 0805 SMD passives (R1-R13, C1-C10, C12-C15) — bench-verified unnecessary (ESP32-S3 internal pull-ups + firmware debounce cover the encoders). Rationale and the on-module GPIO0 cold-boot fix (#16) preserved as Section 10 design notes.
- PCB ordering now explicitly points to `patternflow_v2.1_gerber.zip`, with a warning not to order the unverified `v2.2_test` Gerbers.
- Top-of-guide heads-up: photos are from an early build (minor cosmetic drift possible), and a full v3.0 revision is in progress.

**Enclosure (closes the scope of #113)**
- One-piece snap-fit enclosure promoted out of `experiment/` to `hardware/case/print-ready/oneshot/` as an official build option. Requires a ~330mm+ bed (H2S-class); does not fit P1S/256mm.
- New `divided_test_1..5.stl` in `experiment/`: 5-part split of the same design for 256mm beds — modeled, not yet print-tested. Validation tracked in #169.
- Documented in `hardware/case/README.md` and `docs/assembly/enclosure/3d-print.md`.

**Also riding along (earlier dev commits)**
- Ableton Live / Max for Live OSC bridge (`a680718`)
- Firmware OSC: rx queue drain, ping/announce, auto-learn remote host (`203a70f`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)