### PR TITLE
docs(discussion): make build location required

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/show-and-tell.yml
+++ b/.github/DISCUSSION_TEMPLATE/show-and-tell.yml
@@ -23,5 +23,7 @@ body:
       description: Drag & drop ~3 screenshots or photos here
   - type: input
     attributes:
-      label: Location (optional)
+      label: Location
       description: City or country, so we can place you on the globe
+    validations:
+      required: true


### PR DESCRIPTION
Follow-up to #185. Location drives placement on the interactive globe, so it should be required rather than optional.

- `Location (optional)` → `Location` with `required: true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)