### PR TITLE
docs(release): sync v3.0.0 notes source with the published notes

### DIFF
--- a/docs/releases/v3.0.0.md
+++ b/docs/releases/v3.0.0.md
@@ -13,6 +13,7 @@ The biggest hardware revision since launch. The v3.0 board and enclosure were re
 
 ### The enclosure: snap-fit, printable on a 256 mm bed
 - Folders named by **printer bed size**: `bed_256mm/encloser.stl` (one STL, ~10 h on a P1S) or `bed_330mm/` one-piece for large-format printers. Knobs print separately in black — white body, black knobs.
+- **Bambu printers: one click** — the case is on [MakerWorld](https://makerworld.com/ko/models/3072492-patternflow-open-source-led-synthesizer-case#profileId-3459015) with tuned print profiles; the same 4-plate project is attached below as `patternflow_v3.3mf`.
 - **Snap-fit back panel**, **two wall-mount holes**, and recesses for the LED panel's alignment bumps — **the nipper-trimming step that's been with us since v1.0 is gone** ([#19](https://github.com/engmung/Patternflow/issues/19)).
 - Using a different LED panel than the recommended one? `bed_256mm/for_other_panels/` has an adjustable-mount variant ([#169](https://github.com/engmung/Patternflow/issues/169)).
 
@@ -35,6 +36,7 @@ The biggest hardware revision since launch. The v3.0 board and enclosure were re
 ## Assets
 
 - `patternflow_v3_case_stl_pack.zip` — all v3 case STLs (256 mm kit, 330 mm one-piece, adjustable-mount variant, knob plates)
+- `patternflow_v3.3mf` — Bambu Studio project (4 pre-arranged plates with print settings; same as the [MakerWorld listing](https://makerworld.com/ko/models/3072492-patternflow-open-source-led-synthesizer-case#profileId-3459015))
 - `patternflow_v3.0_gerber.zip` — the verified board
 - `patternflow_v3_firmware.zip` — prebuilt ESP32-S3 binaries (the browser-flasher image) with esptool offsets in the included README
 - `patternflow_case.blend` — Blender source for every printed part (stored in Git LFS; attached here so *Download ZIP* users get the real file)


### PR DESCRIPTION
The published v3.0.0 release gained the `patternflow_v3.3mf` asset and a MakerWorld line; this syncs the in-repo notes file to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)