### PR TITLE
docs(discussion): add "Share your build" form for Show and tell

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/show-and-tell.yml
+++ b/.github/DISCUSSION_TEMPLATE/show-and-tell.yml
@@ -1,0 +1,27 @@
+title: "Share your build"
+labels: ["area:community"]
+body:
+  - type: input
+    attributes:
+      label: Project / Maker name
+      description: How you want to be credited on the globe
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Short intro
+      description: About 3 sentences is enough
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Links
+      description: Your app, project page, video — anything
+  - type: textarea
+    attributes:
+      label: Images
+      description: Drag & drop ~3 screenshots or photos here
+  - type: input
+    attributes:
+      label: Location (optional)
+      description: City or country, so we can place you on the globe


### PR DESCRIPTION
Adds a structured discussion form so makers can submit their builds for the globe.

**File:** `.github/DISCUSSION_TEMPLATE/show-and-tell.yml` (filename matches the `show-and-tell` category slug, so GitHub attaches it to the existing **Show and tell** category)

**Fields:** Project / Maker name (required), Short intro (required), Links, Images, Location (optional).

**Label:** `area:community` (reuses existing taxonomy — no new label needed).

Takes effect once merged to `main` (discussion templates only load from the default branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)