### PR TITLE
feat(web): interactive project map for Inside status page

### DIFF
--- a/hardware/case/print-ready/experiment/divided_test_1.stl
+++ b/hardware/case/print-ready/experiment/divided_test_1.stl
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:560d85fbb05dc82de42123ceab7cea39929034b528426ce5ef67342743cbd390
-size 13134
+oid sha256:f9b097bc93ed4d2d419656d4c23a138f21d70d37aac9feddf6f3d878b4a55383
+size 14884

--- a/hardware/case/print-ready/experiment/divided_test_2.stl
+++ b/hardware/case/print-ready/experiment/divided_test_2.stl
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:bef9aed3a7b4aac31a5fb9a1536a5c6f4834baf1dca3fd39a0916e3d10b2eff5
-size 53484
+oid sha256:629a71b01ff250ddbf122d20efbe1df543799a6511e9e21b34584809093af1dc
+size 50084

--- a/hardware/case/print-ready/experiment/divided_test_3.stl
+++ b/hardware/case/print-ready/experiment/divided_test_3.stl
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ba4c9d0a2ae76c9f762d1392d585caa0803c960d9e80a9245c173cc7ebbba91b
-size 18384
+oid sha256:de27cd1244dbd748bc1ecfadfe05e156a402fdf4581fb7d503d19ab428a729f5
+size 18784

--- a/hardware/case/print-ready/oneshot/oneshot_1.stl
+++ b/hardware/case/print-ready/oneshot/oneshot_1.stl
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:420166ece5c1e94ad2d26292ffc09bc386bb45af34df77cf3ebeff5319fedddb
-size 203584
+oid sha256:2c9df20a6b6eab54b207b00dcf798daf242d50ee4dda1f62381fc61c5c4f7a74
+size 200084

--- a/hardware/case/print-ready/oneshot/oneshot_2.stl
+++ b/hardware/case/print-ready/oneshot/oneshot_2.stl
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:406c058af64f913e23dedfc927a58fa2f6de2d02fa9a303f1e1d62ce4ffeaeb4
+oid sha256:c72cabbbb096e3818e1b5cfd3d1f421ae2eb2996de7e295791549c4980709d0d
 size 57984

--- a/hardware/case/source/patternflow_v1.blend
+++ b/hardware/case/source/patternflow_v1.blend
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b7f71d39eede4283efecd7ec2a6e15ec7dba68eebba17ce0616995c00d27885c
-size 40358548
+oid sha256:76108e688dffc3080c82ded2f29dad2dc87a0fcef4de84e30da278a49d0effb3
+size 40558799

--- a/web/src/app/roadmap/Roadmap.module.css
+++ b/web/src/app/roadmap/Roadmap.module.css
@@ -321,6 +321,30 @@
   stroke: var(--pf-ink-muted);
 }
 
+/* Secondary = level-2 nodes, only ever visible in the detailed view —
+   lighter fill and a muted, thinner border keeps overview nodes dominant. */
+.nodeDoneSecondary {
+  fill: var(--pf-cream-2);
+  stroke: var(--pf-ink-faint);
+  stroke-width: 1.1;
+}
+
+.nodeGroup:hover .nodeDoneSecondary {
+  fill: #fff;
+  stroke: var(--pf-ink-muted);
+}
+
+.nodePlannedSecondary {
+  fill: transparent;
+  stroke: var(--pf-ink-ghost);
+  stroke-width: 1.1;
+  stroke-dasharray: 4 3;
+}
+
+.nodeGroup:hover .nodePlannedSecondary {
+  stroke: var(--pf-ink-faint);
+}
+
 .nodeSelected {
   fill: var(--pf-ink);
   stroke: var(--pf-ink);
@@ -329,6 +353,8 @@
 
 .nodeText,
 .nodeTextPlanned,
+.nodeTextSecondary,
+.nodeTextPlannedSecondary,
 .nodeTextSelected {
   font-family: var(--pf-mono);
   font-size: 15px;
@@ -342,6 +368,14 @@
 
 .nodeTextPlanned {
   fill: var(--pf-ink-muted);
+}
+
+.nodeTextSecondary {
+  fill: var(--pf-ink-muted);
+}
+
+.nodeTextPlannedSecondary {
+  fill: var(--pf-ink-faint);
 }
 
 .nodeTextSelected {

--- a/web/src/app/roadmap/Roadmap.module.css
+++ b/web/src/app/roadmap/Roadmap.module.css
@@ -137,11 +137,18 @@
   border-top: 2px dashed var(--pf-ink-faint);
 }
 
-.canvas {
+/* .viewport does NOT clip, so the popup can never be cut off by the
+   pannable canvas underneath it — only the canvas itself clips. */
+.viewport {
   position: relative;
-  overflow: hidden;
   flex: 1;
   min-height: 0;
+}
+
+.canvas {
+  position: absolute;
+  inset: 0;
+  overflow: hidden;
   border-top: 1px solid var(--pf-rule);
   background: #fbf8f2;
   cursor: grab;
@@ -344,11 +351,13 @@
 .popup {
   position: absolute;
   z-index: 10;
+  max-height: calc(100% - 24px);
   padding: 18px 20px 20px;
   background: #fff;
   border: 1px solid var(--pf-ink);
   border-radius: 12px;
   box-shadow: 6px 6px 0 rgba(20, 20, 20, 0.08);
+  overflow-y: auto;
   cursor: auto;
 }
 

--- a/web/src/app/roadmap/Roadmap.module.css
+++ b/web/src/app/roadmap/Roadmap.module.css
@@ -351,7 +351,6 @@
 .popup {
   position: absolute;
   z-index: 10;
-  max-height: calc(100% - 24px);
   padding: 18px 20px 20px;
   background: #fff;
   border: 1px solid var(--pf-ink);

--- a/web/src/app/roadmap/RoadmapMap.tsx
+++ b/web/src/app/roadmap/RoadmapMap.tsx
@@ -257,17 +257,23 @@ export default function RoadmapMap() {
       : [];
 
   // Popup lives outside the zoomed layer (so its text never scales) and is
-  // positioned in screen space next to the node.
-  let popupPos: { left: number; top: number } | null = null;
+  // positioned in screen space next to the node. maxHeight is computed in
+  // real pixels from the actual viewport size — a percentage-based CSS
+  // max-height doesn't reliably resolve inside this flex layout, and the
+  // popup would silently get clipped by an ancestor's overflow:hidden
+  // instead of scrolling.
+  let popupPos: { left: number; top: number; maxHeight: number } | null = null;
   if (selected) {
     const cw = canvasSize.w;
     const ch = canvasSize.h;
+    const margin = 14;
     const rightEdge = (selected.x + selected.w) * zoom + pan.x;
     const leftEdge = selected.x * zoom + pan.x;
     const left =
       rightEdge + 18 + POPUP_W > cw ? leftEdge - POPUP_W - 18 : rightEdge + 18;
-    const top = Math.min(Math.max(selected.y * zoom + pan.y - 90, 14), ch - 300);
-    popupPos = { left, top };
+    const top = Math.min(Math.max(selected.y * zoom + pan.y - 90, margin), ch - 160 - margin);
+    const maxHeight = Math.max(160, ch - top - margin);
+    popupPos = { left, top, maxHeight };
   }
 
   return (
@@ -524,7 +530,12 @@ export default function RoadmapMap() {
         {selected && popupPos && (
           <div
             className={styles.popup}
-            style={{ left: popupPos.left, top: popupPos.top, width: POPUP_W }}
+            style={{
+              left: popupPos.left,
+              top: popupPos.top,
+              width: POPUP_W,
+              maxHeight: popupPos.maxHeight,
+            }}
             onPointerDown={(event) => event.stopPropagation()}
           >
               <div className={styles.popupHead}>

--- a/web/src/app/roadmap/RoadmapMap.tsx
+++ b/web/src/app/roadmap/RoadmapMap.tsx
@@ -479,16 +479,27 @@ export default function RoadmapMap() {
 
             {nodes.map((n) => {
               const isSelected = n.id === selectedId;
+              // Level 2 nodes only exist in the detailed view — give them a
+              // visibly secondary color so overview-level nodes keep priority.
+              const secondary = n.level === 2 && !isSelected;
               const boxClass = isSelected
                 ? styles.nodeSelected
                 : n.status === 'planned'
-                  ? styles.nodePlanned
-                  : styles.nodeDone;
+                  ? secondary
+                    ? styles.nodePlannedSecondary
+                    : styles.nodePlanned
+                  : secondary
+                    ? styles.nodeDoneSecondary
+                    : styles.nodeDone;
               const textClass = isSelected
                 ? styles.nodeTextSelected
                 : n.status === 'planned'
-                  ? styles.nodeTextPlanned
-                  : styles.nodeText;
+                  ? secondary
+                    ? styles.nodeTextPlannedSecondary
+                    : styles.nodeTextPlanned
+                  : secondary
+                    ? styles.nodeTextSecondary
+                    : styles.nodeText;
               return (
                 <g
                   key={n.id}

--- a/web/src/app/roadmap/RoadmapMap.tsx
+++ b/web/src/app/roadmap/RoadmapMap.tsx
@@ -329,19 +329,20 @@ export default function RoadmapMap() {
         </div>
       </div>
 
-      <div
-        ref={canvasRef}
-        className={styles.canvas}
-        onPointerDown={onPointerDown}
-        onPointerMove={onPointerMove}
-        onPointerUp={onPointerUp}
-        onPointerCancel={onPointerUp}
-      >
+      <div className={styles.viewport}>
         <div
-          className={styles.layer}
-          style={{ transform: `translate(${pan.x}px, ${pan.y}px) scale(${zoom})` }}
+          ref={canvasRef}
+          className={styles.canvas}
+          onPointerDown={onPointerDown}
+          onPointerMove={onPointerMove}
+          onPointerUp={onPointerUp}
+          onPointerCancel={onPointerUp}
         >
-          <svg
+          <div
+            className={styles.layer}
+            style={{ transform: `translate(${pan.x}px, ${pan.y}px) scale(${zoom})` }}
+          >
+            <svg
             className={styles.mapSvg}
             viewBox={`0 0 ${width} ${HEIGHT}`}
             width={width}
@@ -517,6 +518,7 @@ export default function RoadmapMap() {
               );
             })}
           </svg>
+          </div>
         </div>
 
         {selected && popupPos && (

--- a/web/src/app/roadmap/roadmap-data.ts
+++ b/web/src/app/roadmap/roadmap-data.ts
@@ -374,9 +374,9 @@ export const NODES: RoadmapNode[] = [
     date: '2026-04-21',
     title: 'First PCBWay order',
     status: 'done',
-    level: 2,
+    level: 1,
     detail:
-      'Serene from PCBWay sent a DM on 04-20, having seen the Reddit post, offering to sponsor a PCB order — the very first PCB, ordered free the next day, before the repo was even public. The relationship went public as a sponsor section on the website two months later.',
+      'Serene from PCBWay sent a DM on 04-20, having seen the Reddit post, offering to sponsor a PCB order — the very first PCB, ordered free the next day, before the repo was even public. PCBWay has kept sponsoring since, through the 3D-printing experiments and the v2.2 gerber order.',
   },
   {
     id: 'biz-reddit',
@@ -409,14 +409,14 @@ export const NODES: RoadmapNode[] = [
       'The Crowd Supply contract was signed — the commitment that Patternflow becomes a product you can order, not just a repo you can build from.',
   },
   {
-    id: 'biz-pcbway-sponsor',
+    id: 'biz-nath-build',
     lane: 'community',
     date: '2026-06-05',
-    title: 'PCBWay sponsorship',
+    title: 'First community build',
     status: 'done',
     level: 2,
     detail:
-      'The PCBWay relationship became a public sponsorship — a section on the website, and around the same time the first fully independent community build (Nath) went up on the build map.',
+      'The first fully independent community build (Nath) went up on the build map — proof the guide worked for someone who wasn’t the author.',
   },
   {
     id: 'biz-prelaunch',

--- a/web/src/app/roadmap/roadmap-data.ts
+++ b/web/src/app/roadmap/roadmap-data.ts
@@ -349,6 +349,16 @@ export const NODES: RoadmapNode[] = [
 
   // Community & business
   {
+    id: 'biz-pcbway-order',
+    lane: 'community',
+    date: '2026-04-21',
+    title: 'First PCBWay order',
+    status: 'done',
+    level: 2,
+    detail:
+      'The very first PCB order placed with PCBWay, right after finishing the first board design — before the repo was even public. That relationship grew into a formal sponsorship two months later.',
+  },
+  {
     id: 'biz-reddit',
     lane: 'community',
     date: '2026-04-23',
@@ -371,7 +381,7 @@ export const NODES: RoadmapNode[] = [
   {
     id: 'biz-cs',
     lane: 'community',
-    date: '2026-05-30',
+    date: '2026-05-29',
     title: 'Crowd Supply contract',
     status: 'done',
     level: 1,
@@ -379,14 +389,14 @@ export const NODES: RoadmapNode[] = [
       'The Crowd Supply contract was signed — the commitment that Patternflow becomes a product you can order, not just a repo you can build from.',
   },
   {
-    id: 'biz-pcbway',
+    id: 'biz-pcbway-sponsor',
     lane: 'community',
     date: '2026-06-05',
-    title: 'PCBWay + first build',
+    title: 'PCBWay sponsorship',
     status: 'done',
     level: 2,
     detail:
-      'PCBWay sponsorship landed, and the first fully independent community build (Nath) went up on the build map.',
+      'The PCBWay relationship became a public sponsorship — a section on the website, and around the same time the first fully independent community build (Nath) went up on the build map.',
   },
   {
     id: 'biz-prelaunch',

--- a/web/src/app/roadmap/roadmap-data.ts
+++ b/web/src/app/roadmap/roadmap-data.ts
@@ -76,7 +76,7 @@ export const NODES: RoadmapNode[] = [
     status: 'done',
     level: 1,
     detail:
-      'Test board that moves power input to USB-C and goes fully SMD-free. Once verified, this board gets promoted to v3. Moving the power connector also breaks the current enclosure, which was designed around v2.1 — so the case follows.',
+      'Test board that moves power input to USB-C and goes fully SMD-free. Ordered on 2026-06-30 through a PCBWay gerber sponsorship. Once verified, this board gets promoted to v3. Moving the power connector also breaks the current enclosure, which was designed around v2.1 — so the case follows.',
   },
   {
     id: 'pcb-v3',
@@ -120,7 +120,7 @@ export const NODES: RoadmapNode[] = [
     status: 'done',
     level: 2,
     detail:
-      'A long run of 3D-printing experiments through June: flat plates, easybond, big-oneshot, easyfit with alignment tabs, one-shot print ribs, a wall-mount hanger — searching for a case that prints reliably without support pain.',
+      'A long run of 3D-printing experiments through June, kicked off by a PCBWay 3D-printing sponsorship that funded test prints: flat plates, easybond, big-oneshot, easyfit with alignment tabs, one-shot print ribs, a wall-mount hanger — searching for a case that prints reliably without support pain.',
   },
   {
     id: 'case-snapfit',

--- a/web/src/app/roadmap/roadmap-data.ts
+++ b/web/src/app/roadmap/roadmap-data.ts
@@ -297,6 +297,26 @@ export const NODES: RoadmapNode[] = [
     links: [{ label: 'origin.patternflow.work', href: 'https://origin.patternflow.work/' }],
   },
   {
+    id: 'tools-paik',
+    lane: 'tools',
+    date: '2026-01-28',
+    title: 'Nam June Paik Art Center',
+    status: 'done',
+    level: 2,
+    detail:
+      'The project’s second root. The trip was originally to see a different artist’s exhibition — Paik’s own permanent works, Participation TV and Robot K-456, and a 20th-anniversary memorial performance were all chance encounters the same day. Months later, an assignment in an "Authorial Design Studio" class asking students to reinterpret a senior artist gave that chance visit a name: Patternflow as a contemporary Participation TV, where the audience becomes the creator instead of just the viewer.',
+    links: [
+      {
+        label: 'Patternflow in 30 days (journal)',
+        href: 'https://patternflow.work/journal/v1-30-days/en',
+      },
+      {
+        label: 'Nam June Paik, Me, Patternflow (journal)',
+        href: 'https://patternflow.work/journal/nam-june-paik-me-patternflow/en',
+      },
+    ],
+  },
+  {
     id: 'tools-editor',
     lane: 'tools',
     date: '2026-05-04',
@@ -356,7 +376,7 @@ export const NODES: RoadmapNode[] = [
     status: 'done',
     level: 2,
     detail:
-      'The very first PCB order placed with PCBWay, right after finishing the first board design — before the repo was even public. That relationship grew into a formal sponsorship two months later.',
+      'Serene from PCBWay sent a DM on 04-20, having seen the Reddit post, offering to sponsor a PCB order — the very first PCB, ordered free the next day, before the repo was even public. The relationship went public as a sponsor section on the website two months later.',
   },
   {
     id: 'biz-reddit',

--- a/web/src/app/roadmap/roadmap-data.ts
+++ b/web/src/app/roadmap/roadmap-data.ts
@@ -302,7 +302,7 @@ export const NODES: RoadmapNode[] = [
     date: '2026-01-28',
     title: 'Nam June Paik Art Center',
     status: 'done',
-    level: 2,
+    level: 1,
     detail:
       'The project’s second root. The trip was originally to see a different artist’s exhibition — Paik’s own permanent works, Participation TV and Robot K-456, and a 20th-anniversary memorial performance were all chance encounters the same day. Months later, an assignment in an "Authorial Design Studio" class asking students to reinterpret a senior artist gave that chance visit a name: Patternflow as a contemporary Participation TV, where the audience becomes the creator instead of just the viewer.',
     links: [


### PR DESCRIPTION
## Summary
- Replaces the raw open-issues "Project status" page with a full-screen, pannable/zoomable project map (`/roadmap`): six lanes (PCB, enclosure, guides, firmware, pattern tools, community), shipped work at real dates, planned work in a single future zone, and a v3.0.0 build-release gate around the hardware+guides scope.
- Corrects several real-world dates (Crowd Supply contract, PCBWay origin) and adds the Nam June Paik Art Center visit as the project's second root, alongside the original origin website.
- Fixes a popup-clipping bug (computed max-height in real pixels instead of relying on unreliable percentage CSS) and adds level-based node coloring so overview vs. detail-only nodes read as a visual hierarchy.
- Also includes a small hardware fix: enclosure USB-C adapter clearance, corrected after the rotary encoder position changed.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `eslint` clean
- [ ] Manual check of `/roadmap` in browser (pan, zoom, node click popups, overview/detailed toggle)