### PR TITLE
release: pre-load v3.0.0 (notes, launch checklist, version labels)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to Patternflow will be documented in this file.
 
-## [Unreleased] — toward v3.0.0
+## [3.0.0] - 2026-07
 
 ### Added
 - **v3.0 board promoted to the recommended revision** (`hardware/pcb/gerber/patternflow_v3.0_gerber.zip`). Fabricated, assembled, and verified ([#114](https://github.com/engmung/Patternflow/issues/114)): hybrid power input — USB-C (`USB1` + 5.1k CC pull-downs) or a back-side 2-pin screw terminal (`J4`) as the beginner bypass — all-through-hole, no SMD passives. **Not size-compatible with v2.x cases (and vice versa).**
@@ -10,7 +10,7 @@ All notable changes to Patternflow will be documented in this file.
 - **v3 build guide** — now the main `BUILD_GUIDE.md`: soldering covered by a full [video walkthrough](https://youtu.be/NZCjMBCsDAc), photo-documented print/case/wiring steps, netlist-derived pin reference. The v2 guide moved to `BUILD_GUIDE_v2.md` for existing v2.x builds.
 
 ### Changed
-- **`hardware/case/` reorganized by printer bed size**: `bed_256mm/encloser.stl` (the standard print — every part in one STL, 20 mm knobs included, ~10 h) and `bed_330mm/` (one-piece snap-fit). `bed_256mm/for_other_panels/` holds the community divided variant with an adjustable LED-panel mount ([#169](https://github.com/engmung/Patternflow/issues/169)-tested) for panels other than the BOM-linked one. All v2.x-board cases moved to `case/legacy_v2/`.
+- **`hardware/case/` reorganized by printer bed size**: `bed_256mm/encloser.stl` (the standard print — body frame, back panels, and LED-panel mount in one STL, ~10 h) and `bed_330mm/` (one-piece snap-fit); knobs print separately from `knobs/` in black, required for every build. `bed_256mm/for_other_panels/` holds the community divided variant with an adjustable LED-panel mount ([#169](https://github.com/engmung/Patternflow/issues/169)-tested) for panels other than the BOM-linked one. All v2.x-board cases moved to `case/legacy_v2/`. The snap-fit design adds two wall-mount holes and recesses for the panel's alignment bumps — no more nipper trimming ([#19](https://github.com/engmung/Patternflow/issues/19)).
 - **Browser-flasher firmware refreshed** to the latest build — one image, compatible with both v2.x and v3.0 boards. The `patternflow_v2_firmware.zip` release asset on v2.1.0 was updated to match.
 - The defective `easyfit` plate variant was removed ([#154](https://github.com/engmung/Patternflow/issues/154)); it remains at the v2.1.0 tag.
 - Encoder shaft guidance neutralized: 15mm and 20mm are functionally identical; the BOM reference part (Bourns PEC11R-4220F-S0024) is 20mm.

--- a/docs/releases/v3.0.0-launch.md
+++ b/docs/releases/v3.0.0-launch.md
@@ -1,0 +1,79 @@
+# v3.0.0 Launch Checklist
+
+Everything for the v3.0.0 release is **pre-loaded**. When the final gate below passes, run the steps top to bottom — each is copy-paste. (Windows: run the PowerShell blocks in PowerShell, everything else in any terminal with `git` + `gh`.)
+
+## Gate 0 — the one thing left (hardware)
+
+Print `hardware/case/bed_256mm/encloser.stl` on the v3 unit, assemble with a v3.0 board, and confirm:
+
+- [ ] USB-C / J4 cutouts and board bay line up (this exact STL has never been printed — only its verified v2.1 twin)
+- [ ] Run the full checklist in [BUILD_GUIDE.md §9](../../BUILD_GUIDE.md#9-final-checks)
+
+## Gate 1 — swap the two v2.1-twin photos
+
+While the v3 unit is open, re-shoot and overwrite (same filenames, same orientation):
+
+- [ ] `docs/build-guide/images/v3/14_wiring.jpg` (wiring, §7)
+- [ ] `docs/build-guide/images/v3/15_close_back.jpg` (closing the back, §9)
+
+Then delete the three "shot on the v2.1 twin" notices in `BUILD_GUIDE.md`: the 📷 line in the top banner, and the two italic captions under those photos (§7 and §9).
+
+If any new photos need resizing: `python -c "from PIL import Image; im=Image.open(r'PATH'); im=im.resize((1600,int(im.height*1600/im.width))) if im.width>1600 else im; im.save(r'PATH','JPEG',quality=82,optimize=True)"`
+
+## Gate 2 — last-minute text
+
+- [ ] `CHANGELOG.md`: the `## [3.0.0] - 2026-07` date — correct it if the month changed.
+- [ ] Optional: rebuild firmware once so the flashed image reports `3.0.0` over Improv (`PF_IMPROV_FW_VERSION` is already bumped in `net_config.h`); copy the fresh `build/esp32.esp32.esp32s3/patternflow.ino*.bin` files over `web/public/flash/bin/v2/`. Skipping this is fine — the shipped image works identically, it just self-reports 2.0.0.
+
+## Launch
+
+```sh
+# 1. Commit the photo/text changes and merge to main
+git add -A -- BUILD_GUIDE.md CHANGELOG.md docs/build-guide/images/v3 web/public/flash
+git commit -m "release: v3.0.0"
+git push origin dev
+gh pr create --base main --head dev --title "Release v3.0.0" --body "Final gate passed: v3 unit built and checked. Tag + release to follow."
+gh pr merge --merge
+```
+
+```powershell
+# 2. Build the release assets (PowerShell, from the repo root)
+$s = "$env:TEMP\pf-release"; Remove-Item -Recurse -Force $s -ErrorAction SilentlyContinue; New-Item -ItemType Directory "$s\stl","$s\fw" | Out-Null
+Copy-Item -Recurse hardware\case\bed_256mm,hardware\case\bed_330mm,hardware\case\knobs "$s\stl\"
+Compress-Archive -Path "$s\stl\*" -DestinationPath "$s\patternflow_v3_case_stl_pack.zip" -Force
+Copy-Item web\public\flash\bin\v2\patternflow.ino.bin,web\public\flash\bin\v2\patternflow.ino.bootloader.bin,web\public\flash\bin\v2\patternflow.ino.partitions.bin "$s\fw\"
+@"
+Patternflow v3.0.0 firmware - prebuilt ESP32-S3 binaries
+(the same image served by the browser flasher at patternflow.work;
+one image works on both v2.x and v3.0 boards)
+
+Easiest: use the browser flasher (Chrome/Edge) at https://patternflow.work
+
+Manual flash with esptool:
+  esptool.py --chip esp32s3 write_flash \
+    0x0     patternflow.ino.bootloader.bin \
+    0x8000  patternflow.ino.partitions.bin \
+    0x10000 patternflow.ino.bin
+"@ | Out-File "$s\fw\README.txt" -Encoding utf8
+Compress-Archive -Path "$s\fw\*" -DestinationPath "$s\patternflow_v3_firmware.zip" -Force
+```
+
+```sh
+# 3. Tag + publish (run from the repo root; $env:TEMP\pf-release on Windows = use the full path below)
+gh release create v3.0.0 --target main \
+  --title "Patternflow v3.0.0 — the hybrid-power generation" \
+  --notes-file docs/releases/v3.0.0.md \
+  "$TEMP/pf-release/patternflow_v3_case_stl_pack.zip" \
+  "$TEMP/pf-release/patternflow_v3_firmware.zip" \
+  hardware/pcb/gerber/patternflow_v3.0_gerber.zip \
+  hardware/case/source/patternflow_case.blend
+```
+
+> The `.blend` must be attached (it's the one LFS file — *Download ZIP* gives people a pointer instead of the real file). Verify after publishing: the release page should list **4 assets** and show `patternflow_case.blend` at ~45 MB, not ~130 bytes.
+
+## After publishing
+
+- [ ] Open the release page and sanity-check the rendered notes + 4 assets.
+- [ ] Close [#190](https://github.com/engmung/Patternflow/issues/190) (build-guide tracker) — everything in it is done at this point.
+- [ ] Announce wherever feels right (Discord, Instagram, journal). The README release badge updates itself.
+- [ ] Someday, not urgent: the pattern-creation guide (deliberately decoupled from this release).

--- a/docs/releases/v3.0.0.md
+++ b/docs/releases/v3.0.0.md
@@ -1,0 +1,45 @@
+# Patternflow v3.0.0 — the hybrid-power generation
+
+The biggest hardware revision since launch. The v3.0 board and enclosure were rebuilt around one goal: **anyone should be able to solder and assemble this.**
+
+**Building one? Start here → [BUILD_GUIDE.md](https://github.com/engmung/Patternflow/blob/v3.0.0/BUILD_GUIDE.md)** — the PCB soldering is covered by a [full video walkthrough](https://youtu.be/NZCjMBCsDAc).
+
+## Highlights
+
+### The board: two power inputs, zero SMD
+- **Hybrid power input** — USB-C for a clean finish, or a 2-pin screw terminal on the back of the board that bypasses the tricky Type-C soldering entirely. Populate either (or both); electrically identical. ([#114](https://github.com/engmung/Patternflow/issues/114))
+- **No SMD passives at all** — every part you solder is through-hole. The whole board is beginner-solderable.
+- Fabricated, assembled, and verified, including both power inputs.
+
+### The enclosure: snap-fit, printable on a 256 mm bed
+- Folders named by **printer bed size**: `bed_256mm/encloser.stl` (one STL, ~10 h on a P1S) or `bed_330mm/` one-piece for large-format printers. Knobs print separately in black — white body, black knobs.
+- **Snap-fit back panel**, **two wall-mount holes**, and recesses for the LED panel's alignment bumps — **the nipper-trimming step that's been with us since v1.0 is gone** ([#19](https://github.com/engmung/Patternflow/issues/19)).
+- Using a different LED panel than the recommended one? `bed_256mm/for_other_panels/` has an adjustable-mount variant ([#169](https://github.com/engmung/Patternflow/issues/169)).
+
+### The BOM: every part by part number
+- [`hardware/bom/bom_v3.0.csv`](https://github.com/engmung/Patternflow/blob/v3.0.0/hardware/bom/bom_v3.0.csv) — machine-readable, every part specified by MPN, sourcing notes included. Order from Mouser/DigiKey/LCSC or find the same parts anywhere.
+
+### The guide: watch, don't decipher
+- [BUILD_GUIDE.md](https://github.com/engmung/Patternflow/blob/v3.0.0/BUILD_GUIDE.md) rewritten for v3.0 — soldering as one YouTube video, photo-documented printing/bonding/assembly, a collapsible netlist-derived pin reference, and a dedicated OSC/Ableton build path.
+- PCB ordering routed through the [PCBWay shared project](https://www.pcbway.com/project/shareproject/Patternflow_An_LED_synthesizer_776d796c.html) (no Gerber upload needed) — any fab works with the attached zip too.
+
+### Firmware
+- **One image for every board generation** — v2.x and v3.0 share an identical pin map, so the [browser flasher](https://patternflow.work) just works on both. No board selection to get wrong.
+
+## Breaking changes
+
+- **v2.x boards and v3.0 cases are not interchangeable** (and vice versa) — different board size, different port positions.
+- Already own a v2.x build? Everything you need stays bundled at the [v2.1.0 release](https://github.com/engmung/Patternflow/releases/tag/v2.1.0), and the v2 guide lives on as [`BUILD_GUIDE_v2.md`](https://github.com/engmung/Patternflow/blob/v3.0.0/BUILD_GUIDE_v2.md). Bonus for v2 owners: `hardware/case/legacy_v2/encloser_v2.1.stl` is a newly verified snap-fit case for the v2.1 board — no gluing, no trimming.
+
+## Assets
+
+- `patternflow_v3_case_stl_pack.zip` — all v3 case STLs (256 mm kit, 330 mm one-piece, adjustable-mount variant, knob plates)
+- `patternflow_v3.0_gerber.zip` — the verified board
+- `patternflow_v3_firmware.zip` — prebuilt ESP32-S3 binaries (the browser-flasher image) with esptool offsets in the included README
+- `patternflow_case.blend` — Blender source for every printed part (stored in Git LFS; attached here so *Download ZIP* users get the real file)
+
+Full details in the [CHANGELOG](https://github.com/engmung/Patternflow/blob/v3.0.0/CHANGELOG.md).
+
+---
+
+Firmware & web: MIT · Hardware & designs: CC-BY-SA 4.0

--- a/firmware/patternflow/net_config.h
+++ b/firmware/patternflow/net_config.h
@@ -51,7 +51,7 @@
 // Firmware version string reported to the flasher (Improv device-info RPC).
 // Keep in sync with web/public/flash/manifest.json.
 #ifndef PF_IMPROV_FW_VERSION
-#define PF_IMPROV_FW_VERSION "2.0.0"
+#define PF_IMPROV_FW_VERSION "3.0.0"
 #endif
 
 // ── OTA (wireless flashing from Arduino IDE / espota.py) ─────

--- a/web/public/flash/manifest.json
+++ b/web/public/flash/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Patternflow",
-  "version": "v2.0.0",
+  "version": "v3.0.0",
   "new_install_prompt_erase": true,
   "builds": [
     {


### PR DESCRIPTION
Loads the v3.0.0 release: CHANGELOG cut, final release notes at docs/releases/v3.0.0.md, a self-serve launch checklist at docs/releases/v3.0.0-launch.md (final hardware gate → photo swap → asset build → gh release, all copy-paste), and version-label bumps (flasher manifest, Improv FW string).

🤖 Generated with [Claude Code](https://claude.com/claude-code)