### PR TITLE
docs: snap-fit encloser resolves the LED-matrix bump trimming (#4)

### DIFF
--- a/BUILD_GUIDE.md
+++ b/BUILD_GUIDE.md
@@ -105,7 +105,7 @@ If you want to order the PCB without manually uploading Gerbers, the Patternflow
 
 **Print the main body, dividers, and one knob file.** Print the knob STL that matches your encoder shaft length — `knobs_15mm.stl` or `knobs_20mm.stl`. Each file is one print job; each knob STL contains all four knobs.
 
-> 💡 **Easier option — skip the gluing.** [`hardware/case/legacy_v2/encloser_v2.1.stl`](hardware/case/legacy_v2/encloser_v2.1.stl) packs the newer **snap-fit** design, cut for the v2.1 board, into one STL — body, LED-panel mount, and knobs all inside. Print & assembly verified. Open it in your slicer, split the objects, print the knobs in black and the rest in white — then skip Section 3 entirely (no bonding; assembly follows the [v3 guide's Section 6](BUILD_GUIDE_v3.md#6-case-assembly) sequence). The plates below remain the classic, fully photo-documented path.
+> 💡 **Easier option — skip the gluing (and the nippers).** [`hardware/case/legacy_v2/encloser_v2.1.stl`](hardware/case/legacy_v2/encloser_v2.1.stl) packs the newer **snap-fit** design, cut for the v2.1 board, into one STL — body, LED-panel mount, and knobs all inside. Print & assembly verified. Open it in your slicer, split the objects, print the knobs in black and the rest in white — then skip Section 3 entirely (no bonding; assembly follows the [v3 guide's Section 6](BUILD_GUIDE_v3.md#6-case-assembly) sequence) **and skip Section 5.1 too**: the design recesses the LED matrix's alignment bumps, so no trimming. Bonus: a snap-fit back panel and two wall-mount holes. The plates below remain the classic, fully photo-documented path.
 
 > **Note:** an `easyfit` main-body variant (alignment tabs along the bond seam) existed briefly but was retired over a fit defect ([Issue #154](https://github.com/engmung/Patternflow/issues/154)). Use the standard `plate_main.stl`; the old variant remains at the [v2.1.0 tag](https://github.com/engmung/Patternflow/tree/v2.1.0/hardware/case) if you're curious.
 
@@ -267,7 +267,7 @@ The LED matrix has two small alignment bumps on its back, diagonally opposite ea
 
 **Cut them off with strong nippers or pliers.** Slight residual nubs are fine — flat enough is flat enough.
 
-> A future case revision will include recesses for these bumps so trimming isn't needed.
+> This step only applies to the glued-plate body. If you printed `encloser_v2.1.stl` (the 💡 option in Section 2), skip it — that design has recesses for the bumps.
 
 <img src="docs/build-guide/images/matrix_bump_cut1.jpg" width="33%"> <img src="docs/build-guide/images/matrix_bump_cut2.jpg" width="33%">
 
@@ -466,7 +466,7 @@ With flashing complete and the USB cable disconnected, plug the ESP32-S3 module 
 
 ### Still open
 
-- **Issue #4 -- LED matrix back has alignment bumps.** The matrix manufacturer leaves two small alignment bumps on the back of the panel. Current workaround: cut them off during assembly (see Section 5.1). They cut easily. A future case revision (planned to land with the LED diffuser variant) will add recesses to accommodate them.
+- **Issue #4 -- LED matrix back has alignment bumps.** The matrix manufacturer leaves two small alignment bumps on the back of the panel. On the glued-plate body, cut them off during assembly (see Section 5.1) — they cut easily. **Resolved in the snap-fit enclosure design** (`encloser_v2.1.stl` and the v3 cases), which recesses the bumps so no trimming is needed.
 
 ### Design notes (not bugs)
 

--- a/BUILD_GUIDE_v3.md
+++ b/BUILD_GUIDE_v3.md
@@ -233,7 +233,7 @@ The stock flasher image ships with **OSC disabled at compile time** — live con
 - **C11 (1000µF bulk cap) retained** — Patternflow is power-bank-powered; the cap stabilizes the boot transient. Designing a desktop-USB derivative? Drop it to ≤50µF.
 - **GPIO0 left floating by design** — most modules don't need the pullup; if yours does, it's a one-resistor fix (Section 5 note, [#16](https://github.com/engmung/Patternflow/issues/16)).
 - **Encoder direction is handled in firmware** — the default suits the Bourns PEC11R; if your encoders read backwards, set `INVERT_ENCODER` to `1` in `config.h` instead of touching hardware.
-- <!-- TODO: LED matrix alignment-bump trimming (#4) — confirm whether the v3 cases still need it. -->
+- **No LED-matrix bump trimming.** The enclosure recesses the panel's two alignment bumps, so the old nipper step ([#4](https://github.com/engmung/Patternflow/issues/4)) is gone. The design also gives you a snap-fit back panel and two wall-mount holes.
 
 ---
 

--- a/hardware/case/README.md
+++ b/hardware/case/README.md
@@ -26,6 +26,8 @@ The original mass-production-oriented design: a single-piece body plus a snap-fi
 
 **`encloser.stl`** is the whole kit in one file: body parts, the LED-panel mounting part, and the 20 mm knobs. Split the objects in your slicer — knobs in **black**, everything else in **white**. ~10 hours total on a P1S. The LED-panel mount is sized for the panel linked in the [BOM](../bom/). (Its v2.1 twin — same design, cut for the v2.1 board — is print & assembly verified; this file is the v3.0 cut.)
 
+Design perks: **two wall-mount holes**, a **snap-fit back panel**, and recesses for the LED matrix's alignment bumps — **no more nipper-trimming** the panel back (the old [#4](https://github.com/engmung/Patternflow/issues/4) workaround).
+
 ### `for_other_panels/` — using a different LED panel?
 
 `divided_v3_part1..5.stl` is a community variant whose **LED-panel mounting part adapts to varying bolt-hole positions** — panel suppliers drill them in different places. Print this instead of `encloser.stl` **only if** your panel is not the BOM-linked one. Print & assembly verified with a v3.0 board in [#169](https://github.com/engmung/Patternflow/issues/169), including USB-C port alignment.
@@ -45,7 +47,7 @@ Everything that fits the v2.x board generation, kept for existing builds. **None
 
 | File | What |
 |---|---|
-| `encloser_v2.1.stl` | ✅ **Recommended v2 print** — the snap-fit design cut for the v2.1 board, every part in one STL (knobs included). Print & assembly verified. No body gluing; assemble per the sequence in the [v3 guide §6](../../BUILD_GUIDE_v3.md#6-case-assembly). |
+| `encloser_v2.1.stl` | ✅ **Recommended v2 print** — the snap-fit design cut for the v2.1 board, every part in one STL (knobs included). Print & assembly verified. No body gluing, snap-fit back panel, two wall-mount holes, and **no LED-matrix bump trimming** ([#4](https://github.com/engmung/Patternflow/issues/4) recesses built in). Assemble per the sequence in the [v3 guide §6](../../BUILD_GUIDE_v3.md#6-case-assembly). |
 | `plate_main.stl` + `plate_dividers.stl` | Classic split plates (256 mm bed, glued) — the path the [v2 guide](https://github.com/engmung/Patternflow/blob/v2.1.0/BUILD_GUIDE.md) documents with full photos |
 | `oneshot_v2_part1/2.stl` | One-piece snap-fit for the v2.x board (330 mm+ bed) |
 


### PR DESCRIPTION
The encloser design recesses the panel's two alignment bumps — no more nipper step on this path (verified on the v2.1-cut build). Docs now say so everywhere: case README (both v3 and legacy rows), v2 guide §2/§5.1/Known Issues, v3 guide design notes. Also surfaces the snap-fit back panel and the two wall-mount holes.

Refs #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)