### PR TITLE
Rework the build map card so it stops jumping, and give phones their own layout

### DIFF
--- a/web/src/components/sections/InsideGlobe/BuildCard.module.css
+++ b/web/src/components/sections/InsideGlobe/BuildCard.module.css
@@ -1,0 +1,172 @@
+/* Mobile-only. On desktop the globe overlay already shows all of this, so the
+   card would just be a duplicate. */
+.card {
+  display: none;
+}
+
+/* The card sits inside .panel-body, whose global `p` rule (17px on mobile,
+   plus a 28px bottom margin) outranks a bare module class. Both paragraph
+   styles below are scoped through .card to win that. */
+.card .empty {
+  margin: 0;
+  color: var(--pf-ink-muted);
+  font-family: var(--pf-mono);
+  font-size: 10.5px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+@media (max-width: 900px) {
+  .card {
+    display: grid;
+    gap: 16px;
+    margin-top: 20px;
+    padding-top: 20px;
+    border-top: var(--pf-rule-w) solid var(--pf-rule);
+    /* Clears the fixed viewer when the card is scrolled to. */
+    scroll-margin-top: calc(var(--mb-viewer-h) + var(--mb-nav-h) + 12px);
+  }
+
+  .head {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 16px;
+  }
+
+  .headText {
+    display: grid;
+    gap: 4px;
+  }
+
+  .maker {
+    font-size: 19px;
+    font-weight: 500;
+    letter-spacing: -0.02em;
+    line-height: 1.2;
+    color: var(--pf-ink);
+  }
+
+  .meta {
+    font-family: var(--pf-mono);
+    font-size: 10.5px;
+    letter-spacing: 0.1em;
+    color: var(--pf-ink-muted);
+  }
+
+  .close {
+    flex-shrink: 0;
+    padding: 0;
+    border: 0;
+    background: transparent;
+    color: var(--pf-ink-muted);
+    font-family: var(--pf-mono);
+    font-size: 10.5px;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    cursor: pointer;
+  }
+
+  /* Two tiles on one row, and only two — the rest live in the lightbox, so
+     the description below stays on screen. */
+  .photos {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 8px;
+  }
+
+  .photo {
+    position: relative;
+    aspect-ratio: 4 / 3;
+    overflow: hidden;
+    padding: 0;
+    border: var(--pf-rule-w) solid var(--pf-rule);
+    background: #000;
+    cursor: pointer;
+  }
+
+  .photo:nth-child(n + 3) {
+    display: none;
+  }
+
+  .photo img {
+    object-fit: cover;
+  }
+
+  /* How many more are waiting in the lightbox. */
+  .more {
+    position: absolute;
+    right: 6px;
+    bottom: 6px;
+    z-index: 1;
+    padding: 2px 7px;
+    background: rgba(13, 13, 13, 0.72);
+    color: var(--cream);
+    font-family: var(--pf-mono);
+    font-size: 10px;
+    letter-spacing: 0.04em;
+  }
+
+  .card .desc {
+    margin: 0;
+    max-width: none;
+    color: var(--pf-ink-muted);
+    font-size: 14px;
+    line-height: 1.6;
+  }
+
+  .links {
+    display: grid;
+    justify-items: start;
+    gap: 6px;
+  }
+
+  /* Near-zero tracking: these are URLs, not labels, and the panel's 0.14em
+     mono tracking stretches them into a line of their own for no gain. */
+  .link {
+    width: fit-content;
+    color: var(--pf-ink);
+    border-bottom: var(--pf-rule-w) solid currentColor;
+    font-family: var(--pf-mono);
+    font-size: 10.5px;
+    letter-spacing: 0.01em;
+    text-decoration: none;
+    word-break: break-all;
+  }
+
+  /* Step through builds without going back up to the map. */
+  .pager {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 20px;
+    padding-top: 4px;
+  }
+
+  .pager button {
+    display: grid;
+    place-items: center;
+    padding: 6px;
+    border: 0;
+    background: transparent;
+    color: var(--pf-ink);
+    cursor: pointer;
+  }
+
+  .pager svg {
+    width: 22px;
+    height: 22px;
+    fill: none;
+    stroke: currentColor;
+    stroke-width: 2.1;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+  }
+
+  .counter {
+    font-family: var(--pf-mono);
+    font-size: 10.5px;
+    letter-spacing: 0.1em;
+    color: var(--pf-ink-muted);
+  }
+}

--- a/web/src/components/sections/InsideGlobe/BuildCard.tsx
+++ b/web/src/components/sections/InsideGlobe/BuildCard.tsx
@@ -1,0 +1,147 @@
+'use client';
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+import Image from 'next/image';
+import PhotoLightbox from './PhotoLightbox';
+import { builds } from './builds';
+import { useAppStore } from '@/store/useAppStore';
+import styles from './BuildCard.module.css';
+
+// Mobile-only companion to the globe. The viewer is pinned to the top 44vh on
+// phones, which leaves no room for photos and a description on top of the map,
+// so the picked build's details are rendered down here in the Inside panel
+// instead. Hidden entirely on desktop, where the globe overlay does the job.
+export default function BuildCard() {
+  const selectedId = useAppStore((state) => state.selectedBuildId);
+  const setSelectedId = useAppStore((state) => state.setSelectedBuildId);
+  const [galleryIndex, setGalleryIndex] = useState<number | null>(null);
+  const cardRef = useRef<HTMLDivElement>(null);
+
+  const selectedIndex = useMemo(
+    () => builds.findIndex((build) => build.id === selectedId),
+    [selectedId],
+  );
+  const selected = selectedIndex === -1 ? null : builds[selectedIndex];
+  const images = selected?.images;
+
+  // Bring the card into view when a pin is tapped — the globe is fixed over
+  // the top of the screen, so without this the details land off-screen.
+  useEffect(() => {
+    if (!selectedId) return;
+    const card = cardRef.current;
+    if (!card || window.matchMedia('(min-width: 901px)').matches) return;
+
+    const styleOf = getComputedStyle(document.documentElement);
+    const viewerHeight = parseFloat(styleOf.getPropertyValue('--mb-viewer-h')) || 0;
+    const navHeight = parseFloat(styleOf.getPropertyValue('--mb-nav-h')) || 0;
+    // --mb-viewer-h is in vh; --mb-nav-h in px.
+    const offset = (window.innerHeight * viewerHeight) / 100 + navHeight + 12;
+
+    window.scrollTo({
+      top: card.getBoundingClientRect().top + window.scrollY - offset,
+      behavior: 'smooth',
+    });
+  }, [selectedId]);
+
+  const step = (delta: number) => {
+    if (selectedIndex === -1) return;
+    const next = (selectedIndex + delta + builds.length) % builds.length;
+    setSelectedId(builds[next].id);
+    setGalleryIndex(null);
+  };
+
+  return (
+    <div className={styles.card} ref={cardRef}>
+      {!selected ? (
+        <p className={styles.empty}>Tap a marker on the map to see that build.</p>
+      ) : (
+        <>
+          <div className={styles.head}>
+            <div className={styles.headText}>
+              <strong className={styles.maker}>{selected.maker}</strong>
+              <span className={styles.meta}>
+                {selected.location.label} · {selected.date}
+              </span>
+            </div>
+            <button
+              type="button"
+              className={styles.close}
+              onClick={() => setSelectedId(null)}
+              aria-label="Clear selection"
+            >
+              close
+            </button>
+          </div>
+
+          {selected.links && selected.links.length > 0 && (
+            <div className={styles.links}>
+              {selected.links.map((link) => (
+                <a
+                  key={link.href}
+                  className={styles.link}
+                  href={link.href}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  {link.label} ↗
+                </a>
+              ))}
+            </div>
+          )}
+
+          {/* A two-tile preview, not the whole set — a taller strip pushed the
+              description off-screen, so you could not tell it was there. Any
+              tile opens the full run of photos in the lightbox. */}
+          {images && images.length > 0 && (
+            <div className={styles.photos}>
+              {images.map((image, index) => (
+                <button
+                  key={image.src}
+                  type="button"
+                  className={styles.photo}
+                  onClick={() => setGalleryIndex(index)}
+                  aria-label={image.alt}
+                >
+                  <Image src={image.src} alt="" fill sizes="45vw" />
+                  {index === 1 && images.length > 2 && (
+                    <span className={styles.more}>+{images.length - 2}</span>
+                  )}
+                </button>
+              ))}
+            </div>
+          )}
+
+          <p className={styles.desc}>{selected.description}</p>
+
+          {builds.length > 1 && (
+            <div className={styles.pager}>
+              <button type="button" onClick={() => step(-1)} aria-label="Previous build">
+                <svg viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M15 4 7 12l8 8" />
+                </svg>
+              </button>
+              <span className={styles.counter}>
+                {String(selectedIndex + 1).padStart(2, '0')} /{' '}
+                {String(builds.length).padStart(2, '0')}
+              </span>
+              <button type="button" onClick={() => step(1)} aria-label="Next build">
+                <svg viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M9 4l8 8-8 8" />
+                </svg>
+              </button>
+            </div>
+          )}
+        </>
+      )}
+
+      {galleryIndex !== null && images && images.length > 0 && (
+        <PhotoLightbox
+          images={images}
+          index={galleryIndex}
+          onIndexChange={setGalleryIndex}
+          onClose={() => setGalleryIndex(null)}
+        />
+      )}
+    </div>
+  );
+}

--- a/web/src/components/sections/InsideGlobe/GlobeViewer.module.css
+++ b/web/src/components/sections/InsideGlobe/GlobeViewer.module.css
@@ -18,8 +18,8 @@
 .preloadBox {
   position: relative;
   display: block;
-  width: 160px;
-  height: 120px;
+  width: 280px;
+  height: 210px;
 }
 
 /* When open, the whole viewer becomes a click-to-close surface. */
@@ -58,10 +58,45 @@
   opacity: 0;
 }
 
-/* Bare glyph arrows to flip between builds. */
+/* The counter's row, centred in the upper part of the frame. Everything in the
+   upper column hangs off this one line — arrows centred on it, name above,
+   links below — so no piece of variable content can shift the name. */
+.nav {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 33%;
+  transform: translateY(50%);
+  text-align: center;
+  pointer-events: none;
+}
+
+/* Name and place, stacked directly above the counter. */
+.info {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: calc(100% + 10px);
+  display: grid;
+  justify-items: center;
+  gap: 9px;
+}
+
+/* Links hang below the counter, where growing downward disturbs nothing. */
+.links {
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: calc(100% + 10px);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+/* Bare glyph arrows to flip between builds, centred on the counter's line. */
 .arrow {
   position: absolute;
-  top: 44%;
+  top: 50%;
   transform: translateY(-50%);
   display: grid;
   place-items: center;
@@ -93,25 +128,25 @@
   right: 12px;
 }
 
-/* Layout-only container; text rows carry their own highlight backgrounds. */
-.card {
+/* Description, centred against the bottom edge. Switching builds swaps the
+   text in place, with no fade or slide, so nothing blinks on every click.
+   (The overlay's own opacity transition still handles opening and closing.) */
+.detail {
   position: absolute;
   left: 0;
-  bottom: 0;
-  width: min(100%, 600px);
-  display: grid;
-  justify-items: start;
-  gap: 9px;
-  padding: 0 30px 32px;
+  right: 0;
+  bottom: 32px;
+  padding: 0 30px;
+  box-sizing: border-box;
+  text-align: center;
   pointer-events: none;
-  transform: translateY(14px);
-  transition: transform 0.42s cubic-bezier(0.16, 1, 0.3, 1);
-}
-.overlayOpen .card {
-  transform: translateY(0);
 }
 
-/* Highlight backgrounds that hug the text itself, line by line. */
+/* Highlight backgrounds that hug the text itself, line by line. Translucent,
+   so the globe reads through — which means each wrapped line's padded box must
+   stay shorter than the line advance, or the fills stack where they overlap
+   and draw a seam across every line break. Hence the roomy line-height and
+   modest vertical padding on .desc below, the only block that ever wraps. */
 .kicker,
 .maker,
 .meta,
@@ -119,16 +154,15 @@
   display: inline;
   box-decoration-break: clone;
   -webkit-box-decoration-break: clone;
-  background: rgba(13, 13, 13, 0.85);
+  background: rgba(13, 13, 13, 0.72);
   color: var(--cream);
 }
 
 .kicker {
-  padding: 3px 9px;
+  padding: 4px 12px;
   font-family: var(--pf-mono);
-  font-size: 13px;
-  letter-spacing: 0.18em;
-  text-transform: uppercase;
+  font-size: 22px;
+  letter-spacing: 0.14em;
   color: var(--pf-led);
 }
 
@@ -148,24 +182,17 @@
 }
 
 .desc {
-  padding: 4px 10px;
-  max-width: 60ch;
+  padding: 3px 10px;
   font-size: 19px;
-  line-height: 1.75;
-}
-
-/* Stack multiple links tight, no gap between them. */
-.links {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
+  line-height: 1.9;
+  text-align: center;
 }
 
 .link {
   display: inline;
   box-decoration-break: clone;
   -webkit-box-decoration-break: clone;
-  background: rgba(13, 13, 13, 0.85);
+  background: rgba(13, 13, 13, 0.72);
   color: var(--pf-led);
   padding: 4px 10px;
   font-family: var(--pf-mono);
@@ -178,26 +205,40 @@
   text-decoration: underline;
 }
 
+/* Pinned to the top edge and centred, so the slack left over once the tiles
+   hit their width cap splits evenly instead of all landing on one side. Spans
+   the full width but stays click-through itself, so the space beside the strip
+   still closes the card. */
 .thumbs {
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 40px;
   display: flex;
+  justify-content: center;
   gap: 12px;
-  margin-top: 6px;
-  flex-wrap: wrap;
-  pointer-events: auto;
+  padding: 0 30px;
+  box-sizing: border-box;
+  pointer-events: none;
 }
 .thumb {
   position: relative;
-  width: 150px;
-  height: 112px;
+  flex: 0 1 270px;
+  aspect-ratio: 4 / 3;
   overflow: hidden;
   padding: 0;
   border: 1px solid rgba(244, 239, 230, 0.45);
   background: #000;
   cursor: pointer;
-  transition: border-color 0.2s ease;
+  pointer-events: auto;
+  /* Let the globe read faintly through the strip, like the text highlights.
+     Full strength on hover, so the one you're about to open is clear. */
+  opacity: 0.82;
+  transition: border-color 0.2s ease, opacity 0.2s ease;
 }
 .thumb:hover {
   border-color: var(--cream);
+  opacity: 1;
 }
 .thumb img {
   object-fit: cover;
@@ -208,10 +249,26 @@
 }
 
 @media (max-width: 900px) {
-  .card {
-    width: 100%;
-    padding: 0 16px 14px;
-    gap: 5px;
+  /* Same three centred bands, just tighter — the panel is only 44vh here. */
+  .thumbs {
+    top: 16px;
+    gap: 7px;
+    padding: 0 16px;
+  }
+  .detail {
+    bottom: 14px;
+    padding: 0 16px;
+  }
+  .info {
+    bottom: calc(100% + 6px);
+    gap: 4px;
+  }
+  .links {
+    top: calc(100% + 6px);
+  }
+  .kicker {
+    padding: 2px 8px;
+    font-size: 14px;
   }
   .maker {
     padding: 2px 7px;
@@ -227,19 +284,12 @@
     font-size: 10.5px;
   }
   .desc {
-    padding: 3px 7px;
+    padding: 2px 7px;
     font-size: 12.5px;
-    line-height: 1.5;
-    max-width: none;
-  }
-  .thumbs {
-    gap: 7px;
-    margin-top: 4px;
-    flex-wrap: nowrap;
+    line-height: 1.85;
   }
   .thumb {
-    width: 76px;
-    height: 57px;
+    flex: 0 1 100px;
   }
   /* Keep the strip to a single row — show only the first three. */
   .thumb:nth-child(n + 4) {

--- a/web/src/components/sections/InsideGlobe/GlobeViewer.module.css
+++ b/web/src/components/sections/InsideGlobe/GlobeViewer.module.css
@@ -93,11 +93,13 @@
   align-items: center;
 }
 
-/* Bare glyph arrows to flip between builds, centred on the counter's line. */
+/* Bare glyph arrows to flip between builds. Anchored to the counter's line
+   rather than nested inside it, so mobile can move the text group up without
+   dragging the arrows along. */
 .arrow {
   position: absolute;
-  top: 50%;
-  transform: translateY(-50%);
+  bottom: 33%;
+  transform: translateY(50%);
   display: grid;
   place-items: center;
   padding: 0;
@@ -119,7 +121,7 @@
   stroke-linejoin: round;
 }
 .arrow:hover {
-  transform: translateY(-50%) scale(1.08);
+  transform: translateY(50%) scale(1.08);
 }
 .arrowPrev {
   left: 12px;
@@ -249,26 +251,50 @@
 }
 
 @media (max-width: 900px) {
-  /* Same three centred bands, just tighter — the panel is only 44vh here. */
-  .thumbs {
-    top: 16px;
-    gap: 7px;
-    padding: 0 16px;
+  /* The viewer is only 44vh here, so the photos, description and links move
+     out of the overlay entirely and are rendered as a card in the Inside panel
+     below (see BuildCard). What stays on the map is just enough to say which
+     pin is open and to step between them. */
+  .thumbs,
+  .detail,
+  .links {
+    display: none;
   }
-  .detail {
-    bottom: 14px;
-    padding: 0 16px;
+
+  /* The name/counter group moves up near the top edge, clear of the globe,
+     while the arrows go back to the middle of the frame where they are
+     easiest to reach with a thumb. */
+  .nav {
+    /* Enough that the name clears the top edge rather than hugging it. */
+    top: 78px;
+    bottom: auto;
+    transform: none;
   }
   .info {
     bottom: calc(100% + 6px);
     gap: 4px;
   }
-  .links {
-    top: calc(100% + 6px);
+  .arrow {
+    top: 50%;
+    bottom: auto;
+    transform: translateY(-50%);
+  }
+  .arrow:hover {
+    transform: translateY(-50%) scale(1.08);
+  }
+  .arrow svg {
+    width: 44px;
+    height: 44px;
   }
   .kicker {
     padding: 2px 8px;
-    font-size: 14px;
+    font-size: 13px;
+  }
+  /* Never wrap: a two-line name or place would push the row out of place and
+     read as a jump when stepping between builds. */
+  .maker,
+  .meta {
+    white-space: nowrap;
   }
   .maker {
     padding: 2px 7px;
@@ -278,25 +304,5 @@
   .meta {
     padding: 2px 7px;
     font-size: 10.5px;
-  }
-  .link {
-    padding: 2px 7px;
-    font-size: 10.5px;
-  }
-  .desc {
-    padding: 2px 7px;
-    font-size: 12.5px;
-    line-height: 1.85;
-  }
-  .thumb {
-    flex: 0 1 100px;
-  }
-  /* Keep the strip to a single row — show only the first three. */
-  .thumb:nth-child(n + 4) {
-    display: none;
-  }
-  .arrow svg {
-    width: 52px;
-    height: 52px;
   }
 }

--- a/web/src/components/sections/InsideGlobe/GlobeViewer.tsx
+++ b/web/src/components/sections/InsideGlobe/GlobeViewer.tsx
@@ -16,10 +16,11 @@ export default function GlobeViewer() {
   const [galleryIndex, setGalleryIndex] = useState<number | null>(null);
   const [hasSelected, setHasSelected] = useState(false);
 
-  const selected = useMemo(
-    () => builds.find((build) => build.id === selectedId) ?? null,
+  const selectedIndex = useMemo(
+    () => builds.findIndex((build) => build.id === selectedId),
     [selectedId],
   );
+  const selected = selectedIndex === -1 ? null : builds[selectedIndex];
 
   // Every build photo across all pins — warmed up front (see preloader below).
   const allImages = useMemo(() => builds.flatMap((build) => build.images ?? []), []);
@@ -34,9 +35,8 @@ export default function GlobeViewer() {
 
   // Step to the previous/next build, cycling through the list.
   const step = (delta: number) => {
-    const index = builds.findIndex((build) => build.id === selectedId);
-    if (index === -1) return;
-    const next = (index + delta + builds.length) % builds.length;
+    if (selectedIndex === -1) return;
+    const next = (selectedIndex + delta + builds.length) % builds.length;
     select(builds[next].id);
   };
 
@@ -64,7 +64,7 @@ export default function GlobeViewer() {
       <div className={styles.preload} aria-hidden>
         {allImages.map((image) => (
           <span key={image.src} className={styles.preloadBox}>
-            <Image src={image.src} alt="" fill sizes="160px" loading="eager" />
+            <Image src={image.src} alt="" fill sizes="280px" loading="eager" />
           </span>
         ))}
       </div>
@@ -84,46 +84,73 @@ export default function GlobeViewer() {
       >
         {selected && (
           <>
-            {builds.length > 1 && (
-              <>
-                <button
-                  className={`${styles.arrow} ${styles.arrowPrev}`}
-                  onClick={(event) => {
-                    event.stopPropagation();
-                    step(-1);
-                  }}
-                  aria-label="Previous build"
-                >
-                  <svg viewBox="0 0 24 24" aria-hidden="true">
-                    <path d="M15 4 7 12l8 8" />
-                  </svg>
-                </button>
-                <button
-                  className={`${styles.arrow} ${styles.arrowNext}`}
-                  onClick={(event) => {
-                    event.stopPropagation();
-                    step(1);
-                  }}
-                  aria-label="Next build"
-                >
-                  <svg viewBox="0 0 24 24" aria-hidden="true">
-                    <path d="M9 4l8 8-8 8" />
-                  </svg>
-                </button>
-              </>
+            {/* Photo strip, pinned to the top edge. */}
+            {images && images.length > 0 && (
+              <div className={styles.thumbs} onClick={(event) => event.stopPropagation()}>
+                {images.map((image, index) => (
+                  <button
+                    key={image.src}
+                    type="button"
+                    className={styles.thumb}
+                    onClick={() => setGalleryIndex(index)}
+                    aria-label={image.alt}
+                  >
+                    <Image src={image.src} alt="" fill sizes="280px" />
+                  </button>
+                ))}
+              </div>
             )}
-            <div className={styles.card}>
-              <div>
-                <span className={styles.maker}>{selected.maker}</span>
+
+            {/* The counter row is the anchor for the middle group: the arrows
+                are centred on it, the name and place hang above it, and the
+                links hang below — so the name sits on the same line for every
+                build no matter how many links there are. */}
+            <div className={styles.nav}>
+              <div className={styles.info}>
+                <div>
+                  <span className={styles.maker}>{selected.maker}</span>
+                </div>
+                <div>
+                  <span className={styles.meta}>
+                    {selected.location.label} · {selected.date}
+                  </span>
+                </div>
               </div>
-              <div>
-                <span className={styles.meta}>
-                  {selected.location.label} · {selected.date}
-                </span>
-              </div>
-              <div>
-                <span className={styles.desc}>{selected.description}</span>
-              </div>
+
+              {builds.length > 1 && (
+                <>
+                  <button
+                    className={`${styles.arrow} ${styles.arrowPrev}`}
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      step(-1);
+                    }}
+                    aria-label="Previous build"
+                  >
+                    <svg viewBox="0 0 24 24" aria-hidden="true">
+                      <path d="M15 4 7 12l8 8" />
+                    </svg>
+                  </button>
+                  <button
+                    className={`${styles.arrow} ${styles.arrowNext}`}
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      step(1);
+                    }}
+                    aria-label="Next build"
+                  >
+                    <svg viewBox="0 0 24 24" aria-hidden="true">
+                      <path d="M9 4l8 8-8 8" />
+                    </svg>
+                  </button>
+                </>
+              )}
+
+              <span className={styles.kicker}>
+                {String(selectedIndex + 1).padStart(2, '0')} /{' '}
+                {String(builds.length).padStart(2, '0')}
+              </span>
+
               {selected.links && selected.links.length > 0 && (
                 <div className={styles.links}>
                   {selected.links.map((link) => (
@@ -140,21 +167,13 @@ export default function GlobeViewer() {
                   ))}
                 </div>
               )}
-              {images && images.length > 0 && (
-                <div className={styles.thumbs} onClick={(event) => event.stopPropagation()}>
-                  {images.map((image, index) => (
-                    <button
-                      key={image.src}
-                      type="button"
-                      className={styles.thumb}
-                      onClick={() => setGalleryIndex(index)}
-                      aria-label={image.alt}
-                    >
-                      <Image src={image.src} alt="" fill sizes="160px" />
-                    </button>
-                  ))}
-                </div>
-              )}
+            </div>
+
+            {/* Description, pinned to the bottom edge. Wrapper keeps the span
+                inline, so the highlight hugs each wrapped line instead of
+                becoming one big rectangle. */}
+            <div className={styles.detail}>
+              <span className={styles.desc}>{selected.description}</span>
             </div>
           </>
         )}
@@ -177,18 +196,24 @@ export default function GlobeViewer() {
             >
               close
             </button>
-            <div className={gallery.galleryStage} onClick={(event) => event.stopPropagation()}>
+            {/* No stopPropagation on the stage itself — only the photo, the
+                arrows and the thumbnails swallow the click, so clicking the
+                space around them closes the popup. */}
+            <div className={gallery.galleryStage}>
               <div className={gallery.galleryFrame}>
                 {images.length > 1 && (
                   <button
                     type="button"
                     className={gallery.galleryNav}
                     aria-label="Previous photo"
-                    onClick={() =>
-                      setGalleryIndex((i) => (i === null ? i : (i - 1 + images.length) % images.length))
-                    }
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      setGalleryIndex((i) => (i === null ? i : (i - 1 + images.length) % images.length));
+                    }}
                   >
-                    ‹
+                    <svg viewBox="0 0 24 24" aria-hidden="true">
+                      <path d="M15 4 7 12l8 8" />
+                    </svg>
                   </button>
                 )}
                 {/* eslint-disable-next-line @next/next/no-img-element */}
@@ -196,22 +221,26 @@ export default function GlobeViewer() {
                   className={gallery.galleryMain}
                   src={images[galleryIndex].src}
                   alt={images[galleryIndex].alt}
+                  onClick={(event) => event.stopPropagation()}
                 />
                 {images.length > 1 && (
                   <button
                     type="button"
                     className={gallery.galleryNav}
                     aria-label="Next photo"
-                    onClick={() =>
-                      setGalleryIndex((i) => (i === null ? i : (i + 1) % images.length))
-                    }
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      setGalleryIndex((i) => (i === null ? i : (i + 1) % images.length));
+                    }}
                   >
-                    ›
+                    <svg viewBox="0 0 24 24" aria-hidden="true">
+                      <path d="M9 4l8 8-8 8" />
+                    </svg>
                   </button>
                 )}
               </div>
               {images.length > 1 && (
-                <div className={gallery.galleryThumbs}>
+                <div className={gallery.galleryThumbs} onClick={(event) => event.stopPropagation()}>
                   {images.map((image, index) => (
                     <button
                       key={image.src}

--- a/web/src/components/sections/InsideGlobe/GlobeViewer.tsx
+++ b/web/src/components/sections/InsideGlobe/GlobeViewer.tsx
@@ -1,18 +1,23 @@
 'use client';
 
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import Image from 'next/image';
-import { createPortal } from 'react-dom';
 import Globe from './Globe';
+import PhotoLightbox from './PhotoLightbox';
 import { builds } from './builds';
-import gallery from '../InsidePanel.module.css';
+import { useAppStore } from '@/store/useAppStore';
 import styles from './GlobeViewer.module.css';
 
-// The Inside section's left viewer: an interactive globe with the picked
-// build's details overlaid on a translucent scrim. Tap a marker (or the X)
-// to open/close; tapping empty space or the marker again clears it.
+// The Inside section's viewer: an interactive globe with the picked build's
+// details overlaid on a translucent scrim. Tap a marker (or empty space, or
+// the marker again) to open/close.
+//
+// The selection lives in the app store rather than here, because on mobile the
+// viewer is only 44vh — far too little room for photos and a description — so
+// the Inside panel renders those as a card instead. See BuildCard.
 export default function GlobeViewer() {
-  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const selectedId = useAppStore((state) => state.selectedBuildId);
+  const setSelectedId = useAppStore((state) => state.setSelectedBuildId);
   const [galleryIndex, setGalleryIndex] = useState<number | null>(null);
   const [hasSelected, setHasSelected] = useState(false);
 
@@ -39,22 +44,6 @@ export default function GlobeViewer() {
     const next = (selectedIndex + delta + builds.length) % builds.length;
     select(builds[next].id);
   };
-
-  useEffect(() => {
-    if (!galleryOpen || !images) return;
-    const count = images.length;
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') setGalleryIndex(null);
-      else if (event.key === 'ArrowRight') setGalleryIndex((i) => (i === null ? i : (i + 1) % count));
-      else if (event.key === 'ArrowLeft') setGalleryIndex((i) => (i === null ? i : (i - 1 + count) % count));
-    };
-    document.body.style.overflow = 'hidden';
-    document.addEventListener('keydown', handleKeyDown);
-    return () => {
-      document.body.style.overflow = '';
-      document.removeEventListener('keydown', handleKeyDown);
-    };
-  }, [galleryOpen, images]);
 
   return (
     <div className={styles.viewer}>
@@ -101,10 +90,40 @@ export default function GlobeViewer() {
               </div>
             )}
 
-            {/* The counter row is the anchor for the middle group: the arrows
-                are centred on it, the name and place hang above it, and the
-                links hang below — so the name sits on the same line for every
-                build no matter how many links there are. */}
+            {builds.length > 1 && (
+              <>
+                <button
+                  className={`${styles.arrow} ${styles.arrowPrev}`}
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    step(-1);
+                  }}
+                  aria-label="Previous build"
+                >
+                  <svg viewBox="0 0 24 24" aria-hidden="true">
+                    <path d="M15 4 7 12l8 8" />
+                  </svg>
+                </button>
+                <button
+                  className={`${styles.arrow} ${styles.arrowNext}`}
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    step(1);
+                  }}
+                  aria-label="Next build"
+                >
+                  <svg viewBox="0 0 24 24" aria-hidden="true">
+                    <path d="M9 4l8 8-8 8" />
+                  </svg>
+                </button>
+              </>
+            )}
+
+            {/* The counter row is the anchor for the text group: the name and
+                place hang above it and the links below, so the name sits on
+                the same line for every build however many links there are. On
+                desktop the arrows share its line; on mobile they stay centred
+                in the frame while this group moves up out of the way. */}
             <div className={styles.nav}>
               <div className={styles.info}>
                 <div>
@@ -116,35 +135,6 @@ export default function GlobeViewer() {
                   </span>
                 </div>
               </div>
-
-              {builds.length > 1 && (
-                <>
-                  <button
-                    className={`${styles.arrow} ${styles.arrowPrev}`}
-                    onClick={(event) => {
-                      event.stopPropagation();
-                      step(-1);
-                    }}
-                    aria-label="Previous build"
-                  >
-                    <svg viewBox="0 0 24 24" aria-hidden="true">
-                      <path d="M15 4 7 12l8 8" />
-                    </svg>
-                  </button>
-                  <button
-                    className={`${styles.arrow} ${styles.arrowNext}`}
-                    onClick={(event) => {
-                      event.stopPropagation();
-                      step(1);
-                    }}
-                    aria-label="Next build"
-                  >
-                    <svg viewBox="0 0 24 24" aria-hidden="true">
-                      <path d="M9 4l8 8-8 8" />
-                    </svg>
-                  </button>
-                </>
-              )}
 
               <span className={styles.kicker}>
                 {String(selectedIndex + 1).padStart(2, '0')} /{' '}
@@ -179,86 +169,14 @@ export default function GlobeViewer() {
         )}
       </div>
 
-      {galleryOpen && images && typeof document !== 'undefined' &&
-        createPortal(
-          <div
-            className={gallery.gallery}
-            role="dialog"
-            aria-modal="true"
-            aria-label="Build photos"
-            onClick={() => setGalleryIndex(null)}
-          >
-            <button
-              className={gallery.galleryClose}
-              type="button"
-              aria-label="Close gallery"
-              onClick={() => setGalleryIndex(null)}
-            >
-              close
-            </button>
-            {/* No stopPropagation on the stage itself — only the photo, the
-                arrows and the thumbnails swallow the click, so clicking the
-                space around them closes the popup. */}
-            <div className={gallery.galleryStage}>
-              <div className={gallery.galleryFrame}>
-                {images.length > 1 && (
-                  <button
-                    type="button"
-                    className={gallery.galleryNav}
-                    aria-label="Previous photo"
-                    onClick={(event) => {
-                      event.stopPropagation();
-                      setGalleryIndex((i) => (i === null ? i : (i - 1 + images.length) % images.length));
-                    }}
-                  >
-                    <svg viewBox="0 0 24 24" aria-hidden="true">
-                      <path d="M15 4 7 12l8 8" />
-                    </svg>
-                  </button>
-                )}
-                {/* eslint-disable-next-line @next/next/no-img-element */}
-                <img
-                  className={gallery.galleryMain}
-                  src={images[galleryIndex].src}
-                  alt={images[galleryIndex].alt}
-                  onClick={(event) => event.stopPropagation()}
-                />
-                {images.length > 1 && (
-                  <button
-                    type="button"
-                    className={gallery.galleryNav}
-                    aria-label="Next photo"
-                    onClick={(event) => {
-                      event.stopPropagation();
-                      setGalleryIndex((i) => (i === null ? i : (i + 1) % images.length));
-                    }}
-                  >
-                    <svg viewBox="0 0 24 24" aria-hidden="true">
-                      <path d="M9 4l8 8-8 8" />
-                    </svg>
-                  </button>
-                )}
-              </div>
-              {images.length > 1 && (
-                <div className={gallery.galleryThumbs} onClick={(event) => event.stopPropagation()}>
-                  {images.map((image, index) => (
-                    <button
-                      key={image.src}
-                      type="button"
-                      className={`${gallery.galleryThumb} ${index === galleryIndex ? gallery.galleryThumbActive : ''}`}
-                      onClick={() => setGalleryIndex(index)}
-                      aria-label={image.alt}
-                      aria-current={index === galleryIndex}
-                    >
-                      <Image src={image.src} alt="" fill sizes="42px" />
-                    </button>
-                  ))}
-                </div>
-              )}
-            </div>
-          </div>,
-          document.body,
-        )}
+      {galleryOpen && images && (
+        <PhotoLightbox
+          images={images}
+          index={galleryIndex}
+          onIndexChange={setGalleryIndex}
+          onClose={() => setGalleryIndex(null)}
+        />
+      )}
     </div>
   );
 }

--- a/web/src/components/sections/InsideGlobe/PhotoLightbox.tsx
+++ b/web/src/components/sections/InsideGlobe/PhotoLightbox.tsx
@@ -1,0 +1,116 @@
+'use client';
+
+import { useEffect } from 'react';
+import Image from 'next/image';
+import { createPortal } from 'react-dom';
+import type { BuildImage } from './builds';
+import gallery from '../InsidePanel.module.css';
+
+interface PhotoLightboxProps {
+  images: BuildImage[];
+  index: number;
+  onIndexChange: (next: number) => void;
+  onClose: () => void;
+}
+
+// Full-screen photo viewer for a build's images. Shared by the globe overlay
+// and the Inside panel's mobile build card.
+export default function PhotoLightbox({
+  images,
+  index,
+  onIndexChange,
+  onClose,
+}: PhotoLightboxProps) {
+  const count = images.length;
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') onClose();
+      else if (event.key === 'ArrowRight') onIndexChange((index + 1) % count);
+      else if (event.key === 'ArrowLeft') onIndexChange((index - 1 + count) % count);
+    };
+    document.body.style.overflow = 'hidden';
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.body.style.overflow = '';
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [index, count, onClose, onIndexChange]);
+
+  if (typeof document === 'undefined') return null;
+
+  return createPortal(
+    <div
+      className={gallery.gallery}
+      role="dialog"
+      aria-modal="true"
+      aria-label="Build photos"
+      onClick={onClose}
+    >
+      <button className={gallery.galleryClose} type="button" aria-label="Close gallery" onClick={onClose}>
+        close
+      </button>
+      {/* No stopPropagation on the stage itself — only the photo, the arrows
+          and the thumbnails swallow the click, so clicking the space around
+          them closes the popup. */}
+      <div className={gallery.galleryStage}>
+        <div className={gallery.galleryFrame}>
+          {count > 1 && (
+            <button
+              type="button"
+              className={gallery.galleryNav}
+              aria-label="Previous photo"
+              onClick={(event) => {
+                event.stopPropagation();
+                onIndexChange((index - 1 + count) % count);
+              }}
+            >
+              <svg viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M15 4 7 12l8 8" />
+              </svg>
+            </button>
+          )}
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            className={gallery.galleryMain}
+            src={images[index].src}
+            alt={images[index].alt}
+            onClick={(event) => event.stopPropagation()}
+          />
+          {count > 1 && (
+            <button
+              type="button"
+              className={gallery.galleryNav}
+              aria-label="Next photo"
+              onClick={(event) => {
+                event.stopPropagation();
+                onIndexChange((index + 1) % count);
+              }}
+            >
+              <svg viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M9 4l8 8-8 8" />
+              </svg>
+            </button>
+          )}
+        </div>
+        {count > 1 && (
+          <div className={gallery.galleryThumbs} onClick={(event) => event.stopPropagation()}>
+            {images.map((image, thumbIndex) => (
+              <button
+                key={image.src}
+                type="button"
+                className={`${gallery.galleryThumb} ${thumbIndex === index ? gallery.galleryThumbActive : ''}`}
+                onClick={() => onIndexChange(thumbIndex)}
+                aria-label={image.alt}
+                aria-current={thumbIndex === index}
+              >
+                <Image src={image.src} alt="" fill sizes="42px" />
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/web/src/components/sections/InsidePanel.module.css
+++ b/web/src/components/sections/InsidePanel.module.css
@@ -207,12 +207,13 @@
   cursor: pointer;
 }
 
+/* Keeps the zoom-out cursor: only the photo, the arrows and the thumbnails
+   swallow the click, so anywhere around them closes the popup. */
 .galleryStage {
   display: flex;
   flex-direction: column;
   align-items: center;
   gap: 14px;
-  cursor: default;
 }
 
 .galleryFrame {
@@ -221,27 +222,32 @@
   gap: 16px;
 }
 
+/* Bare glyph chevrons, the same shape as the build map's. */
 .galleryNav {
   flex-shrink: 0;
-  width: 44px;
-  height: 44px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
   padding: 0;
-  border: 1px solid rgba(244, 239, 230, 0.35);
-  border-radius: 50%;
-  background: rgba(20, 20, 20, 0.35);
-  color: var(--cream);
-  font-size: 24px;
-  line-height: 1;
+  border: 0;
+  background: transparent;
+  color: var(--pf-led);
   cursor: pointer;
-  transition: background 0.2s ease, border-color 0.2s ease;
+  transition: transform 0.18s ease;
+}
+
+.galleryNav svg {
+  width: 56px;
+  height: 56px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2.1;
+  stroke-linecap: round;
+  stroke-linejoin: round;
 }
 
 .galleryNav:hover {
-  background: rgba(20, 20, 20, 0.85);
-  border-color: var(--cream);
+  transform: scale(1.08);
 }
 
 .galleryMain {
@@ -251,6 +257,7 @@
   height: auto;
   object-fit: contain;
   display: block;
+  cursor: default;
 }
 
 .galleryThumbs {
@@ -290,7 +297,7 @@
   .galleryThumb { width: 36px; }
   .galleryMain { max-width: 94vw; max-height: 72vh; }
   .galleryFrame { gap: 8px; }
-  .galleryNav { width: 36px; height: 36px; font-size: 20px; }
+  .galleryNav svg { width: 36px; height: 36px; }
 }
 
 .actionList {

--- a/web/src/components/sections/InsidePanel.tsx
+++ b/web/src/components/sections/InsidePanel.tsx
@@ -2,6 +2,7 @@
 
 import Link from 'next/link';
 import { SectionContent } from '@/lib/content';
+import BuildCard from './InsideGlobe/BuildCard';
 import styles from './InsidePanel.module.css';
 
 interface InsidePanelProps {
@@ -66,6 +67,9 @@ export default function InsidePanel({ content }: InsidePanelProps) {
               one yourself, come share it in Discord and I&apos;ll add your pin to the map.
             </p>
           </div>
+          {/* Mobile only — the details for the pin picked on the globe above,
+              which has no room to show them at 44vh. */}
+          <BuildCard />
         </div>
 
         <div className="pf-block">

--- a/web/src/store/useAppStore.ts
+++ b/web/src/store/useAppStore.ts
@@ -11,6 +11,11 @@ interface AppState {
   setActiveSection: (section: SectionType) => void;
   homeTab: HomeTabType;
   setHomeTab: (tab: HomeTabType) => void;
+  // Which build pin is open on the globe. Lifted out of the globe itself so
+  // the Inside panel can show the details as a card — on mobile the viewer is
+  // only 44vh, far too little room for photos and a description.
+  selectedBuildId: string | null;
+  setSelectedBuildId: (id: string | null) => void;
   knobValues: {
     c1: number;
     c2: number;
@@ -39,6 +44,8 @@ export const useAppStore = create<AppState>((set) => ({
   setActiveSection: (section) => set({ activeSection: section }),
   homeTab: 'hero',
   setHomeTab: (tab) => set({ homeTab: tab }),
+  selectedBuildId: null,
+  setSelectedBuildId: (id) => set({ selectedBuildId: id }),
   knobValues: {
     c1: 0.00, // Hue
     c2: 2.00, // Speed


### PR DESCRIPTION
## What

Two passes over the Inside section's build map.

**Desktop.** The card was one bottom-anchored stack, so a longer description or an extra link shoved the maker's name up the frame — the name moved by as much as 280px between pins, which is tiring to read through. It is now three independent bands that cannot push each other: photos pinned to the top, the name / place / counter / links group hung off a single centred row a third up from the bottom, and the description pinned to the bottom edge. Switching pins swaps text in place, with no fade or slide.

Along the way: the position in the set (`03 / 08`) sits between the arrows, the photo tiles are larger and centred, and the globe reads faintly through the text highlights — with the line-height opened up so the per-line fills no longer overlap and draw a seam at every line break.

**Mobile.** The viewer is pinned to the top 44vh, which is nowhere near enough room for photos, a description and links on top of the globe. The overlay now carries only the name, place, position and arrows; the picked build's details render as a card down in the Inside panel instead, in the panel's own typography. Tapping a pin scrolls to it.

**Photo popup.** Extracted into `PhotoLightbox` so the overlay and the mobile card share one copy. Its arrows now match the build map's, and a click anywhere around the photo closes it.

## Notes

- The selection moved into `useAppStore` because the globe and the Inside panel are separate component trees.
- The card's description needed `.card .desc` rather than a bare module class: `globals.css`'s `.panel-body p` (17px on mobile) outranks a single module class and was silently winning.

## Testing

- `npm run build` passes.
- Checked in the browser at 375px and 1440px: the card renders on mobile and is `display: none` on desktop, the moved elements are `none` in the mobile overlay, no console errors either way.
- The layout itself was reviewed visually by @engmung throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
