### PR TITLE
SEO: make journal indexable (drop language-sniff redirect, add canonical + hreflang)

### DIFF
--- a/web/src/app/journal/[slug]/en/page.tsx
+++ b/web/src/app/journal/[slug]/en/page.tsx
@@ -31,6 +31,14 @@ export async function generateMetadata({
   return {
     title: `${post.title} / Patternflow Journal`,
     description: post.excerpt,
+    alternates: {
+      canonical: `/journal/${post.slug}/en`,
+      languages: {
+        ko: `/journal/${post.slug}`,
+        en: `/journal/${post.slug}/en`,
+        "x-default": `/journal/${post.slug}/en`,
+      },
+    },
     openGraph: {
       title: post.title,
       description: post.excerpt,

--- a/web/src/app/journal/[slug]/page.tsx
+++ b/web/src/app/journal/[slug]/page.tsx
@@ -31,6 +31,14 @@ export async function generateMetadata({
   return {
     title: `${post.title} / Patternflow Journal`,
     description: post.excerpt,
+    alternates: {
+      canonical: `/journal/${post.slug}`,
+      languages: {
+        ko: `/journal/${post.slug}`,
+        en: `/journal/${post.slug}/en`,
+        "x-default": `/journal/${post.slug}/en`,
+      },
+    },
     openGraph: {
       title: post.title,
       description: post.excerpt,

--- a/web/src/app/journal/en/page.tsx
+++ b/web/src/app/journal/en/page.tsx
@@ -5,6 +5,14 @@ import { getAllJournalPosts } from "@/lib/journal";
 export const metadata: Metadata = {
   title: "Journal / Patternflow",
   description: "Writing and notes from Patternflow.",
+  alternates: {
+    canonical: "/journal/en",
+    languages: {
+      ko: "/journal",
+      en: "/journal/en",
+      "x-default": "/journal/en",
+    },
+  },
 };
 
 export default function EnglishJournalPage() {

--- a/web/src/app/journal/page.tsx
+++ b/web/src/app/journal/page.tsx
@@ -5,6 +5,14 @@ import { getAllJournalPosts } from "@/lib/journal";
 export const metadata: Metadata = {
   title: "Journal / Patternflow",
   description: "Writing and notes from Patternflow.",
+  alternates: {
+    canonical: "/journal",
+    languages: {
+      ko: "/journal",
+      en: "/journal/en",
+      "x-default": "/journal/en",
+    },
+  },
 };
 
 export default function JournalPage() {

--- a/web/src/proxy.ts
+++ b/web/src/proxy.ts
@@ -5,29 +5,13 @@ const ONE_YEAR_SECONDS = 60 * 60 * 24 * 365;
 const JOURNAL_ASSET_EXTENSION_PATTERN = /\.[a-z0-9]+$/i;
 
 function preferredJournalLang(request: NextRequest) {
+  // Cookie only (set when the user picks a language via ?lang=). No
+  // Accept-Language guessing: crawlers request with English headers, and
+  // auto-redirecting them made every Korean journal URL unindexable.
+  // Search engines route languages via hreflang instead.
   const cookieLang = request.cookies.get(LANGUAGE_COOKIE)?.value;
   if (cookieLang === "ko" || cookieLang === "en") return cookieLang;
-
-  const acceptLanguage = request.headers.get("accept-language") ?? "";
-  const languages = acceptLanguage
-    .split(",")
-    .map((item) => {
-      const [tag, qPart] = item.trim().split(";q=");
-      return {
-        tag: tag.toLowerCase(),
-        quality: qPart ? Number(qPart) : 1,
-      };
-    })
-    .filter(({ tag }) => tag.length > 0)
-    .sort((a, b) => b.quality - a.quality);
-
-  const primaryLanguage = languages[0]?.tag;
-
-  if (primaryLanguage === "en" || primaryLanguage?.startsWith("en-")) {
-    return "en";
-  }
-
-  return "ko";
+  return null;
 }
 
 function cleanLangQuery(request: NextRequest, responsePathname: string, lang: "ko" | "en") {


### PR DESCRIPTION
## What changed

- **proxy.ts**: the journal language auto-redirect now fires only on the explicit `pf-journal-lang` cookie (set when a visitor clicks the ko/en switch). The `Accept-Language` fallback is removed.
- **Journal metadata** (index + post pages, ko and en): added `canonical` and `hreflang` alternates (`ko`, `en`, `x-default` → English version).

## Why

Search Console showed every Korean journal URL classified as "page with redirect" and the ko/en pairs as "duplicate without user-selected canonical". Root cause: crawlers request with English `Accept-Language`, so the old proxy 307-redirected them off every Korean URL, making those pages unindexable. With hreflang in place, search engines route users to the right language themselves: Korean searchers get the Korean page, everyone else gets English (`x-default`).

## Behavior matrix

| Request | Before | After |
|---|---|---|
| Crawler / first visit, English UA | 307 → /en | 200 (indexable) |
| Visitor with `pf-journal-lang=en` cookie | 307 → /en | 307 → /en (unchanged) |
| Old `?lang=` URLs | redirect + cookie | unchanged |

## Verified

Against the local dev server: Korean post returns 200 with an English Accept-Language header and no cookie; 307 to /en with the cookie; canonical + hreflang links render on both index and post pages.

## Reviewer notes

- Firmware working-tree changes are unrelated and not included.
- After deploy, worth requesting re-indexing for a few journal URLs in Search Console to speed up recrawl.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
