### PR TITLE
Build and flash custom patterns from the browser, without the Arduino IDE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,6 @@ tmp/
 integrations/ableton/max/*.amxd
 integrations/ableton/projects/
 
+
+# firmware build worker scratch (warm cache + sketch copy)
+/.build-worker

--- a/BUILD_GUIDE.md
+++ b/BUILD_GUIDE.md
@@ -265,7 +265,7 @@ No installation required — desktop **Chrome or Edge** only (Web Serial; Firefo
 
 > 🔌 **Use the RIGHT USB-C port** for Arduino IDE — the one on your right when the ports face you, labeled `UART`/`COM`. It's the USB-to-UART bridge Arduino uploads through; the left (native `USB`) port is for the browser flasher (§8.1). If the IDE doesn't see a serial port, you're likely on the wrong one.
 
-- Board settings: *ESP32S3 Dev Module*, PSRAM: *OPI PSRAM*, Flash: *16MB*, USB CDC On Boot: *Disabled* — full setup in [`firmware/README.md`](firmware/README.md).
+- Board settings: *ESP32S3 Dev Module*, PSRAM: *OPI PSRAM*, Flash: *16MB*, USB CDC On Boot: *Enabled* — full setup in [`firmware/README.md`](firmware/README.md). CDC On Boot is what puts the browser flasher's Wi-Fi setup on the left `USB` port; with it disabled that step moves to the other socket.
 - If your panel's driver IC is FM6126A/FM6124, set `PANEL_PROFILE` to `PANEL_HIGHREFRESH` in `config.h` (default `PANEL_STANDARD` covers 74HC595).
 - To wipe stored Wi-Fi credentials, enable **Tools → Erase All Flash Before Sketch Upload** before uploading (see the Wi-Fi note in §8.1).
 - **ArduinoOTA** works over Wi-Fi after the first join — functional, but the flasher and wired upload are the primary paths.

--- a/firmware/README.md
+++ b/firmware/README.md
@@ -16,8 +16,16 @@ The firmware handles the ESP32-S3 DMA driver for the HUB75 LED matrix, reads fou
 - **PSRAM:** OPI PSRAM
 - **Flash Size:** 16MB
 - **Partition Scheme:** 16M Flash with PSRAM-aware partition
-- **USB CDC On Boot:** Disabled
+- **USB CDC On Boot:** Enabled
 - **Upload Mode:** UART0 / Hardware CDC
+
+> **Why CDC On Boot matters.** It decides whether `Serial` is the native USB
+> peripheral or UART0 — and therefore which of the two USB-C ports answers the
+> browser flasher's Wi-Fi setup (Improv speaks over `Serial`). Enabled puts it
+> on the **left/native `USB`** port, which is what the released firmware does
+> and what §8.1 of the build guide tells people to use. Building with it
+> disabled produces firmware that flashes fine but whose Wi-Fi setup only
+> appears on the other socket.
 
 ### Required libraries
 Install these via the Arduino Library Manager:

--- a/firmware/patternflow/net_config.h
+++ b/firmware/patternflow/net_config.h
@@ -76,10 +76,19 @@
 #endif
 
 // ── OSC (Ableton/Max sidechannel) ────────────────────────────
-// Off by default — opt in from patternflow_secrets.h. Sends knob/button/
-// state out and accepts knob/pattern/content commands back.
+// Sends knob/button/state out and accepts knob/pattern/content commands back.
+//
+// On by default so that a build from a clean checkout matches the firmware we
+// release. It used to be opt-in from patternflow_secrets.h, but that file is
+// gitignored — so anyone building without one (a fresh clone, CI, the web
+// build service) silently got firmware with OSC missing, showing "OSC n/a" on
+// the knob-2 status screen while everything else looked right.
+//
+// Costs nothing when unused: with no remote configured it only listens, and
+// sends nothing until something talks to it first. Set to 0 in
+// patternflow_secrets.h to compile it out.
 #ifndef PF_OSC_ENABLED
-#define PF_OSC_ENABLED 0
+#define PF_OSC_ENABLED 1
 #endif
 // Where outgoing OSC goes. Leave EMPTY (the default) to auto-learn: the
 // device locks onto whoever sends it the first valid OSC packet — the M4L

--- a/web/.env.example
+++ b/web/.env.example
@@ -49,15 +49,10 @@ COMMUNITY_ALLOWED_ORIGINS=https://patternflow.work
 #BUILD_ARTIFACT_DIR=/home/pi/patternflow-data/builds
 #ARDUINO_CLI_PATH=arduino-cli
 #
-# BUILD_FQBN — set this EXPLICITLY. A bare `esp32:esp32:esp32s3` compiles with
-# the board package's defaults, which are not the settings this firmware needs
-# (see firmware/README.md), and the mismatch is silent:
-#   · PSRAM defaults to OFF, so PFMem::allocFloats gets no PSRAM and patterns
-#     with framebuffer-sized buffers fail only on web-built firmware
-#   · FlashSize defaults to 4MB against a 16MB partition table
-#   · CDCOnBoot decides whether Serial — and therefore Improv Wi-Fi setup —
-#     answers on the native USB port or the UART bridge, so getting it wrong
-#     moves Wi-Fi provisioning to the other USB socket
-# Confirm the option names against the installed core before trusting this:
-#   arduino-cli board details --fqbn esp32:esp32:esp32s3
+# BUILD_FQBN — normally leave this unset. The built-in default already pins the
+# board options firmware/README.md requires (PSRAM, flash size, partition
+# scheme, CDC on boot), and a build is refused if an override drops any of
+# them: leaving one out compiles against the board defaults and produces
+# firmware that boots but is not the firmware we release.
+# To inspect the available options: arduino-cli board details --fqbn esp32:esp32:esp32s3
 #BUILD_FQBN=esp32:esp32:esp32s3:PSRAM=opi,FlashSize=16M,PartitionScheme=app3M_fat9M_16MB,CDCOnBoot=cdc,USBMode=hwcdc

--- a/web/.env.example
+++ b/web/.env.example
@@ -35,3 +35,17 @@ NEXT_PUBLIC_COMMUNITY_URL=https://community.patternflow.work
 # trustedOrigins (its Origin-header CSRF check), so the main site must be named
 # here or cross-origin sign-in and publishing are rejected.
 COMMUNITY_ALLOWED_ORIGINS=https://patternflow.work
+
+# ── Firmware build service (community host with a worker) ────────────────────
+# Server side: enables POST /api/community/builds. Needs arduino-cli installed
+# and `npm run worker` running. Compiling submitted C++ is arbitrary code
+# execution at compile time — keep this off until the worker is sandboxed.
+#BUILD_ENABLED=1
+# Client side: shows the "Build firmware" buttons. Set both, or neither.
+#NEXT_PUBLIC_BUILD_ENABLED=1
+# Overrides for the worker (defaults are usually right in a repo checkout):
+#FIRMWARE_SRC_DIR=/home/pi/Patternflow/firmware/patternflow
+#BUILD_WORK_DIR=/home/pi/patternflow-data/build-worker
+#BUILD_ARTIFACT_DIR=/home/pi/patternflow-data/builds
+#ARDUINO_CLI_PATH=arduino-cli
+#BUILD_FQBN=esp32:esp32:esp32s3

--- a/web/.env.example
+++ b/web/.env.example
@@ -48,4 +48,16 @@ COMMUNITY_ALLOWED_ORIGINS=https://patternflow.work
 #BUILD_WORK_DIR=/home/pi/patternflow-data/build-worker
 #BUILD_ARTIFACT_DIR=/home/pi/patternflow-data/builds
 #ARDUINO_CLI_PATH=arduino-cli
-#BUILD_FQBN=esp32:esp32:esp32s3
+#
+# BUILD_FQBN — set this EXPLICITLY. A bare `esp32:esp32:esp32s3` compiles with
+# the board package's defaults, which are not the settings this firmware needs
+# (see firmware/README.md), and the mismatch is silent:
+#   · PSRAM defaults to OFF, so PFMem::allocFloats gets no PSRAM and patterns
+#     with framebuffer-sized buffers fail only on web-built firmware
+#   · FlashSize defaults to 4MB against a 16MB partition table
+#   · CDCOnBoot decides whether Serial — and therefore Improv Wi-Fi setup —
+#     answers on the native USB port or the UART bridge, so getting it wrong
+#     moves Wi-Fi provisioning to the other USB socket
+# Confirm the option names against the installed core before trusting this:
+#   arduino-cli board details --fqbn esp32:esp32:esp32s3
+#BUILD_FQBN=esp32:esp32:esp32s3:PSRAM=opi,FlashSize=16M,PartitionScheme=app3M_fat9M_16MB,CDCOnBoot=cdc,USBMode=hwcdc

--- a/web/drizzle/0004_add-builds.sql
+++ b/web/drizzle/0004_add-builds.sql
@@ -1,0 +1,18 @@
+CREATE TABLE `builds` (
+	`id` text PRIMARY KEY NOT NULL,
+	`user_id` text NOT NULL,
+	`status` text DEFAULT 'queued' NOT NULL,
+	`patterns` text NOT NULL,
+	`namespaces` text,
+	`artifact` text,
+	`artifact_bytes` integer,
+	`error` text,
+	`worker` text,
+	`created_at` integer NOT NULL,
+	`started_at` integer,
+	`finished_at` integer,
+	FOREIGN KEY (`user_id`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `builds_status_created_idx` ON `builds` (`status`,`created_at`);--> statement-breakpoint
+CREATE INDEX `builds_user_id_idx` ON `builds` (`user_id`);

--- a/web/drizzle/meta/0004_snapshot.json
+++ b/web/drizzle/meta/0004_snapshot.json
@@ -1,0 +1,932 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "cd533c39-68db-48d9-92ce-d1cc38597af5",
+  "prevId": "a9fdae23-e1a1-4dc1-890c-4028a811d393",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "builds": {
+      "name": "builds",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'queued'"
+        },
+        "patterns": {
+          "name": "patterns",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "namespaces": {
+          "name": "namespaces",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "artifact": {
+          "name": "artifact",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "artifact_bytes": {
+          "name": "artifact_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "worker": {
+          "name": "worker",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "builds_status_created_idx": {
+          "name": "builds_status_created_idx",
+          "columns": [
+            "status",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "builds_user_id_idx": {
+          "name": "builds_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "builds_user_id_user_id_fk": {
+          "name": "builds_user_id_user_id_fk",
+          "tableFrom": "builds",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "comments": {
+      "name": "comments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pattern_id": {
+          "name": "pattern_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "comments_pattern_id_idx": {
+          "name": "comments_pattern_id_idx",
+          "columns": [
+            "pattern_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "comments_pattern_id_patterns_id_fk": {
+          "name": "comments_pattern_id_patterns_id_fk",
+          "tableFrom": "comments",
+          "tableTo": "patterns",
+          "columnsFrom": [
+            "pattern_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "comments_user_id_user_id_fk": {
+          "name": "comments_user_id_user_id_fk",
+          "tableFrom": "comments",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "likes": {
+      "name": "likes",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pattern_id": {
+          "name": "pattern_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "likes_pattern_id_idx": {
+          "name": "likes_pattern_id_idx",
+          "columns": [
+            "pattern_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "likes_user_id_user_id_fk": {
+          "name": "likes_user_id_user_id_fk",
+          "tableFrom": "likes",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "likes_pattern_id_patterns_id_fk": {
+          "name": "likes_pattern_id_patterns_id_fk",
+          "tableFrom": "likes",
+          "tableTo": "patterns",
+          "columnsFrom": [
+            "pattern_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "likes_user_id_pattern_id_pk": {
+          "columns": [
+            "user_id",
+            "pattern_id"
+          ],
+          "name": "likes_user_id_pattern_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "patterns": {
+      "name": "patterns",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code_cpp": {
+          "name": "code_cpp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "license": {
+          "name": "license",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'CC-BY-SA-4.0'"
+        },
+        "made_on": {
+          "name": "made_on",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "patterns_created_at_idx": {
+          "name": "patterns_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "patterns_user_id_idx": {
+          "name": "patterns_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "patterns_user_id_user_id_fk": {
+          "name": "patterns_user_id_user_id_fk",
+          "tableFrom": "patterns",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "patterns_parent_id_patterns_id_fk": {
+          "name": "patterns_parent_id_patterns_id_fk",
+          "tableFrom": "patterns",
+          "tableTo": "patterns",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "post_comments": {
+      "name": "post_comments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "post_comments_post_id_idx": {
+          "name": "post_comments_post_id_idx",
+          "columns": [
+            "post_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "post_comments_post_id_posts_id_fk": {
+          "name": "post_comments_post_id_posts_id_fk",
+          "tableFrom": "post_comments",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_comments_user_id_user_id_fk": {
+          "name": "post_comments_user_id_user_id_fk",
+          "tableFrom": "post_comments",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "posts": {
+      "name": "posts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "posts_created_at_idx": {
+          "name": "posts_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "posts_user_id_idx": {
+          "name": "posts_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "posts_user_id_user_id_fk": {
+          "name": "posts_user_id_user_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "display_username": {
+          "name": "display_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        },
+        "user_username_unique": {
+          "name": "user_username_unique",
+          "columns": [
+            "username"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/web/drizzle/meta/_journal.json
+++ b/web/drizzle/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1784949672023,
       "tag": "0003_add-board",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "6",
+      "when": 1784987368285,
+      "tag": "0004_add-builds",
+      "breakpoints": true
     }
   ]
 }

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -5263,7 +5263,6 @@
       "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.11.1.tgz",
       "integrity": "sha512-dq9AtApgg5PGFtBzPFSBl3HZQjHok5gaQCM6zh2Yk0aSmDCs1CbnVI8/HgASQkNKsWFpseIO9beg5xxpYhbIfA==",
       "hasInstallScript": true,
-      "license": "MIT",
       "dependencies": {
         "bindings": "^1.5.0",
         "prebuild-install": "^7.1.1"

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -44,6 +44,7 @@
         "eslint": "^9",
         "eslint-config-next": "16.2.4",
         "tailwindcss": "^4",
+        "tsx": "^4.20.6",
         "typescript": "^5"
       }
     },

--- a/web/package.json
+++ b/web/package.json
@@ -6,7 +6,10 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "worker": "tsx scripts/build-worker.ts",
+    "build:enqueue": "tsx scripts/enqueue-test-build.ts",
+    "build:status": "tsx scripts/build-status.ts"
   },
   "dependencies": {
     "@chenglou/pretext": "^0.0.6",
@@ -45,6 +48,7 @@
     "eslint": "^9",
     "eslint-config-next": "16.2.4",
     "tailwindcss": "^4",
+    "tsx": "^4.20.6",
     "typescript": "^5"
   }
 }

--- a/web/scripts/build-status.ts
+++ b/web/scripts/build-status.ts
@@ -1,0 +1,46 @@
+/**
+ * Show a build's state.
+ *
+ *   npm run build:status -- <build-id>
+ *   npm run build:status              # the most recent build
+ */
+import { loadEnv } from "./loadEnv";
+
+loadEnv();
+
+async function main() {
+  const { getBuild, parseBuildPatterns, artifactDir } = await import("../src/lib/community/builds");
+  const { getDb } = await import("../src/lib/community/db");
+  const { builds } = await import("../src/lib/community/schema");
+  const { desc } = await import("drizzle-orm");
+  const path = await import("node:path");
+
+  const id = process.argv[2];
+  const build = id
+    ? await getBuild(id)
+    : (await getDb().select().from(builds).orderBy(desc(builds.createdAt)).limit(1))[0];
+
+  if (!build) {
+    console.log(id ? `No build ${id}` : "No builds yet.");
+    process.exit(1);
+  }
+
+  const seconds =
+    build.startedAt && build.finishedAt
+      ? ((build.finishedAt.getTime() - build.startedAt.getTime()) / 1000).toFixed(1)
+      : null;
+
+  console.log(`build   : ${build.id}`);
+  console.log(`status  : ${build.status}`);
+  console.log(`patterns: ${parseBuildPatterns(build.patterns).map((p) => p.label).join(", ")}`);
+  if (build.namespaces) console.log(`namespac: ${build.namespaces}`);
+  if (build.worker) console.log(`worker  : ${build.worker}`);
+  if (seconds) console.log(`took    : ${seconds}s`);
+  if (build.artifact) {
+    console.log(`image   : ${path.join(artifactDir(), build.artifact)}`);
+    console.log(`size    : ${((build.artifactBytes ?? 0) / 1024).toFixed(0)} KB`);
+  }
+  if (build.error) console.log(`\n--- error ---\n${build.error}`);
+}
+
+void main();

--- a/web/scripts/build-worker.ts
+++ b/web/scripts/build-worker.ts
@@ -37,7 +37,10 @@ const WORK_DIR = process.env.BUILD_WORK_DIR ?? path.resolve(process.cwd(), "../.
 
 const options = {
   firmwareSrcDir: FIRMWARE_SRC_DIR,
-  sketchDir: path.join(WORK_DIR, "sketch"),
+  // Keeps the source directory's name: arduino-cli requires a sketch folder to
+  // contain a .ino of the same name, so renaming this to "sketch" would make
+  // every build fail to find patternflow.ino.
+  sketchDir: path.join(WORK_DIR, path.basename(FIRMWARE_SRC_DIR)),
   buildPath: path.join(WORK_DIR, "cache"),
   artifactDir: artifactDir(),
 };

--- a/web/scripts/build-worker.ts
+++ b/web/scripts/build-worker.ts
@@ -18,6 +18,10 @@
  * reach it.
  */
 import path from "node:path";
+import { loadEnv } from "./loadEnv";
+
+loadEnv();
+
 import {
   artifactDir,
   claimNextBuild,

--- a/web/scripts/build-worker.ts
+++ b/web/scripts/build-worker.ts
@@ -1,0 +1,121 @@
+/**
+ * Firmware build worker.
+ *
+ * Runs as its own process, beside the web server but not inside it: a build
+ * pegs a core for ~15 seconds, and doing that in a request handler would let
+ * concurrent uploads starve the site of the CPU it is running on.
+ *
+ *   npx tsx scripts/build-worker.ts
+ *
+ * One worker owns one sketch directory and one build path, and takes one job at
+ * a time. For two concurrent builds, run two workers with different
+ * BUILD_WORK_DIR and WORKER_ID — never point two at the same directories, as
+ * they would overwrite each other's intermediates and lose the warm cache that
+ * makes a build 15 s instead of 2 min.
+ *
+ * ⚠️  This compiles submitted C++ with no sandbox of its own. See the warning
+ * in src/lib/firmware/buildRunner.ts before letting anyone but the maintainer
+ * reach it.
+ */
+import path from "node:path";
+import {
+  artifactDir,
+  claimNextBuild,
+  completeBuild,
+  failBuild,
+  parseBuildPatterns,
+} from "../src/lib/community/builds";
+import { runBuild } from "../src/lib/firmware/buildRunner";
+
+const WORKER_ID = process.env.WORKER_ID ?? `worker-${process.pid}`;
+const POLL_MS = Number(process.env.BUILD_POLL_MS ?? 2000);
+
+// Defaults assume the worker is started from web/ in a repo checkout.
+const FIRMWARE_SRC_DIR =
+  process.env.FIRMWARE_SRC_DIR ?? path.resolve(process.cwd(), "../firmware/patternflow");
+const WORK_DIR = process.env.BUILD_WORK_DIR ?? path.resolve(process.cwd(), "../.build-worker");
+
+const options = {
+  firmwareSrcDir: FIRMWARE_SRC_DIR,
+  sketchDir: path.join(WORK_DIR, "sketch"),
+  buildPath: path.join(WORK_DIR, "cache"),
+  artifactDir: artifactDir(),
+};
+
+let stopping = false;
+
+function log(message: string, extra: Record<string, unknown> = {}) {
+  const detail = Object.entries(extra)
+    .map(([key, value]) => `${key}=${value}`)
+    .join(" ");
+  console.log(`[${new Date().toISOString()}] [${WORKER_ID}] ${message}${detail ? ` ${detail}` : ""}`);
+}
+
+async function processOne(): Promise<boolean> {
+  const job = await claimNextBuild(WORKER_ID);
+  if (!job) return false;
+
+  const patterns = parseBuildPatterns(job.patterns);
+  log("build started", { id: job.id, patterns: patterns.length });
+  const startedAt = Date.now();
+
+  try {
+    const result = await runBuild(job.id, patterns, options);
+    const seconds = ((Date.now() - startedAt) / 1000).toFixed(1);
+
+    if (result.ok) {
+      await completeBuild(job.id, {
+        artifact: result.artifact,
+        artifactBytes: result.artifactBytes,
+        namespaces: result.namespaces,
+      });
+      log("build ok", { id: job.id, seconds, kb: Math.round(result.artifactBytes / 1024) });
+    } else {
+      await failBuild(job.id, result.error);
+      log("build failed", { id: job.id, seconds });
+    }
+  } catch (error) {
+    // An unexpected throw must still release the job, or it sits in "running"
+    // until the stale reaper picks it up ten minutes later.
+    const message = error instanceof Error ? error.stack ?? error.message : String(error);
+    await failBuild(job.id, message);
+    log("build crashed", { id: job.id });
+  }
+
+  return true;
+}
+
+async function main() {
+  log("starting", {
+    firmware: options.firmwareSrcDir,
+    work: WORK_DIR,
+    artifacts: options.artifactDir,
+  });
+
+  for (const signal of ["SIGINT", "SIGTERM"] as const) {
+    process.on(signal, () => {
+      if (stopping) process.exit(1); // second signal: give up waiting
+      stopping = true;
+      log("stopping after the current build");
+    });
+  }
+
+  while (!stopping) {
+    let worked = false;
+    try {
+      worked = await processOne();
+    } catch (error) {
+      // Database hiccup, not a build failure — back off and keep going rather
+      // than exiting, so a transient error doesn't take the queue down.
+      log(`poll error: ${error instanceof Error ? error.message : String(error)}`);
+    }
+    if (!worked && !stopping) {
+      await new Promise((resolve) => setTimeout(resolve, POLL_MS));
+    }
+  }
+
+  log("stopped");
+  process.exit(0);
+}
+
+void main();

--- a/web/scripts/enqueue-test-build.ts
+++ b/web/scripts/enqueue-test-build.ts
@@ -1,0 +1,46 @@
+/**
+ * Put one build on the queue, for testing the worker without the web UI.
+ *
+ *   npm run build:enqueue                 # uses firmware/patternflow/custom1.h
+ *   npm run build:enqueue -- path/to.h    # or a header of your choosing
+ *
+ * Prints the build id, then poll it with:  npm run build:status -- <id>
+ */
+import fs from "node:fs";
+import path from "node:path";
+import { loadEnv } from "./loadEnv";
+
+loadEnv();
+
+async function main() {
+  const { enqueueBuild } = await import("../src/lib/community/builds");
+  const { getDb } = await import("../src/lib/community/db");
+  const { user } = await import("../src/lib/community/schema");
+
+  const headerArg = process.argv[2];
+  const headerPath = headerArg
+    ? path.resolve(process.cwd(), headerArg)
+    : path.resolve(process.cwd(), "../firmware/patternflow/custom1.h");
+
+  if (!fs.existsSync(headerPath)) {
+    console.error(`No header at ${headerPath}`);
+    process.exit(1);
+  }
+
+  // Builds belong to a user, so borrow the first account in the database.
+  const accounts = await getDb().select({ id: user.id, name: user.username }).from(user).limit(1);
+  if (accounts.length === 0) {
+    console.error("No accounts exist yet — sign up on the site first, then rerun.");
+    process.exit(1);
+  }
+
+  const code = fs.readFileSync(headerPath, "utf8");
+  const id = await enqueueBuild(accounts[0].id, [{ label: path.basename(headerPath), code }]);
+
+  console.log(`queued build ${id}`);
+  console.log(`  header : ${headerPath} (${(code.length / 1024).toFixed(1)} KB)`);
+  console.log(`  as     : ${accounts[0].name}`);
+  console.log(`\nnpm run build:status -- ${id}`);
+}
+
+void main();

--- a/web/scripts/loadEnv.ts
+++ b/web/scripts/loadEnv.ts
@@ -1,0 +1,18 @@
+import fs from "node:fs";
+import path from "node:path";
+
+/**
+ * Load .env.local for standalone scripts.
+ *
+ * Next.js does this itself, but the worker is its own process and would
+ * otherwise miss COMMUNITY_DB_PATH and write to a second, empty database
+ * beside the real one — which fails silently and confusingly.
+ */
+export function loadEnv(): void {
+  for (const file of [".env.local", ".env"]) {
+    const target = path.resolve(process.cwd(), file);
+    if (!fs.existsSync(target)) continue;
+    // Node 20.12+ / 22+. Values already in the environment win.
+    process.loadEnvFile(target);
+  }
+}

--- a/web/src/app/api/community/builds/[id]/firmware/route.ts
+++ b/web/src/app/api/community/builds/[id]/firmware/route.ts
@@ -1,0 +1,56 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { artifactDir, getBuild } from "@/lib/community/builds";
+import { preflight, withCors } from "@/lib/community/cors";
+import { communityEnabled } from "@/lib/community/db";
+
+// GET /api/community/builds/[id]/firmware — the built application image.
+//
+// No credential check by design: esp-web-tools fetches this itself, without
+// cookies and possibly cross-origin. The build id is the capability (see the
+// status route). No CORS *rejection* either, for the same reason — the flasher
+// must be able to read it from whichever origin the page was served from.
+
+export async function GET(request: Request, context: { params: Promise<{ id: string }> }) {
+  return withCors(request, await handleGet(context));
+}
+
+export const OPTIONS = preflight;
+
+async function handleGet(context: { params: Promise<{ id: string }> }) {
+  if (!communityEnabled()) {
+    return new Response("Community is not enabled on this deployment.", { status: 503 });
+  }
+
+  const { id } = await context.params;
+  const build = await getBuild(id);
+  if (!build || build.status !== "done" || !build.artifact) {
+    return new Response("No firmware for this build.", { status: 404 });
+  }
+
+  // The artifact name comes from the database, but it is still joined and then
+  // checked: a stored value containing traversal must not be able to read
+  // outside the artifact directory.
+  const directory = artifactDir();
+  const file = path.resolve(directory, build.artifact);
+  if (!file.startsWith(path.resolve(directory) + path.sep)) {
+    return new Response("Invalid artifact path.", { status: 400 });
+  }
+
+  let image: Buffer;
+  try {
+    image = await fs.readFile(file);
+  } catch {
+    return new Response("Firmware image is missing from disk.", { status: 410 });
+  }
+
+  return new Response(new Uint8Array(image), {
+    headers: {
+      "Content-Type": "application/octet-stream",
+      "Content-Length": String(image.byteLength),
+      "Content-Disposition": `attachment; filename="patternflow-${build.id}.bin"`,
+      // Immutable once built, and the URL contains the build id.
+      "Cache-Control": "private, max-age=3600",
+    },
+  });
+}

--- a/web/src/app/api/community/builds/[id]/manifest/route.ts
+++ b/web/src/app/api/community/builds/[id]/manifest/route.ts
@@ -1,0 +1,64 @@
+import { getBuild } from "@/lib/community/builds";
+import { preflight, withCors } from "@/lib/community/cors";
+import { communityEnabled, communityHomeUrl } from "@/lib/community/db";
+import { APP_OFFSET, STATIC_FLASH_PARTS } from "@/lib/firmware/paths";
+
+// GET /api/community/builds/[id]/manifest — an esp-web-tools manifest for a
+// custom build.
+//
+// The bootloader and partition table are the ones already committed for the
+// stock firmware; only the application image is per-build. Paths are absolute
+// URLs rather than relative ones: esp-web-tools resolves them against the
+// manifest's own URL, and this manifest is served from a deep API path where
+// relative paths would resolve to nonsense.
+
+export async function GET(request: Request, context: { params: Promise<{ id: string }> }) {
+  return withCors(request, await handleGet(request, context));
+}
+
+export const OPTIONS = preflight;
+
+/** Origin the flasher should fetch parts from — this deployment's own. */
+function selfOrigin(request: Request): string {
+  const host = request.headers.get("host");
+  if (!host) return communityHomeUrl().replace(/\/+$/, "");
+  const proto =
+    request.headers.get("x-forwarded-proto") ??
+    (host.startsWith("localhost") || host.startsWith("127.0.0.1") ? "http" : "https");
+  return `${proto}://${host}`;
+}
+
+async function handleGet(request: Request, context: { params: Promise<{ id: string }> }) {
+  if (!communityEnabled()) {
+    return Response.json({ error: "Community is not enabled on this deployment." }, { status: 503 });
+  }
+
+  const { id } = await context.params;
+  const build = await getBuild(id);
+  if (!build || build.status !== "done") {
+    return Response.json({ error: "No firmware for this build." }, { status: 404 });
+  }
+
+  const origin = selfOrigin(request);
+  const names = build.namespaces ? (JSON.parse(build.namespaces) as string[]) : [];
+
+  return Response.json(
+    {
+      name: names.length > 0 ? `Patternflow — ${names.join(", ")}` : "Patternflow (custom build)",
+      version: build.id,
+      // A custom build replaces the whole image, so a fresh erase is the
+      // predictable outcome — the same choice the stock manifest makes.
+      new_install_prompt_erase: true,
+      builds: [
+        {
+          chipFamily: "ESP32-S3",
+          parts: [
+            ...STATIC_FLASH_PARTS.map((part) => ({ path: `${origin}${part.path}`, offset: part.offset })),
+            { path: `${origin}/api/community/builds/${build.id}/firmware`, offset: APP_OFFSET },
+          ],
+        },
+      ],
+    },
+    { headers: { "Cache-Control": "private, max-age=3600" } },
+  );
+}

--- a/web/src/app/api/community/builds/[id]/route.ts
+++ b/web/src/app/api/community/builds/[id]/route.ts
@@ -1,0 +1,52 @@
+import { getBuild, parseBuildPatterns, queuePosition } from "@/lib/community/builds";
+import { originBlocked, preflight, withCors } from "@/lib/community/cors";
+import { communityEnabled } from "@/lib/community/db";
+
+// GET /api/community/builds/[id] — poll a build.
+//
+// Readable by anyone holding the id, which is 64 bits of randomness and only
+// ever handed to the person who queued the build. That matters because
+// esp-web-tools fetches the manifest and image itself, without credentials and
+// possibly from another origin — a cookie check here would break flashing from
+// the main site's Pattern Lab. The id is the capability; nothing here exposes
+// anything a guessing attacker could find by other means.
+
+export async function GET(request: Request, context: { params: Promise<{ id: string }> }) {
+  const blocked = originBlocked(request);
+  if (blocked) return blocked;
+  return withCors(request, await handleGet(context));
+}
+
+export const OPTIONS = preflight;
+
+async function handleGet(context: { params: Promise<{ id: string }> }) {
+  if (!communityEnabled()) {
+    return Response.json({ error: "Community is not enabled on this deployment." }, { status: 503 });
+  }
+
+  const { id } = await context.params;
+  const build = await getBuild(id);
+  if (!build) return Response.json({ error: "Build not found." }, { status: 404 });
+
+  const elapsedMs = build.startedAt
+    ? (build.finishedAt ?? new Date()).getTime() - build.startedAt.getTime()
+    : null;
+
+  return Response.json(
+    {
+      id: build.id,
+      status: build.status,
+      patterns: parseBuildPatterns(build.patterns).map((pattern) => pattern.label),
+      namespaces: build.namespaces ? (JSON.parse(build.namespaces) as string[]) : [],
+      queuePosition: build.status === "queued" ? await queuePosition(build.id, build.createdAt) : null,
+      elapsedMs,
+      bytes: build.artifactBytes ?? null,
+      error: build.error ?? null,
+      // Only meaningful once done; the client uses these directly.
+      firmwareUrl: build.status === "done" ? `/api/community/builds/${build.id}/firmware` : null,
+      manifestUrl: build.status === "done" ? `/api/community/builds/${build.id}/manifest` : null,
+    },
+    // A finished build never changes; a running one must not be cached at all.
+    { headers: { "Cache-Control": build.status === "done" ? "private, max-age=60" : "no-store" } },
+  );
+}

--- a/web/src/app/api/community/builds/route.ts
+++ b/web/src/app/api/community/builds/route.ts
@@ -1,0 +1,114 @@
+import fs from "node:fs/promises";
+import { getAuth } from "@/lib/community/auth";
+import { countActiveBuilds, enqueueBuild, type BuildPatternInput } from "@/lib/community/builds";
+import { originBlocked, preflight, withCors } from "@/lib/community/cors";
+import { communityEnabled } from "@/lib/community/db";
+import { rateLimit } from "@/lib/community/ratelimit";
+import { CPP_MAX } from "@/lib/community/validate";
+import { assembleFirmwareSource, MAX_CUSTOM_SLOTS } from "@/lib/firmware/assemble";
+import { registryPath } from "@/lib/firmware/paths";
+
+// POST /api/community/builds — queue a firmware build.
+//
+// The compile itself happens in the worker process (see scripts/build-worker),
+// so this returns as soon as the job is on the queue. What it does do is run
+// the same assembly the worker will: a namespace that collides with a bundled
+// pattern is worth reporting now rather than after a fifteen second wait.
+
+export async function POST(request: Request) {
+  const blocked = originBlocked(request);
+  if (blocked) return blocked;
+  return withCors(request, await handlePost(request));
+}
+
+export const OPTIONS = preflight;
+
+/** Builds are off unless the deployment has a worker to run them. */
+function buildsEnabled(): boolean {
+  return process.env.BUILD_ENABLED === "1";
+}
+
+async function handlePost(request: Request) {
+  if (!communityEnabled()) {
+    return Response.json({ error: "Community is not enabled on this deployment." }, { status: 503 });
+  }
+  if (!buildsEnabled()) {
+    return Response.json(
+      { error: "Firmware building is not enabled on this deployment." },
+      { status: 503 },
+    );
+  }
+
+  const session = await getAuth().api.getSession({ headers: request.headers });
+  if (!session) {
+    return Response.json({ error: "Sign in to build firmware." }, { status: 401 });
+  }
+
+  // Builds are the most expensive thing a signed-in user can ask for, so they
+  // are limited twice: by rate, and by how many can be in flight at once.
+  if (!rateLimit(`build:${session.user.id}`, 10, 60 * 60_000)) {
+    return Response.json(
+      { error: "Build limit reached for this hour. Try again later." },
+      { status: 429 },
+    );
+  }
+  if ((await countActiveBuilds(session.user.id)) >= 2) {
+    return Response.json(
+      { error: "You already have builds queued. Wait for them to finish." },
+      { status: 429 },
+    );
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return Response.json({ error: "Invalid JSON body." }, { status: 400 });
+  }
+
+  const raw = (body as Record<string, unknown>).patterns;
+  if (!Array.isArray(raw) || raw.length === 0) {
+    return Response.json({ error: "Send at least one pattern to build." }, { status: 400 });
+  }
+  if (raw.length > MAX_CUSTOM_SLOTS) {
+    return Response.json(
+      { error: `The firmware has ${MAX_CUSTOM_SLOTS} custom slots.` },
+      { status: 400 },
+    );
+  }
+
+  const patterns: BuildPatternInput[] = [];
+  for (const [index, entry] of raw.entries()) {
+    const item = entry as Record<string, unknown>;
+    const code = typeof item.code === "string" ? item.code : "";
+    if (code.length === 0 || code.length > CPP_MAX) {
+      return Response.json(
+        { error: `Pattern ${index + 1}: header is empty or over ${CPP_MAX / 1000}KB.` },
+        { status: 400 },
+      );
+    }
+    const label = typeof item.label === "string" && item.label.trim().length > 0
+      ? item.label.trim().slice(0, 80)
+      : `pattern ${index + 1}`;
+    patterns.push({ label, code });
+  }
+
+  // Dry-run the assembly so bad submissions fail here, with a readable reason.
+  let registry: string;
+  try {
+    registry = await fs.readFile(registryPath(), "utf8");
+  } catch {
+    return Response.json(
+      { error: "Firmware sources are not available on this deployment." },
+      { status: 503 },
+    );
+  }
+
+  const assembled = assembleFirmwareSource(patterns, registry);
+  if (!assembled.ok) {
+    return Response.json({ error: assembled.error }, { status: 400 });
+  }
+
+  const id = await enqueueBuild(session.user.id, patterns);
+  return Response.json({ id, namespaces: assembled.namespaces }, { status: 202 });
+}

--- a/web/src/app/community/p/[id]/PatternDetailClient.tsx
+++ b/web/src/app/community/p/[id]/PatternDetailClient.tsx
@@ -12,6 +12,8 @@ import LikeButton from "@/components/community/LikeButton";
 import AddHeaderModal from "@/components/community/AddHeaderModal";
 import EditDetailsModal from "@/components/community/EditDetailsModal";
 import DeletePatternButton from "@/components/community/DeletePatternButton";
+import BuildFirmwareModal from "@/components/community/BuildFirmwareModal";
+import { buildsConfigured } from "@/lib/community/apiBase";
 import { knobSetupFromCode } from "@/lib/community/knobs";
 import { describeMatrixShape, matrixFromCode } from "@/lib/patternMatrix";
 import { writeLabHandoff } from "@/lib/community/handoff";
@@ -62,6 +64,7 @@ export default function PatternDetailClient({
   const [codeTab, setCodeTab] = useState<"js" | "h">("js");
   const [headerModalOpen, setHeaderModalOpen] = useState(false);
   const [detailsModalOpen, setDetailsModalOpen] = useState(false);
+  const [buildOpen, setBuildOpen] = useState(false);
   const [savingCode, setSavingCode] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
 
@@ -191,6 +194,18 @@ export default function PatternDetailClient({
             <button type="button" className={styles.btnAccent} onClick={openInLab}>
               Open in Pattern Lab
             </button>
+            {/* Only for patterns that ship a verified header — this is the
+                zero-friction path: nothing to convert, nothing to install. */}
+            {buildsConfigured() && pattern.codeCpp && (
+              <button
+                type="button"
+                className={styles.btnPrimary}
+                title="Compile a firmware image with this pattern and flash it over USB"
+                onClick={() => setBuildOpen(true)}
+              >
+                ⚡ Flash to my board
+              </button>
+            )}
             {isOwner && edited && (
               <button
                 type="button"
@@ -306,8 +321,17 @@ export default function PatternDetailClient({
 
           {codeTab === "h" && (
             <p className={styles.codeFootNote}>
-              To flash it: drop the file into <code>firmware/patternflow/</code> and add it to{" "}
-              <code>pattern_registry.h</code>. Provided by the author and not verified by us.
+              {buildsConfigured() ? (
+                <>
+                  Use <strong>Flash to my board</strong> below to compile and install this without
+                  an Arduino IDE. Provided by the author and not verified by us.
+                </>
+              ) : (
+                <>
+                  To flash it: drop the file into <code>firmware/patternflow/</code> and add it to{" "}
+                  <code>pattern_registry.h</code>. Provided by the author and not verified by us.
+                </>
+              )}
             </p>
           )}
         </div>
@@ -396,6 +420,14 @@ export default function PatternDetailClient({
           patternId={pattern.id}
           initialCpp={pattern.codeCpp}
           onClose={() => setHeaderModalOpen(false)}
+        />
+      )}
+
+      {buildOpen && pattern.codeCpp && (
+        <BuildFirmwareModal
+          initialHeader={pattern.codeCpp}
+          patternLabel={pattern.title}
+          onClose={() => setBuildOpen(false)}
         />
       )}
 

--- a/web/src/app/pattern-lab/PatternLabClient.tsx
+++ b/web/src/app/pattern-lab/PatternLabClient.tsx
@@ -72,7 +72,8 @@ import { captureEvent } from "@/lib/posthogEvents";
 import SharePatternModal from "@/components/share/SharePatternModal";
 import PublishModal from "@/components/community/PublishModal";
 import { clearLabHandoff, readLabHandoff } from "@/lib/community/handoff";
-import { communityConfigured } from "@/lib/community/apiBase";
+import { buildsConfigured, communityConfigured } from "@/lib/community/apiBase";
+import BuildFirmwareModal from "@/components/community/BuildFirmwareModal";
 import {
   codeUsesValueField,
   parseRampAnnotation,
@@ -526,6 +527,7 @@ export default function PatternLabClient() {
   const [buttonHelpOpen, setButtonHelpOpen] = useState(false);
   const [shareOpen, setShareOpen] = useState(false);
   const [communityShareOpen, setCommunityShareOpen] = useState(false);
+  const [buildOpen, setBuildOpen] = useState(false);
   // Fork lineage carried over from a community pattern opened "in Pattern
   // Lab". Sticky until the user detaches it (×) — we never guess whether the
   // code has diverged too far to still count as a fork.
@@ -2120,6 +2122,16 @@ ${codeWithMatrix(activeCode)}
                 Share to Community
               </button>
             )}
+            {buildsConfigured() && (
+              <button
+                type="button"
+                className={styles.darkButton}
+                title="Compile a firmware image with this pattern and flash it over USB — no Arduino IDE"
+                onClick={() => setBuildOpen(true)}
+              >
+                Build firmware
+              </button>
+            )}
           </div>
 
           <div className={styles.sweepBar}>
@@ -2836,6 +2848,16 @@ export function draw(display, params, time) {} // runs each frame`}</pre>
           cppConvertPrompt={buildCppPrompt()}
           source="pattern-lab"
           onClose={() => setShareOpen(false)}
+        />
+      )}
+
+      {buildOpen && (
+        <BuildFirmwareModal
+          patternLabel={forkOf?.title ?? "Pattern Lab pattern"}
+          // The lab holds JavaScript, not a header, so the conversion prompt is
+          // offered right in the modal rather than sending people elsewhere.
+          cppPrompt={buildCppPrompt()}
+          onClose={() => setBuildOpen(false)}
         />
       )}
 

--- a/web/src/components/community/BuildFirmwareModal.tsx
+++ b/web/src/components/community/BuildFirmwareModal.tsx
@@ -1,0 +1,293 @@
+"use client";
+
+import Script from "next/script";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+import { authClient } from "@/lib/community/auth-client";
+import { COMMUNITY_FETCH_INIT, communityApiUrl } from "@/lib/community/apiBase";
+import { captureEvent } from "@/lib/posthogEvents";
+import AuthModal from "./AuthModal";
+import styles from "./Community.module.css";
+
+// Build a firmware image containing a pattern, then flash it — the step that
+// otherwise means installing the Arduino IDE.
+//
+// The server compiles (~15 s) and the browser flashes over USB, so nothing here
+// needs a toolchain. The image is fetched by esp-web-tools directly from its
+// URL, which is why the build id doubles as the capability to read it.
+
+const EspWebInstallButton = "esp-web-install-button" as unknown as React.ElementType<{
+  manifest: string;
+  children: React.ReactNode;
+}>;
+
+type BuildState = {
+  id: string;
+  status: "queued" | "running" | "done" | "error";
+  queuePosition: number | null;
+  elapsedMs: number | null;
+  bytes: number | null;
+  error: string | null;
+  namespaces: string[];
+  manifestUrl: string | null;
+};
+
+export default function BuildFirmwareModal({
+  initialHeader,
+  patternLabel,
+  cppPrompt,
+  onClose,
+}: {
+  /** Pre-filled header, when the caller already has one (a hardware-ready pattern). */
+  initialHeader?: string | null;
+  patternLabel: string;
+  /** JS→C++ prompt to offer when there is no header yet. */
+  cppPrompt?: string | null;
+  onClose: () => void;
+}) {
+  const router = useRouter();
+  const { data: session, isPending } = authClient.useSession();
+
+  const [header, setHeader] = useState(initialHeader ?? "");
+  const [build, setBuild] = useState<BuildState | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [promptCopied, setPromptCopied] = useState(false);
+
+  // Polling is stopped from inside its own callback, so it needs a handle that
+  // survives re-renders.
+  const pollRef = useRef<number | null>(null);
+  useEffect(() => () => { if (pollRef.current) window.clearInterval(pollRef.current); }, []);
+
+  const poll = useCallback(async (id: string) => {
+    try {
+      const response = await fetch(communityApiUrl(`/api/community/builds/${id}`), COMMUNITY_FETCH_INIT);
+      if (!response.ok) return;
+      const state = (await response.json()) as BuildState;
+      setBuild(state);
+      if (state.status === "done" || state.status === "error") {
+        if (pollRef.current) window.clearInterval(pollRef.current);
+        pollRef.current = null;
+        captureEvent("firmware_build_finished", {
+          status: state.status,
+          ms: state.elapsedMs,
+          bytes: state.bytes,
+        });
+      }
+    } catch {
+      // A dropped poll is not a failed build; the next tick will catch up.
+    }
+  }, []);
+
+  const startBuild = async () => {
+    if (!session) return;
+    const code = header.trim();
+    if (code.length === 0) {
+      setError("Paste the pattern's C++ header first.");
+      return;
+    }
+
+    setBusy(true);
+    setError(null);
+    try {
+      const response = await fetch(communityApiUrl("/api/community/builds"), {
+        method: "POST",
+        ...COMMUNITY_FETCH_INIT,
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ patterns: [{ label: patternLabel, code }] }),
+      });
+      const payload = (await response.json()) as { id?: string; error?: string };
+      if (!response.ok || !payload.id) {
+        setError(payload.error ?? "Could not queue the build.");
+        return;
+      }
+
+      // Bind the id locally: narrowing on payload.id does not survive into the
+      // interval callback, since TypeScript cannot prove the property is stable.
+      const buildId = payload.id;
+
+      captureEvent("firmware_build_queued", { pattern: patternLabel });
+      setBuild({
+        id: buildId,
+        status: "queued",
+        queuePosition: null,
+        elapsedMs: null,
+        bytes: null,
+        error: null,
+        namespaces: [],
+        manifestUrl: null,
+      });
+      void poll(buildId);
+      pollRef.current = window.setInterval(() => void poll(buildId), 1500);
+    } catch {
+      setError("Network error — is the build server reachable?");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const copyPrompt = async () => {
+    if (!cppPrompt) return;
+    try {
+      await navigator.clipboard.writeText(cppPrompt);
+      setPromptCopied(true);
+      window.setTimeout(() => setPromptCopied(false), 1500);
+    } catch {
+      // clipboard may be blocked
+    }
+  };
+
+  const reset = () => {
+    if (pollRef.current) window.clearInterval(pollRef.current);
+    pollRef.current = null;
+    setBuild(null);
+    setError(null);
+  };
+
+  const seconds = build?.elapsedMs != null ? (build.elapsedMs / 1000).toFixed(0) : null;
+
+  return (
+    <div className={styles.modalOverlay} role="dialog" aria-modal="true" onClick={onClose}>
+      <Script
+        type="module"
+        src="https://unpkg.com/esp-web-tools@10/dist/web/install-button.js?module"
+        strategy="lazyOnload"
+      />
+      <div
+        className={`${styles.modalCard} ${styles.modalCardWide}`}
+        onClick={(event) => event.stopPropagation()}
+      >
+        <div className={styles.modalHeader}>
+          <span>Build firmware</span>
+          <button type="button" onClick={onClose} aria-label="Close">
+            ×
+          </button>
+        </div>
+
+        {isPending ? (
+          <div className={styles.modalBody}>
+            <span className={styles.formNote}>Checking session…</span>
+          </div>
+        ) : !session ? (
+          // Building costs a machine ~15 seconds of CPU, so it asks who you are
+          // at the moment you ask for one — the same rule as publishing.
+          <AuthModal embedded onClose={() => undefined} onAuthed={() => router.refresh()} />
+        ) : build ? (
+          <div className={styles.modalBody}>
+            {build.status !== "done" && build.status !== "error" && (
+              <>
+                <p className={styles.buildStatusLine}>
+                  <span className={styles.buildSpinner} aria-hidden="true" />
+                  {build.status === "queued"
+                    ? build.queuePosition && build.queuePosition > 1
+                      ? `Waiting — ${build.queuePosition} in the queue…`
+                      : "Waiting for a build slot…"
+                    : `Compiling${seconds ? ` — ${seconds}s` : "…"}`}
+                </p>
+                <p className={styles.formNote}>
+                  A build takes about 15 seconds. The whole preset library is compiled
+                  alongside your pattern, so this produces a complete firmware image.
+                </p>
+              </>
+            )}
+
+            {build.status === "error" && (
+              <>
+                <div className={styles.formError}>The build failed.</div>
+                <pre className={styles.buildLog}>{build.error}</pre>
+                <p className={styles.formNote}>
+                  This is the compiler&apos;s own output. Common causes: a helper that the
+                  firmware already provides being redefined, or a type that differs from the
+                  JavaScript original.
+                </p>
+                <div className={styles.actionRow}>
+                  <button type="button" className={styles.btn} onClick={reset}>
+                    Edit the header and retry
+                  </button>
+                </div>
+              </>
+            )}
+
+            {build.status === "done" && build.manifestUrl && (
+              <>
+                <p className={styles.buildStatusLine}>
+                  ✓ Built in {seconds}s · {((build.bytes ?? 0) / 1024).toFixed(0)} KB
+                  {build.namespaces.length > 0 && ` · ${build.namespaces.join(", ")}`}
+                </p>
+                <p className={styles.formNote}>
+                  Connect the board over USB and flash it. Desktop Chrome or Edge only —
+                  browser flashing needs Web Serial.
+                </p>
+                <div className={styles.actionRow}>
+                  <EspWebInstallButton manifest={communityApiUrl(build.manifestUrl)}>
+                    <button slot="activate" type="button" className={styles.btnAccent}>
+                      Flash to my Patternflow
+                    </button>
+                    <span slot="unsupported" className={styles.formNote}>
+                      This browser cannot flash — use desktop Chrome or Edge, or download below.
+                    </span>
+                    <span slot="not-allowed" className={styles.formNote}>
+                      Flashing needs a secure (https) page.
+                    </span>
+                  </EspWebInstallButton>
+                  <a
+                    className={styles.btn}
+                    href={communityApiUrl(`/api/community/builds/${build.id}/firmware`)}
+                    download
+                  >
+                    Download .bin
+                  </a>
+                  <span className={styles.headerSpacer} />
+                  <button type="button" className={styles.btn} onClick={reset}>
+                    Build another
+                  </button>
+                </div>
+              </>
+            )}
+          </div>
+        ) : (
+          <div className={styles.modalBody}>
+            <p className={styles.formNote}>
+              The board runs C++, so a pattern needs a <code>.h</code> port before it can be
+              flashed. Paste one below and the server compiles a complete firmware image —
+              no Arduino IDE, no toolchain.
+            </p>
+
+            {cppPrompt && (
+              <div className={styles.actionRow}>
+                <button type="button" className={styles.btn} onClick={() => void copyPrompt()}>
+                  {promptCopied ? "Copied ✓" : "Copy C++ conversion prompt"}
+                </button>
+                <span className={styles.fieldHint}>
+                  Paste it into any AI assistant, then bring the header back here.
+                </span>
+              </div>
+            )}
+
+            <label className={styles.field}>
+              <span className={styles.fieldLabel}>Header source</span>
+              <textarea
+                className={`${styles.textInput} ${styles.cppInput}`}
+                placeholder="#pragma once&#10;…"
+                spellCheck={false}
+                value={header}
+                onChange={(event) => setHeader(event.target.value)}
+              />
+            </label>
+
+            {error && <div className={styles.formError}>{error}</div>}
+
+            <button
+              type="button"
+              className={styles.btnAccent}
+              disabled={busy || header.trim().length === 0}
+              onClick={() => void startBuild()}
+            >
+              {busy ? "Queueing…" : "Build firmware"}
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/community/Community.module.css
+++ b/web/src/components/community/Community.module.css
@@ -1524,3 +1524,47 @@
   color: #171512;
   border-bottom-color: #e8552e;
 }
+
+/* ── Firmware build modal ── */
+
+.buildStatusLine {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 14px;
+  font-weight: 600;
+  color: #171512;
+}
+
+.buildSpinner {
+  flex: none;
+  width: 14px;
+  height: 14px;
+  border: 2px solid rgba(232, 85, 46, 0.25);
+  border-top-color: #e8552e;
+  border-radius: 50%;
+  animation: buildSpin 700ms linear infinite;
+}
+
+@keyframes buildSpin {
+  to { transform: rotate(360deg); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .buildSpinner { animation-duration: 2.4s; }
+}
+
+.buildLog {
+  margin: 0;
+  max-height: 260px;
+  overflow: auto;
+  padding: 10px 12px;
+  border-radius: 6px;
+  background: #1e1e1e;
+  color: #e8e2d6;
+  font-family: var(--pf-mono, monospace);
+  font-size: 11.5px;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}

--- a/web/src/lib/community/apiBase.ts
+++ b/web/src/lib/community/apiBase.ts
@@ -50,6 +50,18 @@ export function communityHref(path = "/community"): string {
   return origin ? `${origin}${path}` : path;
 }
 
+/**
+ * Does the community this page talks to compile firmware?
+ *
+ * Separate from `communityConfigured` because the build worker is its own
+ * process: a community can be running perfectly well with nobody to compile
+ * for it, and offering a button that can only 503 is worse than not offering
+ * one. Set NEXT_PUBLIC_BUILD_ENABLED alongside the server's BUILD_ENABLED.
+ */
+export function buildsConfigured(): boolean {
+  return process.env.NEXT_PUBLIC_BUILD_ENABLED === "1";
+}
+
 /** Absolute community origin, or null when the API is same-origin. */
 export function crossOriginCommunityBase(): string | null {
   if (typeof window === "undefined") return null;

--- a/web/src/lib/community/builds.ts
+++ b/web/src/lib/community/builds.ts
@@ -1,0 +1,156 @@
+import path from "node:path";
+import { and, desc, eq, lt, sql } from "drizzle-orm";
+import { getDb } from "./db";
+import { newId } from "./queries";
+import { builds } from "./schema";
+
+// Build queue.
+//
+// The web request enqueues; a separate worker process claims and compiles. All
+// coordination goes through this table so the two halves share nothing but the
+// database — the worker can be restarted, moved to another machine, or run
+// twice without the site knowing.
+
+export type BuildStatus = "queued" | "running" | "done" | "error";
+
+/** A pattern header as submitted, stored inline on the job. */
+export type BuildPatternInput = { label: string; code: string };
+
+/** A build claimed for this long is treated as abandoned (worker died). */
+const STALE_AFTER_MS = 10 * 60 * 1000;
+
+/** Where finished images live. Beside the database, never inside the repo. */
+export function artifactDir(): string {
+  if (process.env.BUILD_ARTIFACT_DIR) return process.env.BUILD_ARTIFACT_DIR;
+  const dbPath = process.env.COMMUNITY_DB_PATH ?? path.join(process.cwd(), "data", "community.db");
+  return path.join(path.dirname(dbPath), "builds");
+}
+
+export async function enqueueBuild(userId: string, patterns: BuildPatternInput[]): Promise<string> {
+  const id = newId();
+  await getDb().insert(builds).values({
+    id,
+    userId,
+    status: "queued",
+    patterns: JSON.stringify(patterns),
+    createdAt: new Date(),
+  });
+  return id;
+}
+
+/** How many of this user's builds are still waiting or compiling. */
+export async function countActiveBuilds(userId: string): Promise<number> {
+  const rows = await getDb()
+    .select({ count: sql<number>`COUNT(*)` })
+    .from(builds)
+    .where(
+      and(
+        eq(builds.userId, userId),
+        sql`${builds.status} IN ('queued', 'running')`,
+      ),
+    );
+  return rows[0]?.count ?? 0;
+}
+
+/**
+ * Take the oldest queued job, atomically.
+ *
+ * The UPDATE ... WHERE id = (SELECT ... LIMIT 1) form is what makes this safe
+ * with more than one worker: SQLite serialises writers, so exactly one of them
+ * can flip a given row out of "queued". Selecting first and updating after
+ * would let two workers claim the same job.
+ */
+export async function claimNextBuild(worker: string) {
+  await reapStaleBuilds();
+
+  const rows = await getDb()
+    .update(builds)
+    .set({ status: "running", worker, startedAt: new Date() })
+    .where(
+      eq(
+        builds.id,
+        sql`(SELECT id FROM ${builds} WHERE status = 'queued' ORDER BY created_at LIMIT 1)`,
+      ),
+    )
+    .returning();
+
+  return rows[0] ?? null;
+}
+
+/** Fail anything left "running" by a worker that went away. */
+export async function reapStaleBuilds(): Promise<number> {
+  const cutoff = new Date(Date.now() - STALE_AFTER_MS);
+  const rows = await getDb()
+    .update(builds)
+    .set({
+      status: "error",
+      error: "Build worker stopped responding. Try again.",
+      finishedAt: new Date(),
+    })
+    .where(and(eq(builds.status, "running"), lt(builds.startedAt, cutoff)))
+    .returning({ id: builds.id });
+  return rows.length;
+}
+
+export async function completeBuild(
+  id: string,
+  result: { artifact: string; artifactBytes: number; namespaces: string[] },
+): Promise<void> {
+  await getDb()
+    .update(builds)
+    .set({
+      status: "done",
+      artifact: result.artifact,
+      artifactBytes: result.artifactBytes,
+      namespaces: JSON.stringify(result.namespaces),
+      finishedAt: new Date(),
+    })
+    .where(eq(builds.id, id));
+}
+
+export async function failBuild(id: string, error: string): Promise<void> {
+  await getDb()
+    .update(builds)
+    .set({
+      status: "error",
+      // Compiler output can be enormous; keep the tail, which is where the
+      // actual error is, and leave the row readable.
+      error: error.length > 8000 ? `…\n${error.slice(-8000)}` : error,
+      finishedAt: new Date(),
+    })
+    .where(eq(builds.id, id));
+}
+
+export async function getBuild(id: string) {
+  const rows = await getDb().select().from(builds).where(eq(builds.id, id)).limit(1);
+  return rows[0] ?? null;
+}
+
+/** Position in the queue, 1-based. Null once it is no longer waiting. */
+export async function queuePosition(id: string, createdAt: Date): Promise<number | null> {
+  const rows = await getDb()
+    .select({ count: sql<number>`COUNT(*)` })
+    .from(builds)
+    .where(and(eq(builds.status, "queued"), lt(builds.createdAt, createdAt)));
+  const build = await getBuild(id);
+  if (!build || build.status !== "queued") return null;
+  return (rows[0]?.count ?? 0) + 1;
+}
+
+export async function listUserBuilds(userId: string, limit = 20) {
+  return getDb()
+    .select()
+    .from(builds)
+    .where(eq(builds.userId, userId))
+    .orderBy(desc(builds.createdAt))
+    .limit(limit);
+}
+
+export function parseBuildPatterns(raw: string): BuildPatternInput[] {
+  try {
+    const parsed = JSON.parse(raw) as BuildPatternInput[];
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}

--- a/web/src/lib/community/schema.ts
+++ b/web/src/lib/community/schema.ts
@@ -179,6 +179,46 @@ export const postComments = sqliteTable(
   (table) => [index("post_comments_post_id_idx").on(table.postId)],
 );
 
+// ── Firmware builds ──────────────────────────────────────────────────────────
+// A build is slow (~15 s) and CPU-bound, so the web request only enqueues one
+// and a separate worker process picks it up. Without that split, concurrent
+// requests would compile in-process and starve the site of the cores it is
+// running on.
+//
+// The submitted headers are stored inline rather than referenced: a build is
+// then self-contained and stays reproducible even if the pattern it came from
+// is later edited or deleted.
+export const builds = sqliteTable(
+  "builds",
+  {
+    id: text("id").primaryKey(),
+    userId: text("user_id")
+      .notNull()
+      .references(() => user.id, { onDelete: "cascade" }),
+    /** queued → running → done | error */
+    status: text("status").notNull().default("queued"),
+    /** JSON: [{ label, code }] — the C++ headers to put in the custom slots. */
+    patterns: text("patterns").notNull(),
+    /** Namespaces resolved at assembly time, for display. */
+    namespaces: text("namespaces"),
+    /** Filename of the finished image, relative to the artifact directory. */
+    artifact: text("artifact"),
+    artifactBytes: integer("artifact_bytes"),
+    /** Compiler output when status is "error" — shown to the author. */
+    error: text("error"),
+    /** Which worker claimed it; helps when more than one is running. */
+    worker: text("worker"),
+    createdAt: integer("created_at", { mode: "timestamp" }).notNull(),
+    startedAt: integer("started_at", { mode: "timestamp" }),
+    finishedAt: integer("finished_at", { mode: "timestamp" }),
+  },
+  (table) => [
+    // The worker's claim query orders queued jobs by age.
+    index("builds_status_created_idx").on(table.status, table.createdAt),
+    index("builds_user_id_idx").on(table.userId),
+  ],
+);
+
 export const comments = sqliteTable(
   "comments",
   {

--- a/web/src/lib/firmware/assemble.ts
+++ b/web/src/lib/firmware/assemble.ts
@@ -1,0 +1,184 @@
+// ─────────────────────────────────────────────────────────────────────────────
+// Firmware source assembly.
+//
+// Turns "here are 1–3 pattern headers" into "here are the files a build needs",
+// which is the step people currently do by hand in the Arduino IDE: drop a .h
+// into a custom slot, then add a matching PATTERN_ENTRY line to the registry.
+//
+// Deliberately pure text in / text out — no filesystem, no compiler. The build
+// worker writes what this returns into a scratch checkout and runs arduino-cli
+// against it, so all of the logic that can be got wrong is testable without a
+// toolchain.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Firmware slots reserved for user patterns (custom1.h … custom3.h). */
+export const MAX_CUSTOM_SLOTS = 3;
+
+/** A pattern's C++ header, exactly as the author supplied it. */
+export type CustomPatternInput = {
+  /** Complete `.h` source. */
+  code: string;
+  /** Only used to make error messages nameable; not written to disk. */
+  label?: string;
+};
+
+export type AssembledFile = { path: string; content: string };
+
+export type AssembleResult =
+  | { ok: true; files: AssembledFile[]; namespaces: string[] }
+  | { ok: false; error: string };
+
+// A header's namespace is the handle the registry refers to it by, so it has to
+// be found the same way the compiler would. Anonymous namespaces are rejected
+// because there would be nothing to name in PATTERN_ENTRY.
+const NAMESPACE_RE = /^[ \t]*namespace[ \t]+([A-Za-z_]\w*)[ \t]*\{/m;
+
+// The two regions of pattern_registry.h this module owns. Everything else in
+// that file — presets, the PatternEntry struct, buildPatternList — is left
+// exactly as it is, so the generated registry stays diffable against the repo's.
+const CUSTOM_INCLUDE_BLOCK_RE = /(?:^[ \t]*#include[ \t]+"custom\d+\.h"[ \t]*\r?\n)+/m;
+const CUSTOM_ARRAY_RE = /PatternEntry[ \t]+customPatterns\[\][ \t]*=[ \t]*\{[\s\S]*?\};/;
+
+/** Strip comments and string literals so scans can't trip over them. */
+function stripCommentsAndStrings(code: string): string {
+  return code
+    .replace(/\/\*[\s\S]*?\*\//g, " ")
+    .replace(/\/\/[^\n]*/g, " ")
+    .replace(/"(?:[^"\\\n]|\\.)*"/g, '""');
+}
+
+/** The namespace a header declares, or null when it declares none usable. */
+export function extractNamespace(code: string): string | null {
+  return stripCommentsAndStrings(code).match(NAMESPACE_RE)?.[1] ?? null;
+}
+
+/**
+ * Namespaces the registry already uses for presets. A custom pattern reusing
+ * one of these compiles into a redefinition of NAME/setup/draw rather than a
+ * missing-symbol error, so it is worth catching before the toolchain does.
+ */
+export function listRegistryNamespaces(registry: string): string[] {
+  const found = new Set<string>();
+  const source = stripCommentsAndStrings(registry);
+  for (const match of source.matchAll(/PATTERN_ENTRY\(\s*([A-Za-z_]\w*)\s*\)/g)) {
+    found.add(match[1]);
+  }
+  return [...found];
+}
+
+/**
+ * Shape check on a submitted header. This cannot tell whether the pattern
+ * compiles — only the compiler knows that — but it catches the mistakes that
+ * would otherwise surface as an unreadable wall of C++ errors ten seconds
+ * later: a JavaScript file pasted by accident, a missing namespace, a
+ * half-copied snippet.
+ */
+export function validateCustomPattern(code: string): { ok: true; namespace: string } | { ok: false; error: string } {
+  const source = stripCommentsAndStrings(code);
+
+  if (!/^\s*#pragma\s+once\b/m.test(source)) {
+    return { ok: false, error: "Header must start with `#pragma once`." };
+  }
+
+  const namespace = extractNamespace(code);
+  if (!namespace) {
+    return {
+      ok: false,
+      error: "No named namespace found — a pattern needs `namespace YourPattern { … }`.",
+    };
+  }
+
+  // The five symbols PATTERN_ENTRY expands to. Missing any of them is a link
+  // error at the very end of a build, which is the slowest possible way to find
+  // out about it.
+  const required = ["NAME", "KNOB_LABELS", "setup", "update", "draw"];
+  const missing = required.filter((symbol) => !new RegExp(`\\b${symbol}\\b`).test(source));
+  if (missing.length > 0) {
+    return {
+      ok: false,
+      error: `Namespace \`${namespace}\` is missing: ${missing.join(", ")}. PATTERN_ENTRY needs all five.`,
+    };
+  }
+
+  return { ok: true, namespace };
+}
+
+/** Rewrite the registry's custom includes and entry list for `namespaces`. */
+export function buildRegistry(originalRegistry: string, namespaces: string[]): string {
+  const includes = namespaces
+    .map((_, index) => `#include "custom${index + 1}.h"`)
+    .join("\n");
+
+  const entries = namespaces.map((ns) => `  PATTERN_ENTRY(${ns}),`).join("\n");
+  const array = `PatternEntry customPatterns[] = {\n${entries}\n};`;
+
+  if (!CUSTOM_INCLUDE_BLOCK_RE.test(originalRegistry)) {
+    throw new Error("pattern_registry.h has no custom include block to replace.");
+  }
+  if (!CUSTOM_ARRAY_RE.test(originalRegistry)) {
+    throw new Error("pattern_registry.h has no customPatterns[] array to replace.");
+  }
+
+  return originalRegistry
+    .replace(CUSTOM_INCLUDE_BLOCK_RE, `${includes}\n`)
+    .replace(CUSTOM_ARRAY_RE, array);
+}
+
+/**
+ * Full assembly: validate every header, then return the files a build needs.
+ *
+ * `originalRegistry` is the repo's own pattern_registry.h, so the preset half
+ * of the firmware is carried through untouched and only the custom slots differ
+ * from a stock build.
+ */
+export function assembleFirmwareSource(
+  patterns: CustomPatternInput[],
+  originalRegistry: string,
+): AssembleResult {
+  if (patterns.length === 0) {
+    return { ok: false, error: "Select at least one pattern to build." };
+  }
+  if (patterns.length > MAX_CUSTOM_SLOTS) {
+    return {
+      ok: false,
+      error: `The firmware has ${MAX_CUSTOM_SLOTS} custom slots; ${patterns.length} patterns were given.`,
+    };
+  }
+
+  const reserved = new Set(listRegistryNamespaces(originalRegistry));
+  // Preset namespaces come from the registry, but the custom slots currently
+  // listed there are about to be replaced — they must not count as taken.
+  const replacedCustoms = originalRegistry.match(CUSTOM_ARRAY_RE)?.[0] ?? "";
+  for (const ns of listRegistryNamespaces(replacedCustoms)) reserved.delete(ns);
+
+  const namespaces: string[] = [];
+  const files: AssembledFile[] = [];
+
+  for (const [index, pattern] of patterns.entries()) {
+    const name = pattern.label ?? `pattern ${index + 1}`;
+    const result = validateCustomPattern(pattern.code);
+    if (!result.ok) {
+      return { ok: false, error: `${name}: ${result.error}` };
+    }
+
+    if (reserved.has(result.namespace)) {
+      return {
+        ok: false,
+        error: `${name}: namespace \`${result.namespace}\` is already used by a bundled pattern — rename it.`,
+      };
+    }
+    if (namespaces.includes(result.namespace)) {
+      return {
+        ok: false,
+        error: `${name}: two selected patterns both use namespace \`${result.namespace}\` — rename one.`,
+      };
+    }
+
+    reserved.add(result.namespace);
+    namespaces.push(result.namespace);
+    files.push({ path: `custom${index + 1}.h`, content: pattern.code });
+  }
+
+  files.push({ path: "pattern_registry.h", content: buildRegistry(originalRegistry, namespaces) });
+  return { ok: true, files, namespaces };
+}

--- a/web/src/lib/firmware/buildRunner.ts
+++ b/web/src/lib/firmware/buildRunner.ts
@@ -1,0 +1,209 @@
+import { spawn } from "node:child_process";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { assembleFirmwareSource, type CustomPatternInput } from "./assemble";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Running one firmware build.
+//
+// ⚠️  SANDBOXING — compiling a submitted header is arbitrary code execution at
+// COMPILE time, even though nothing "runs": the preprocessor reaches the
+// filesystem (`#include "/etc/passwd"` leaks through error messages) and
+// template recursion burns CPU without limit. This module does NOT sandbox
+// anything; it assumes the caller has already put it inside a container with no
+// network, a read-only root, an unprivileged user and resource limits.
+// Do not expose it to submissions from anyone but the maintainer until that
+// exists — see issue #230.
+//
+// WARMTH — the sketch directory and the build path are both persistent and
+// reused between builds. That is where the 8× speedup lives: a fresh build
+// directory recompiles the ESP32 core and every library (~2 min) instead of
+// just the sketch (~15 s). One runner owns one pair of directories, so two
+// concurrent builds mean two runners, never two jobs sharing these paths.
+// ─────────────────────────────────────────────────────────────────────────────
+
+export type CompileOutcome =
+  | { ok: true; appBinPath: string; output: string }
+  | { ok: false; output: string };
+
+/** Swappable so the surrounding logic is testable without a toolchain. */
+export type Compiler = (context: {
+  sketchDir: string;
+  buildPath: string;
+}) => Promise<CompileOutcome>;
+
+export type BuildRunnerOptions = {
+  /** Pristine firmware sources, copied in on first use (the repo checkout). */
+  firmwareSrcDir: string;
+  /** Persistent working copy this runner compiles from. */
+  sketchDir: string;
+  /** Persistent arduino-cli --build-path. Never delete this between builds. */
+  buildPath: string;
+  /** Where finished images are written. */
+  artifactDir: string;
+  compile?: Compiler;
+};
+
+export const FQBN = process.env.BUILD_FQBN ?? "esp32:esp32:esp32s3";
+
+/** Files the assembler overwrites; everything else is copied once and left. */
+const GENERATED = /^(custom\d+\.h|pattern_registry\.h)$/;
+
+async function pathExists(target: string): Promise<boolean> {
+  try {
+    await fs.access(target);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Copy the firmware sources into the runner's working directory, once.
+ *
+ * Re-copied on every build only for the files a build can change, so the
+ * remaining sources keep their timestamps and arduino-cli does not decide the
+ * world has moved and rebuild the lot.
+ */
+export async function syncSketchDir(firmwareSrcDir: string, sketchDir: string): Promise<void> {
+  if (!(await pathExists(sketchDir))) {
+    await fs.mkdir(path.dirname(sketchDir), { recursive: true });
+    await fs.cp(firmwareSrcDir, sketchDir, {
+      recursive: true,
+      // The repo's own build output would be copied as a stale cache.
+      filter: (source) => !source.split(path.sep).includes("build"),
+    });
+    return;
+  }
+
+  // Restore the generated files to their pristine state so a previous build's
+  // custom slots cannot leak into this one.
+  for (const entry of await fs.readdir(firmwareSrcDir)) {
+    if (!GENERATED.test(entry)) continue;
+    await fs.copyFile(path.join(firmwareSrcDir, entry), path.join(sketchDir, entry));
+  }
+}
+
+/**
+ * Delete any image left in the build path by an earlier build.
+ *
+ * The build path is deliberately persistent — that is where the warm cache
+ * lives — which means the previous job's linked image is still sitting there
+ * when this one starts. Without clearing it, a compile that reports success
+ * without producing an image (a toolchain that exits 0 on a subtle failure,
+ * output written under another name) would be served the PREVIOUS user's
+ * firmware. Removing it first makes "the file exists afterwards" mean "this
+ * build produced it".
+ *
+ * Safe for the cache: this is the final linked output, not an intermediate
+ * object, so nothing that makes a warm build fast is thrown away.
+ */
+async function clearStaleImages(buildPath: string): Promise<void> {
+  if (!(await pathExists(buildPath))) return;
+  for (const entry of await fs.readdir(buildPath)) {
+    if (entry.endsWith(".ino.bin")) {
+      await fs.rm(path.join(buildPath, entry), { force: true });
+    }
+  }
+}
+
+/** Remove custom slots the current build does not use. */
+async function clearUnusedSlots(sketchDir: string, used: number): Promise<void> {
+  for (const entry of await fs.readdir(sketchDir)) {
+    const match = entry.match(/^custom(\d+)\.h$/);
+    if (match && Number(match[1]) > used) {
+      await fs.rm(path.join(sketchDir, entry), { force: true });
+    }
+  }
+}
+
+/** The real compiler: arduino-cli against the persistent build path. */
+export const arduinoCliCompiler: Compiler = ({ sketchDir, buildPath }) =>
+  new Promise((resolve) => {
+    const bin = process.env.ARDUINO_CLI_PATH ?? "arduino-cli";
+    const child = spawn(
+      bin,
+      ["compile", "--fqbn", FQBN, "--build-path", buildPath, sketchDir],
+      { stdio: ["ignore", "pipe", "pipe"] },
+    );
+
+    let output = "";
+    const collect = (chunk: Buffer) => {
+      output += chunk.toString();
+      // A runaway build can emit output without end; keep the tail only.
+      if (output.length > 200_000) output = output.slice(-100_000);
+    };
+    child.stdout.on("data", collect);
+    child.stderr.on("data", collect);
+
+    child.on("error", (error) => {
+      resolve({ ok: false, output: `${output}\nFailed to start ${bin}: ${error.message}` });
+    });
+
+    child.on("close", (code) => {
+      if (code !== 0) {
+        resolve({ ok: false, output: output || `arduino-cli exited with code ${code}` });
+        return;
+      }
+      resolve({ ok: true, appBinPath: path.join(buildPath, "patternflow.ino.bin"), output });
+    });
+  });
+
+export type RunBuildResult =
+  | { ok: true; artifact: string; artifactBytes: number; namespaces: string[]; output: string }
+  | { ok: false; error: string };
+
+/**
+ * Assemble sources, compile, and file the resulting image under `buildId`.
+ *
+ * Only the application image is kept. The bootloader, partition table and
+ * boot_app0 are identical for every build, so they are served as static files
+ * and the per-build artifact stays ~1.1 MB instead of the 16 MB merged image.
+ */
+export async function runBuild(
+  buildId: string,
+  patterns: CustomPatternInput[],
+  options: BuildRunnerOptions,
+): Promise<RunBuildResult> {
+  const compile = options.compile ?? arduinoCliCompiler;
+
+  const registryPath = path.join(options.firmwareSrcDir, "pattern_registry.h");
+  let originalRegistry: string;
+  try {
+    originalRegistry = await fs.readFile(registryPath, "utf8");
+  } catch {
+    return { ok: false, error: `Firmware sources not found at ${options.firmwareSrcDir}` };
+  }
+
+  const assembled = assembleFirmwareSource(patterns, originalRegistry);
+  if (!assembled.ok) return { ok: false, error: assembled.error };
+
+  await syncSketchDir(options.firmwareSrcDir, options.sketchDir);
+  for (const file of assembled.files) {
+    await fs.writeFile(path.join(options.sketchDir, file.path), file.content, "utf8");
+  }
+  await clearUnusedSlots(options.sketchDir, patterns.length);
+  await clearStaleImages(options.buildPath);
+
+  const result = await compile({ sketchDir: options.sketchDir, buildPath: options.buildPath });
+  if (!result.ok) return { ok: false, error: result.output };
+
+  let image: Buffer;
+  try {
+    image = await fs.readFile(result.appBinPath);
+  } catch {
+    return { ok: false, error: `Build reported success but produced no image at ${result.appBinPath}` };
+  }
+
+  await fs.mkdir(options.artifactDir, { recursive: true });
+  const artifact = `${buildId}.bin`;
+  await fs.writeFile(path.join(options.artifactDir, artifact), image);
+
+  return {
+    ok: true,
+    artifact,
+    artifactBytes: image.byteLength,
+    namespaces: assembled.namespaces,
+    output: result.output,
+  };
+}

--- a/web/src/lib/firmware/buildRunner.ts
+++ b/web/src/lib/firmware/buildRunner.ts
@@ -45,6 +45,30 @@ export type BuildRunnerOptions = {
 };
 
 /**
+ * Board options this firmware requires, mirroring firmware/README.md.
+ *
+ * A bare `esp32:esp32:esp32s3` is not a neutral choice — it silently selects
+ * the board package's defaults, which are wrong here in ways nothing reports:
+ *
+ *  · PSRAM defaults to OFF. PFMem::allocFloats then has no PSRAM to allocate
+ *    from and falls back to internal DRAM, so patterns with framebuffer-sized
+ *    buffers fail on web-built firmware while working when built locally.
+ *  · FlashSize defaults to 4MB against a 16MB partition table.
+ *  · CDCOnBoot decides whether Serial — and so Improv Wi-Fi provisioning —
+ *    answers on the native USB port or the UART bridge, i.e. which of the two
+ *    USB-C sockets offers Wi-Fi setup after flashing.
+ *
+ * Getting an option NAME wrong makes arduino-cli fail loudly; leaving an option
+ * out fails silently. So the default here is the full string rather than
+ * something minimal, and BUILD_FQBN is checked rather than trusted.
+ */
+export const DEFAULT_FQBN =
+  "esp32:esp32:esp32s3:PSRAM=opi,FlashSize=16M,PartitionScheme=app3M_fat9M_16MB,CDCOnBoot=cdc,USBMode=hwcdc";
+
+/** Options that must be pinned, whatever FQBN is in use. */
+const REQUIRED_FQBN_OPTIONS = ["PSRAM", "FlashSize", "PartitionScheme", "CDCOnBoot"];
+
+/**
  * Read when a build runs, not when this module loads.
  *
  * The worker calls loadEnv() in its own body, which under ES module semantics
@@ -54,7 +78,32 @@ export type BuildRunnerOptions = {
  * ordering question entirely.
  */
 export function fqbn(): string {
-  return process.env.BUILD_FQBN ?? "esp32:esp32:esp32s3";
+  return process.env.BUILD_FQBN ?? DEFAULT_FQBN;
+}
+
+/** Complaint about the configured FQBN, or null when it is usable. */
+export function checkFqbn(value = fqbn()): string | null {
+  const [vendor, arch, board, options] = value.split(":");
+  if (!vendor || !arch || !board) {
+    return `BUILD_FQBN "${value}" is not a valid FQBN (expected vendor:arch:board:options).`;
+  }
+
+  const present = new Set(
+    (options ?? "")
+      .split(",")
+      .map((entry) => entry.split("=")[0].trim())
+      .filter(Boolean),
+  );
+  const missing = REQUIRED_FQBN_OPTIONS.filter((option) => !present.has(option));
+  if (missing.length > 0) {
+    return (
+      `BUILD_FQBN is missing required board options: ${missing.join(", ")}. ` +
+      `Leaving these out compiles against the board defaults, which produces firmware that ` +
+      `boots but differs from the released build (see firmware/README.md). ` +
+      `Either unset BUILD_FQBN to use the pinned default, or add them.`
+    );
+  }
+  return null;
 }
 
 /** Files the assembler overwrites; everything else is copied once and left. */
@@ -190,6 +239,14 @@ export async function runBuild(
   options: BuildRunnerOptions,
 ): Promise<RunBuildResult> {
   const compile = options.compile ?? arduinoCliCompiler;
+
+  // Refuse before spending fifteen seconds producing the wrong firmware. Only
+  // checked for real compiles: an injected compiler is a test double and has no
+  // toolchain to configure.
+  if (!options.compile) {
+    const complaint = checkFqbn();
+    if (complaint) return { ok: false, error: complaint };
+  }
 
   const registryPath = path.join(options.firmwareSrcDir, "pattern_registry.h");
   let originalRegistry: string;

--- a/web/src/lib/firmware/buildRunner.ts
+++ b/web/src/lib/firmware/buildRunner.ts
@@ -107,7 +107,7 @@ export function checkFqbn(value = fqbn()): string | null {
 }
 
 /** Files the assembler overwrites; everything else is copied once and left. */
-const GENERATED = /^(custom\d+\.h|pattern_registry\.h)$/;
+const GENERATED = /^(custom\d+\.h|pattern_registry\.h|patternflow_secrets\.h)$/;
 
 async function pathExists(target: string): Promise<boolean> {
   try {

--- a/web/src/lib/firmware/buildRunner.ts
+++ b/web/src/lib/firmware/buildRunner.ts
@@ -117,6 +117,15 @@ async function clearUnusedSlots(sketchDir: string, used: number): Promise<void> 
   }
 }
 
+/**
+ * arduino-cli names its output after the sketch, and a sketch is a directory
+ * containing a `.ino` of the same name — so the working copy must keep the
+ * firmware directory's name (`patternflow/`), not be renamed to `sketch/`.
+ */
+export function sketchName(sketchDir: string): string {
+  return path.basename(sketchDir);
+}
+
 /** The real compiler: arduino-cli against the persistent build path. */
 export const arduinoCliCompiler: Compiler = ({ sketchDir, buildPath }) =>
   new Promise((resolve) => {
@@ -145,7 +154,11 @@ export const arduinoCliCompiler: Compiler = ({ sketchDir, buildPath }) =>
         resolve({ ok: false, output: output || `arduino-cli exited with code ${code}` });
         return;
       }
-      resolve({ ok: true, appBinPath: path.join(buildPath, "patternflow.ino.bin"), output });
+      resolve({
+        ok: true,
+        appBinPath: path.join(buildPath, `${sketchName(sketchDir)}.ino.bin`),
+        output,
+      });
     });
   });
 

--- a/web/src/lib/firmware/buildRunner.ts
+++ b/web/src/lib/firmware/buildRunner.ts
@@ -44,7 +44,18 @@ export type BuildRunnerOptions = {
   compile?: Compiler;
 };
 
-export const FQBN = process.env.BUILD_FQBN ?? "esp32:esp32:esp32s3";
+/**
+ * Read when a build runs, not when this module loads.
+ *
+ * The worker calls loadEnv() in its own body, which under ES module semantics
+ * happens *after* every import has been evaluated — so anything reading
+ * process.env at module scope would capture the value from before .env.local
+ * was loaded and silently ignore it. Keeping every env read lazy removes the
+ * ordering question entirely.
+ */
+export function fqbn(): string {
+  return process.env.BUILD_FQBN ?? "esp32:esp32:esp32s3";
+}
 
 /** Files the assembler overwrites; everything else is copied once and left. */
 const GENERATED = /^(custom\d+\.h|pattern_registry\.h)$/;
@@ -132,7 +143,7 @@ export const arduinoCliCompiler: Compiler = ({ sketchDir, buildPath }) =>
     const bin = process.env.ARDUINO_CLI_PATH ?? "arduino-cli";
     const child = spawn(
       bin,
-      ["compile", "--fqbn", FQBN, "--build-path", buildPath, sketchDir],
+      ["compile", "--fqbn", fqbn(), "--build-path", buildPath, sketchDir],
       { stdio: ["ignore", "pipe", "pipe"] },
     );
 

--- a/web/src/lib/firmware/paths.ts
+++ b/web/src/lib/firmware/paths.ts
@@ -1,0 +1,28 @@
+import path from "node:path";
+
+// Where the firmware sources live, shared by the API (which validates a
+// submission against the real registry before queueing it) and the worker
+// (which compiles it). Read lazily so .env.local applies to both.
+
+export function firmwareSrcDir(): string {
+  return process.env.FIRMWARE_SRC_DIR ?? path.resolve(process.cwd(), "../firmware/patternflow");
+}
+
+export function registryPath(): string {
+  return path.join(firmwareSrcDir(), "pattern_registry.h");
+}
+
+/**
+ * Static parts of a flashable image, served from public/flash.
+ *
+ * The bootloader and partition table do not depend on the sketch, so every
+ * build shares the ones already committed for the stock firmware and only the
+ * ~1.1 MB application image differs.
+ */
+export const STATIC_FLASH_PARTS = [
+  { path: "/flash/bin/v2/patternflow.ino.bootloader.bin", offset: 0 },
+  { path: "/flash/bin/v2/patternflow.ino.partitions.bin", offset: 0x8000 },
+] as const;
+
+/** Offset the application image is written to (app0 in the partition table). */
+export const APP_OFFSET = 0x10000;


### PR DESCRIPTION
Closes #230. Fixes found and resolved along the way are in #231; follow-up work is split into #232 (firmware) and #233 (web).

## What this does

Paste a pattern's C++ header in the browser, the server compiles a complete firmware image, and esp-web-tools flashes it over USB. About twenty seconds from pressing the button to a device running the pattern — against thirty to sixty minutes of installing an Arduino IDE, a board package and libraries the first time.

Verified end to end on real hardware: the device boots, the preset library and navigation survive, and the custom pattern renders with its knobs behaving as they did in the browser preview.

## How it is put together

- **Source assembly** (`lib/firmware/assemble.ts`) — a submitted `.h` becomes the custom slots plus a patched `pattern_registry.h`. Pure text in and out, so the part that is easy to get wrong is testable without a toolchain. The namespace is read out of the header rather than typed in, and one that collides with a bundled pattern is refused at submit time instead of surfacing as a link error fifteen seconds later.
- **A queue, not an inline compile** — a build pegs a core for ~15 s, so the web request enqueues and a separate worker process claims it. Claiming is one `UPDATE … WHERE id = (SELECT … LIMIT 1) RETURNING`, so two workers can never take the same job, and jobs abandoned by a dead worker are reaped.
- **A warm worker** — the sketch directory and `--build-path` persist between builds. That is the whole performance story: 128 s cold, 14–16 s warm on a Raspberry Pi 5, which turned out to be enough machine that the VPS this was sized for is not needed.
- **API** — queue, poll, download, and an esp-web-tools manifest pairing the fresh image with the bootloader and partition table already committed for the stock firmware, so only ~1.1 MB is per-build.
- **UI** — a build modal in Pattern Lab (which offers the C++ conversion prompt, since the lab holds JavaScript) and a *Flash to my board* button on hardware-ready community patterns, where the header already exists.

## Two decisions worth knowing about

**The read routes are authorised by the build id, not a session.** esp-web-tools fetches the manifest and image itself, without credentials and possibly from a different origin than the page — a cookie check there would break flashing from the main site entirely. The id is 64 bits of randomness handed only to whoever queued the build.

**Board options are pinned in code.** A bare `esp32:esp32:esp32s3` is not neutral: it selects the board package's defaults, which meant PSRAM compiled out, 4 MB flash against a 16 MB partition table, and Wi-Fi provisioning answering on the wrong USB socket. All three produced firmware that booted and looked fine. The default FQBN now pins every required option and an override that drops one is refused before the build starts — a wrong option *name* fails loudly, whereas a *missing* one fails silently, so the verbose default is the safer one.

## Bugs caught while building it

- Because the build path persists, a compile that reported success without producing an image handed back the **previous** build's binary — one user receiving another's firmware.
- `arduino-cli` resolves a sketch by directory name, so the working copy has to keep the firmware directory's name.
- `BUILD_FQBN` was read at module scope, so setting it in `.env.local` was silently ignored.
- `PF_OSC_ENABLED` defaulted off and was opted into from the gitignored secrets file, so any build from a clean checkout lost OSC.

## Effect on this deployment

None visible. The build API needs `BUILD_ENABLED` and the buttons need `NEXT_PUBLIC_BUILD_ENABLED`; neither is set here, and this deployment has no worker or database. The firmware and documentation changes affect people building from source.

**Still maintainer-only.** This compiles submitted C++ with no sandbox of its own — arbitrary code execution at compile time, even though nothing runs. `BUILD_ENABLED` staying unset everywhere but the build host is what keeps that safe, and it must stay that way until the worker runs inside a container with no network, a read-only root and resource limits.