### PR TITLE
docs: correct bump-trimming issue references (#4 → #19)

### DIFF
--- a/BUILD_GUIDE.md
+++ b/BUILD_GUIDE.md
@@ -466,7 +466,7 @@ With flashing complete and the USB cable disconnected, plug the ESP32-S3 module 
 
 ### Still open
 
-- **Issue #4 -- LED matrix back has alignment bumps.** The matrix manufacturer leaves two small alignment bumps on the back of the panel. On the glued-plate body, cut them off during assembly (see Section 5.1) — they cut easily. **Resolved in the snap-fit enclosure design** (`encloser_v2.1.stl` and the v3 cases), which recesses the bumps so no trimming is needed.
+- **Issue #19 -- LED matrix back has alignment bumps.** The matrix manufacturer leaves two small alignment bumps on the back of the panel. On the glued-plate body, cut them off during assembly (see Section 5.1) — they cut easily. **Resolved in the snap-fit enclosure design** (`encloser_v2.1.stl` and the v3 cases), which recesses the bumps so no trimming is needed.
 
 ### Design notes (not bugs)
 

--- a/BUILD_GUIDE_v3.md
+++ b/BUILD_GUIDE_v3.md
@@ -233,7 +233,7 @@ The stock flasher image ships with **OSC disabled at compile time** — live con
 - **C11 (1000µF bulk cap) retained** — Patternflow is power-bank-powered; the cap stabilizes the boot transient. Designing a desktop-USB derivative? Drop it to ≤50µF.
 - **GPIO0 left floating by design** — most modules don't need the pullup; if yours does, it's a one-resistor fix (Section 5 note, [#16](https://github.com/engmung/Patternflow/issues/16)).
 - **Encoder direction is handled in firmware** — the default suits the Bourns PEC11R; if your encoders read backwards, set `INVERT_ENCODER` to `1` in `config.h` instead of touching hardware.
-- **No LED-matrix bump trimming.** The enclosure recesses the panel's two alignment bumps, so the old nipper step ([#4](https://github.com/engmung/Patternflow/issues/4)) is gone. The design also gives you a snap-fit back panel and two wall-mount holes.
+- **No LED-matrix bump trimming.** The enclosure recesses the panel's two alignment bumps, so the old nipper step ([#19](https://github.com/engmung/Patternflow/issues/19)) is gone. The design also gives you a snap-fit back panel and two wall-mount holes.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,7 +79,7 @@ The final consolidation release of the v2.x line before v3.0. Everything a v2.x 
 
 - `easyfit` main plate STL missing the divider slot ([#154](https://github.com/engmung/Patternflow/issues/154)).
 - Divided (256 mm bed) snap-fit enclosure not yet print-tested.
-- LED matrix alignment bumps still require manual trimming ([#4](https://github.com/engmung/Patternflow/issues/4)).
+- LED matrix alignment bumps still require manual trimming ([#19](https://github.com/engmung/Patternflow/issues/19)).
 
 ## [2.0.0] - 2026-05
 
@@ -98,7 +98,7 @@ The final consolidation release of the v2.x line before v3.0. Everything a v2.x 
 - **Cold-boot unreliability** after extended power-off. Root cause: GPIO0 strapping pin floating. Full story: [Issue #16](https://github.com/engmung/Patternflow/issues/16). Credit to @idranoutof1d and u/Infrated on r/AskElectronics.
 
 ### Still open
-- **Issue #4** -- LED matrix alignment bumps require manual trimming. Will be addressed when the LED diffuser variant ships.
+- **Issue #19** -- LED matrix alignment bumps require manual trimming. Will be addressed when the LED diffuser variant ships.
 
 ### Deliberate non-changes
 - **C11 (1000uF bulk cap)** retained despite USB inrush concerns. Patternflow is power-bank-powered, not desktop-USB-powered, and the cap improves boot transient stability.

--- a/hardware/case/README.md
+++ b/hardware/case/README.md
@@ -26,7 +26,7 @@ The original mass-production-oriented design: a single-piece body plus a snap-fi
 
 **`encloser.stl`** is the whole kit in one file: body parts, the LED-panel mounting part, and the 20 mm knobs. Split the objects in your slicer — knobs in **black**, everything else in **white**. ~10 hours total on a P1S. The LED-panel mount is sized for the panel linked in the [BOM](../bom/). (Its v2.1 twin — same design, cut for the v2.1 board — is print & assembly verified; this file is the v3.0 cut.)
 
-Design perks: **two wall-mount holes**, a **snap-fit back panel**, and recesses for the LED matrix's alignment bumps — **no more nipper-trimming** the panel back (the old [#4](https://github.com/engmung/Patternflow/issues/4) workaround).
+Design perks: **two wall-mount holes**, a **snap-fit back panel**, and recesses for the LED matrix's alignment bumps — **no more nipper-trimming** the panel back (the old [#19](https://github.com/engmung/Patternflow/issues/19) workaround).
 
 ### `for_other_panels/` — using a different LED panel?
 
@@ -47,7 +47,7 @@ Everything that fits the v2.x board generation, kept for existing builds. **None
 
 | File | What |
 |---|---|
-| `encloser_v2.1.stl` | ✅ **Recommended v2 print** — the snap-fit design cut for the v2.1 board, every part in one STL (knobs included). Print & assembly verified. No body gluing, snap-fit back panel, two wall-mount holes, and **no LED-matrix bump trimming** ([#4](https://github.com/engmung/Patternflow/issues/4) recesses built in). Assemble per the sequence in the [v3 guide §6](../../BUILD_GUIDE_v3.md#6-case-assembly). |
+| `encloser_v2.1.stl` | ✅ **Recommended v2 print** — the snap-fit design cut for the v2.1 board, every part in one STL (knobs included). Print & assembly verified. No body gluing, snap-fit back panel, two wall-mount holes, and **no LED-matrix bump trimming** ([#19](https://github.com/engmung/Patternflow/issues/19) recesses built in). Assemble per the sequence in the [v3 guide §6](../../BUILD_GUIDE_v3.md#6-case-assembly). |
 | `plate_main.stl` + `plate_dividers.stl` | Classic split plates (256 mm bed, glued) — the path the [v2 guide](https://github.com/engmung/Patternflow/blob/v2.1.0/BUILD_GUIDE.md) documents with full photos |
 | `oneshot_v2_part1/2.stl` | One-piece snap-fit for the v2.x board (330 mm+ bed) |
 


### PR DESCRIPTION
The alignment-bump references pointed at #4, which is an unrelated web PR; the real issue is #19. All links and mentions corrected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)