### PR TITLE
Ableton bridge mapping fix + K1/K2 knob numbering fix + K3 knob-map screen

### DIFF
--- a/firmware/patternflow/config.h
+++ b/firmware/patternflow/config.h
@@ -102,6 +102,8 @@ constexpr float EULER      = 2.71828182845904523536f;
 #define CLK_PIN 2
 
 // --- Encoder Pin Mapping ---
+// ENCn is the encoder at the front-panel Kn position (verified on the
+// board) — no cross-routing; keep LOGICAL_TO_PHYSICAL_KNOB an identity.
 // Encoder 1: Hue Control
 #define ENC1_A   4
 #define ENC1_B   8

--- a/firmware/patternflow/patternflow.ino
+++ b/firmware/patternflow/patternflow.ino
@@ -50,15 +50,30 @@ uint32_t oscInfoIdleAtMs = 0;
 uint32_t netInfoDrawnAtMs = 0;
 bool netInfoDirty = false;
 
+// KNOB MAP screen: K3 longpress shows which physical knob is which number
+// (front view: K1 top-right, K2 top-left, K3 bottom-right, K4 bottom-left).
+// Turning any knob lights its digit up green, so each knob can be verified
+// without leaving the screen. K3 click, a second K3 longpress, or idle exits.
+bool knobMapShowing = false;
+uint32_t knobMapIdleAtMs = 0;
+uint32_t knobMapDrawnAtMs = 0;
+bool knobMapDirty = false;
+uint32_t knobMapActiveAtMs[4] = {0, 0, 0, 0};
+
 const uint32_t MODE_HOLD_MS = 1000;
 const uint32_t BRIGHTNESS_IDLE_MS = 5000;
 const uint32_t OSC_INFO_IDLE_MS = 8000;
 const uint32_t NET_INFO_REDRAW_MS = 250;
+const uint32_t KNOB_MAP_IDLE_MS = 8000;
+const uint32_t KNOB_MAP_HILITE_MS = 600;
 const float CONTENT_NOTICE_SECONDS = 1.0f;
 
-// Front-panel logical order after left-right mirroring by original knob pairs:
-// K1 <-> K2 and K3 <-> K4.
-const int LOGICAL_TO_PHYSICAL_KNOB[4] = {1, 0, 2, 3};
+// Logical knob N = front-panel KN = physical encoder N. The PCB routes ENCn
+// straight to the Kn position (verified on the board) — an earlier build
+// mirrored K1<->K2 here, which put every K1/K2 feature on the wrong physical
+// knob. Keep this an identity unless a future enclosure actually flips the
+// panel.
+const int LOGICAL_TO_PHYSICAL_KNOB[4] = {0, 1, 2, 3};
 
 Button* logicalButton(int logicalIdx) {
   switch (LOGICAL_TO_PHYSICAL_KNOB[logicalIdx]) {
@@ -200,6 +215,46 @@ void drawNetworkInfo() {
   drawCenteredText("TURN K2/K3", 96, dim, 1);
   drawCenteredText("OSC / AUD", 106, dim, 1);
   drawCenteredText("K2 = EXIT", 118, dim, 1);
+
+  dma_display->setRotation(0);
+}
+
+// KNOB MAP screen (K3 longpress). Drawn PORTRAIT like the NETWORK screen.
+// One numbered circle per knob at its front-view corner; a digit turns green
+// for a moment while its knob is being turned. Same throttled-redraw scheme
+// as the NETWORK screen (see netInfoDrawnAtMs).
+void drawKnobMap() {
+  dma_display->setRotation(1);
+  dma_display->fillScreen(0);
+
+  uint16_t white = dma_display->color565(255, 255, 255);
+  uint16_t green = dma_display->color565(80, 220, 130);
+  uint16_t dim   = dma_display->color565(90, 90, 90);
+
+  int w = dma_display->width();   // 64 in portrait
+  int h = dma_display->height();  // 128 in portrait
+
+  drawCenteredText("KNOB MAP", (h / 2) - 10, white, 1);
+  drawCenteredText("TURN = SHOW", (h / 2) + 2, dim, 1);
+  drawCenteredText("K3 = EXIT", (h / 2) + 12, dim, 1);
+
+  // Front-view corners: K1 top-right, K2 top-left, K3 bottom-right,
+  // K4 bottom-left (indices are logical = physical after the identity map).
+  const int cx[4] = { w - 13, 13, w - 13, 13 };
+  const int cy[4] = { 14, 14, h - 14, h - 14 };
+
+  uint32_t now = millis();
+  for (int i = 0; i < 4; i++) {
+    bool active = knobMapActiveAtMs[i] != 0 &&
+                  (now - knobMapActiveAtMs[i]) < KNOB_MAP_HILITE_MS;
+    uint16_t col = active ? green : white;
+    if (active) dma_display->fillCircle(cx[i], cy[i], 10, dma_display->color565(15, 55, 30));
+    dma_display->drawCircle(cx[i], cy[i], 10, col);
+    dma_display->setTextSize(1);
+    dma_display->setTextColor(col);
+    dma_display->setCursor(cx[i] - 2, cy[i] - 3);
+    dma_display->print((char)('1' + i));
+  }
 
   dma_display->setRotation(0);
 }
@@ -359,8 +414,9 @@ void loop() {
   // click that lands outside its mode can't stay latched and fire later.
   bool k1Clicked = logicalButton(0)->clicked();
   bool k2Clicked = logicalButton(1)->clicked();
+  bool k3Clicked = logicalButton(2)->clicked();
 
-  if (!oscInfoShowing && logicalButton(0)->longPressed(MODE_HOLD_MS)) {
+  if (!oscInfoShowing && !knobMapShowing && logicalButton(0)->longPressed(MODE_HOLD_MS)) {
     brightnessAdjusting = !brightnessAdjusting;
     brightnessIdleAtMs = now;
     Serial.printf(">>> BRIGHTNESS MODE: %s (%u%%)\n",
@@ -405,7 +461,7 @@ void loop() {
 
   // K2 longpress → enter/exit the NETWORK status + toggle screen.
   // A K2 click while inside also exits, instantly (mirrors brightness mode).
-  if (logicalButton(1)->longPressed(MODE_HOLD_MS)) {
+  if (!knobMapShowing && logicalButton(1)->longPressed(MODE_HOLD_MS)) {
     oscInfoShowing = !oscInfoShowing;
     oscInfoIdleAtMs = now;
     netInfoDirty = true;
@@ -451,7 +507,36 @@ void loop() {
     }
   }
 
-  if (!oscInfoShowing && logicalButton(3)->longPressed(MODE_HOLD_MS)) {
+  // K3 longpress → enter/exit the KNOB MAP screen. A K3 click inside exits.
+  if (!oscInfoShowing && logicalButton(2)->longPressed(MODE_HOLD_MS)) {
+    knobMapShowing = !knobMapShowing;
+    knobMapIdleAtMs = now;
+    knobMapDirty = true;
+    Serial.printf(">>> KNOB MAP: %s\n", knobMapShowing ? "ON" : "OFF");
+  } else if (knobMapShowing && k3Clicked) {
+    knobMapShowing = false;
+    Serial.println(">>> KNOB MAP: OFF (click)");
+  }
+
+  if (knobMapShowing) {
+    // Light the digit of any knob being turned, then swallow the input so
+    // the pattern underneath (and OSC) don't see it.
+    for (int i = 0; i < 4; i++) {
+      if (input.knobDeltas[i] != 0) {
+        knobMapActiveAtMs[i] = now;
+        knobMapIdleAtMs = now;
+        knobMapDirty = true;
+      }
+      input.knobDeltas[i] = 0;
+      input.btnPressed[i] = false;
+    }
+    if ((now - knobMapIdleAtMs) > KNOB_MAP_IDLE_MS) {
+      knobMapShowing = false;
+      Serial.println(">>> KNOB MAP: OFF (idle)");
+    }
+  }
+
+  if (!oscInfoShowing && !knobMapShowing && logicalButton(3)->longPressed(MODE_HOLD_MS)) {
     if (currentMode == MODE_RUNNING) {
       currentMode = MODE_SELECTING;
       contentNoticeTimer = 0.0f;
@@ -500,6 +585,16 @@ void loop() {
     } else {
       // Nothing redrawn — skip the flip below so the displayed buffer
       // stays untouched (flipping to a stale back buffer flickers).
+      frameDrawn = false;
+    }
+  } else if (knobMapShowing) {
+    // Redraw on activity or at the slow poll (so highlights also fade out);
+    // same anti-flicker scheme as the NETWORK screen above.
+    if (knobMapDirty || (now - knobMapDrawnAtMs) >= NET_INFO_REDRAW_MS) {
+      drawKnobMap();
+      knobMapDrawnAtMs = now;
+      knobMapDirty = false;
+    } else {
       frameDrawn = false;
     }
   } else if (currentMode == MODE_RUNNING) {

--- a/integrations/ableton/README.md
+++ b/integrations/ableton/README.md
@@ -45,7 +45,7 @@ The device ships as a `.maxpat` (plain text, diff-able) rather than a binary `.a
 ## 3. Connect and map
 
 1. The bridge pings `patternflow.local` automatically on load. Status shows **connected · P0 …** when the device answers. If not, type the device's IP (shown on the K2 info screen) into the host field and press Enter, or click **Connect**.
-2. Click any parameter in your Live set (a synth macro, a filter cutoff…), then click **Map 1**. Knob K1 on Patternflow now drives it.
+2. Click any parameter in your Live set (a synth macro, a filter cutoff…), then click **Map 1** — or click **Map 1** first and then the parameter; both orders work. Knob K1 on Patternflow now drives it. Clicking the same Map again cancels an armed mapping.
 3. **Sweep** = how many encoder clicks cover the parameter's full range. 24 clicks = one physical turn; default 48 = two turns. Lower is more sensitive.
 4. Mappings, sweep values, and the host name are saved with your Live set.
 

--- a/integrations/ableton/docs/m4l-osc-guide.md
+++ b/integrations/ableton/docs/m4l-osc-guide.md
@@ -26,7 +26,7 @@ Things that go wrong:
 
 `live.remote~` is the only object that can move a Live parameter continuously without creating undo history and without automation-lane fighting. The gotchas:
 
-- **Bind by id**: send it `id 42` where 42 is a `LiveAPI` object id for a parameter (`DeviceParameter`). Send `id 0` to unbind.
+- **Bind by id**: send it `id 42` where 42 is a `LiveAPI` object id for a parameter (`DeviceParameter`). Send `id 0` to unbind. The `id` message goes into the **right inlet** — the left inlet only takes values, and an `id` sent there is rejected (red error in the Max window) so the parameter never locks. This one cost us an evening.
 - **The parameter locks.** While bound, the parameter is greyed out in Live's UI, shows "Mapped", and the mouse can't move it. This scares people into thinking something broke. Unbind to release it.
 - **Values are in the parameter's native range**, not 0–1. Read `min` and `max` from the parameter via `LiveAPI` and scale yourself: `out = min + v * (max - min)`. (This is what the M4L LFO does internally.)
 - **Zipper noise**: `live.remote~` accepts both signals and floats. Float messages at encoder-event rate are fine for filter sweeps; for very zipper-sensitive targets (gain on a sustained pad), interpolate with `line~ → live.remote~` at signal rate.
@@ -35,7 +35,8 @@ Things that go wrong:
 
 - **You cannot touch `LiveAPI` in global code or `loadbang`.** The API isn't ready; calls fail or return id 0. Wait for the `[live.thisdevice]` bang — that is the "Live is ready" signal.
 - **Ids are session-local; paths are not stable either.** A parameter's numeric id changes between Live sessions, and its canonical path (`live_set tracks 0 devices 1 parameters 3`) changes when tracks/devices are reordered. Persist the *path*, re-resolve to an id on load, and accept that reordering tracks may require re-mapping. (Robust tracking needs id-remap observers — v2 territory.)
-- **`selected_parameter`** (`live_set view`) is how "click a param, then click Map" works. Clicking controls *inside* an M4L device does not change Live's selected parameter, so your own Map button won't steal the selection.
+- **`selected_parameter`** (`live_set view`): don't *read* it when your Map button is clicked — on some Live/OS combos (seen on Live 12 / Windows) it reads as `id 0` by then. Instead *observe* the property and remember the last non-zero id (with a freshness window); then both orders work: param-then-Map uses the remembered id, Map-then-param arms and waits for the next selection change. Same underlying flow as Live's stock LFO.
+- **Observer callbacks run in Live's notification context**, and `live.remote~` refuses id changes from there: `Setting the id cannot be triggered by notifications. You will need to defer your response`. In `[js]`, stash the id and `Task.schedule(0)` the bind; in a patch, put `[deferlow]` before the id inlet.
 - **Getting values**: `api.get("value")` returns an array — take `[0]`. Same for `min`, `max`, `name`.
 
 ## Persistence (mappings that survive save/reload)

--- a/integrations/ableton/max/patternflow-bridge.maxpat
+++ b/integrations/ableton/max/patternflow-bridge.maxpat
@@ -44,7 +44,7 @@
 					"patching_rect": [260.0, 16.0, 460.0, 20.0],
 					"presentation": 1,
 					"presentation_rect": [4.0, 124.0, 452.0, 40.0],
-					"text": "Select a parameter in Live, then click Map. Turn a Patternflow knob to move it. Sweep = encoder clicks for the full range (24 = one physical turn)."
+					"text": "Click a parameter in Live then Map (or Map first, then the parameter). Turn a Patternflow knob to move it. Sweep = encoder clicks for the full range (24 = one physical turn)."
 				}
 			},
 			{
@@ -74,10 +74,10 @@
 				"box": {
 					"id": "obj-3",
 					"maxclass": "newobj",
-					"numinlets": 1,
+					"numinlets": 2,
 					"numoutlets": 1,
 					"outlettype": [""],
-					"patching_rect": [24.0, 210.0, 80.0, 22.0],
+					"patching_rect": [24.0, 240.0, 80.0, 22.0],
 					"text": "live.remote~"
 				}
 			},
@@ -85,10 +85,10 @@
 				"box": {
 					"id": "obj-4",
 					"maxclass": "newobj",
-					"numinlets": 1,
+					"numinlets": 2,
 					"numoutlets": 1,
 					"outlettype": [""],
-					"patching_rect": [114.0, 210.0, 80.0, 22.0],
+					"patching_rect": [114.0, 240.0, 80.0, 22.0],
 					"text": "live.remote~"
 				}
 			},
@@ -96,10 +96,10 @@
 				"box": {
 					"id": "obj-5",
 					"maxclass": "newobj",
-					"numinlets": 1,
+					"numinlets": 2,
 					"numoutlets": 1,
 					"outlettype": [""],
-					"patching_rect": [204.0, 210.0, 80.0, 22.0],
+					"patching_rect": [204.0, 240.0, 80.0, 22.0],
 					"text": "live.remote~"
 				}
 			},
@@ -107,11 +107,99 @@
 				"box": {
 					"id": "obj-6",
 					"maxclass": "newobj",
+					"numinlets": 2,
+					"numoutlets": 1,
+					"outlettype": [""],
+					"patching_rect": [294.0, 240.0, 80.0, 22.0],
+					"text": "live.remote~"
+				}
+			},
+			{
+				"box": {
+					"id": "obj-70",
+					"maxclass": "newobj",
+					"numinlets": 2,
+					"numoutlets": 2,
+					"outlettype": ["", ""],
+					"patching_rect": [24.0, 160.0, 60.0, 22.0],
+					"text": "route id"
+				}
+			},
+			{
+				"box": {
+					"id": "obj-71",
+					"maxclass": "newobj",
+					"numinlets": 2,
+					"numoutlets": 2,
+					"outlettype": ["", ""],
+					"patching_rect": [114.0, 160.0, 60.0, 22.0],
+					"text": "route id"
+				}
+			},
+			{
+				"box": {
+					"id": "obj-72",
+					"maxclass": "newobj",
+					"numinlets": 2,
+					"numoutlets": 2,
+					"outlettype": ["", ""],
+					"patching_rect": [204.0, 160.0, 60.0, 22.0],
+					"text": "route id"
+				}
+			},
+			{
+				"box": {
+					"id": "obj-73",
+					"maxclass": "newobj",
+					"numinlets": 2,
+					"numoutlets": 2,
+					"outlettype": ["", ""],
+					"patching_rect": [294.0, 160.0, 60.0, 22.0],
+					"text": "route id"
+				}
+			},
+			{
+				"box": {
+					"id": "obj-74",
+					"maxclass": "newobj",
 					"numinlets": 1,
 					"numoutlets": 1,
 					"outlettype": [""],
-					"patching_rect": [294.0, 210.0, 80.0, 22.0],
-					"text": "live.remote~"
+					"patching_rect": [44.0, 196.0, 70.0, 22.0],
+					"text": "prepend id"
+				}
+			},
+			{
+				"box": {
+					"id": "obj-75",
+					"maxclass": "newobj",
+					"numinlets": 1,
+					"numoutlets": 1,
+					"outlettype": [""],
+					"patching_rect": [134.0, 196.0, 70.0, 22.0],
+					"text": "prepend id"
+				}
+			},
+			{
+				"box": {
+					"id": "obj-76",
+					"maxclass": "newobj",
+					"numinlets": 1,
+					"numoutlets": 1,
+					"outlettype": [""],
+					"patching_rect": [224.0, 196.0, 70.0, 22.0],
+					"text": "prepend id"
+				}
+			},
+			{
+				"box": {
+					"id": "obj-77",
+					"maxclass": "newobj",
+					"numinlets": 1,
+					"numoutlets": 1,
+					"outlettype": [""],
+					"patching_rect": [314.0, 196.0, 70.0, 22.0],
+					"text": "prepend id"
 				}
 			},
 			{
@@ -637,10 +725,22 @@
 		],
 		"lines": [
 			{ "patchline": { "source": ["obj-1", 0], "destination": ["obj-2", 0] } },
-			{ "patchline": { "source": ["obj-2", 0], "destination": ["obj-3", 0] } },
-			{ "patchline": { "source": ["obj-2", 1], "destination": ["obj-4", 0] } },
-			{ "patchline": { "source": ["obj-2", 2], "destination": ["obj-5", 0] } },
-			{ "patchline": { "source": ["obj-2", 3], "destination": ["obj-6", 0] } },
+			{ "patchline": { "source": ["obj-2", 0], "destination": ["obj-70", 0] } },
+			{ "patchline": { "source": ["obj-2", 1], "destination": ["obj-71", 0] } },
+			{ "patchline": { "source": ["obj-2", 2], "destination": ["obj-72", 0] } },
+			{ "patchline": { "source": ["obj-2", 3], "destination": ["obj-73", 0] } },
+			{ "patchline": { "source": ["obj-70", 0], "destination": ["obj-74", 0] } },
+			{ "patchline": { "source": ["obj-71", 0], "destination": ["obj-75", 0] } },
+			{ "patchline": { "source": ["obj-72", 0], "destination": ["obj-76", 0] } },
+			{ "patchline": { "source": ["obj-73", 0], "destination": ["obj-77", 0] } },
+			{ "patchline": { "source": ["obj-74", 0], "destination": ["obj-3", 1] } },
+			{ "patchline": { "source": ["obj-75", 0], "destination": ["obj-4", 1] } },
+			{ "patchline": { "source": ["obj-76", 0], "destination": ["obj-5", 1] } },
+			{ "patchline": { "source": ["obj-77", 0], "destination": ["obj-6", 1] } },
+			{ "patchline": { "source": ["obj-70", 1], "destination": ["obj-3", 0] } },
+			{ "patchline": { "source": ["obj-71", 1], "destination": ["obj-4", 0] } },
+			{ "patchline": { "source": ["obj-72", 1], "destination": ["obj-5", 0] } },
+			{ "patchline": { "source": ["obj-73", 1], "destination": ["obj-6", 0] } },
 			{ "patchline": { "source": ["obj-2", 4], "destination": ["obj-16", 0] } },
 			{ "patchline": { "source": ["obj-2", 5], "destination": ["obj-7", 0] } },
 			{ "patchline": { "source": ["obj-2", 6], "destination": ["obj-26", 0] } },

--- a/integrations/ableton/max/patternflow.bridge.js
+++ b/integrations/ableton/max/patternflow.bridge.js
@@ -67,6 +67,7 @@ function refreshStatus() {
 // Bang from [live.thisdevice]: the Live API is only usable from here on.
 function init() {
   initialized = true;
+  watchSelection();
   for (var i = 0; i < NUM_SLOTS; i++) {
     bindSlot(i);
     outlet(6 + i, "set", sweeps[i]);
@@ -152,20 +153,77 @@ function markAlive() {
 
 // ── mapping ──────────────────────────────────────────────────
 
-// UX: click the target parameter in Live first (it becomes the "selected
-// parameter"), then click Map N here.
+// Mapping — both orders work:
+//   click-first: click the target parameter in Live, then click Map N.
+//     Reading selected_parameter at Map-click time is unreliable (the Map
+//     click itself clears the selection on some Live/OS combos), so we
+//     observe selection changes continuously and remember the last real
+//     one for SEL_FRESH_MS.
+//   arm-then-click (stock-LFO style): click Map N, then click the parameter.
+// Clicking the same armed Map again cancels.
+var SEL_FRESH_MS = 10000;
+var armSlot = -1;
+var selWatcher = null;
+var lastSelId = 0;
+var lastSelMs = 0;
+
+function watchSelection() {
+  if (!selWatcher) {
+    selWatcher = new LiveAPI(onSelChange, "live_set view");
+    selWatcher.property = "selected_parameter";
+  }
+}
+
 function map(slot) {
   var i = slot - 1;
   if (i < 0 || i >= NUM_SLOTS) return;
   if (!initialized) return;
-  var view = new LiveAPI("live_set view");
-  var sel = view.get("selected_parameter");
-  var selId = (sel && sel.length >= 2) ? sel[1] : 0;
-  if (!selId) {
-    setStatus("click a Live parameter first, then Map " + slot);
+  if (armSlot === i) { // second click on the same Map cancels
+    armSlot = -1;
+    refreshStatus();
     return;
   }
-  var param = new LiveAPI("id " + selId);
+  armSlot = i;
+  // click-first flow: a parameter selected moments ago maps right away
+  // (direct call is fine here — a UI click, not a notification)
+  if (lastSelId && (Date.now() - lastSelMs) <= SEL_FRESH_MS) {
+    applySelected(lastSelId);
+  }
+  if (armSlot >= 0) setStatus("Map " + slot + ": now click a parameter in Live");
+}
+
+// The observer callback runs in Live's notification context, from which
+// live.remote~ refuses id changes ("Setting the id cannot be triggered by
+// notifications"). Stash the id and hop to the scheduler via a Task before
+// touching the outlets.
+var pendingSelId = 0;
+var applyTask = new Task(function () {
+  var id = pendingSelId;
+  pendingSelId = 0;
+  applySelected(id);
+});
+
+function onSelChange(args) {
+  var id = 0;
+  for (var k = 0; k < args.length - 1; k++) {
+    if (String(args[k]) === "id") { id = parseInt(args[k + 1], 10); break; }
+  }
+  if (!id) return; // selection cleared — keep remembering the last real one
+  lastSelId = id;
+  lastSelMs = Date.now();
+  if (armSlot < 0) return;
+  pendingSelId = id;
+  applyTask.schedule(0);
+}
+
+function applySelected(id) {
+  if (armSlot < 0 || !id || isNaN(id)) return;
+  var i = armSlot;
+  var param = new LiveAPI("id " + id);
+  if (!param || param.id == 0) return;
+  if (String(param.type) !== "DeviceParameter") return; // clip/track/etc — keep waiting
+  armSlot = -1;
+  lastSelId = 0; // consumed — the next Map needs a fresh parameter click
   paths[i] = String(param.unquotedpath).split(" ").join(".");
   notifyclients();
   bindSlot(i);

--- a/web/src/components/3d/HeroScene.tsx
+++ b/web/src/components/3d/HeroScene.tsx
@@ -54,6 +54,17 @@ void main() {
 
 useGLTF.preload('/3dforweb.glb');
 
+// The GLB knob meshes are named after the PCB encoder nets, and K1/K2 are
+// cross-routed on the official board (see firmware config.h): the mesh at the
+// physical K1 position is named "c2" and vice versa. Remap mesh name → knob id
+// so the on-screen knobs behave like the physical ones.
+const MESH_TO_KNOB: Record<string, 'c1' | 'c2' | 'c3' | 'c4'> = {
+  c1: 'c2',
+  c2: 'c1',
+  c3: 'c3',
+  c4: 'c4',
+};
+
 // Removed hardcoded ACTIVE_PATTERN
 
 function Model() {
@@ -152,7 +163,8 @@ function Model() {
       
       lastMouseAngle.current = currentAngle;
       
-      const knobName = activeKnobRef.current.name as 'c1' | 'c2' | 'c3' | 'c4';
+      const knobName = MESH_TO_KNOB[activeKnobRef.current.name];
+      if (!knobName) return;
       
       // 노브 시각적 회전 (시계방향 마우스 회전 시 3D 모델도 시계방향 회전)
       activeKnobRef.current.rotation.y -= deltaAngle; 


### PR DESCRIPTION
## Summary

Two sessions of hardware-in-the-loop debugging, all verified on the physical device (Live 12.2.7 / Max 9 / Windows 11):

### Ableton bridge actually maps now (`d314452`)
- **live.remote~ never bound**: the patch fed `id` messages into the left inlet; they belong in the right inlet. Split per slot with `route id` + `prepend id`.
- **selected_parameter reads as id 0 at Map-click time** on Live 12/Windows — switched to observing the property with a 10 s last-selection memory, so both param-then-Map and Map-then-param orders work.
- **Observer callbacks can't drive live.remote~** ("Setting the id cannot be triggered by notifications") — bind is deferred via `Task.schedule(0)`.
- All three gotchas documented in `m4l-osc-guide.md`.

### K1/K2 knob numbering (`50449d5`)
- `LOGICAL_TO_PHYSICAL_KNOB` still mirrored K1↔K2, so every K1 feature (brightness hold, OSC `/knob/1`, hue) landed on the physical K2 encoder. Table is now an identity; pin defines untouched so `patternflow_stream` and `encoder_test` stay correct.
- The web hero simulator had the same swap baked into the GLB mesh names — remapped mesh → knob id in `HeroScene`.

### New: KNOB MAP screen (K3 longpress)
Numbered circles at the four front-view corners (K1 top-right, K2 top-left, K3 bottom-right, K4 bottom-left); turning a knob lights its digit green. Exit via K3 click, second longpress, or 8 s idle.

## Test plan
- [x] Bridge: Map both orders, parameter locks, hardware knob drives it
- [x] Physical K1–K4 match OSC knob numbers and web simulator
- [x] K3 longpress overlay + live green highlight per knob
- [x] Brightness (K1), network (K2), select (K4) modes unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)