### PR TITLE
Docs: custom patterns no longer need the Arduino IDE (+ Pattern Lab paste/clear)

### DIFF
--- a/BUILD_GUIDE.md
+++ b/BUILD_GUIDE.md
@@ -300,6 +300,6 @@ The stock flasher image ships with **OSC disabled at compile time** — live con
 
 ---
 
-**Want custom patterns?** After building, see [`firmware/CUSTOM_PATTERNS.md`](firmware/CUSTOM_PATTERNS.md) and the Live Editor at [patternflow.work](https://patternflow.work).
+**Want custom patterns?** You no longer need the Arduino IDE for this — Pattern Lab's **Build firmware** button compiles a firmware image containing your pattern on the server and flashes it from the browser over USB, in about fifteen seconds. The Arduino IDE route above stays for firmware development. See [`firmware/CUSTOM_PATTERNS.md`](firmware/CUSTOM_PATTERNS.md) and the Live Editor at [patternflow.work](https://patternflow.work).
 
 *Licenses: firmware & web MIT; hardware & designs CC-BY-SA 4.0.*

--- a/README.md
+++ b/README.md
@@ -81,12 +81,15 @@ Patternflow ships with a prompt template designed for AI coding assistants (Clau
 2. Paste it into your AI assistant (Claude, ChatGPT, etc.) along with a description of the look you want.
 3. Copy the generated JavaScript code, paste it into the **Live Editor**, and turn the virtual knobs in the web preview to test the pattern.
 4. Once you are happy with the visuals, click **Copy C++ prompt** in the editor and send it to your AI assistant.
-5. Open `firmware/patternflow/patternflow.ino` in the Arduino IDE — the custom slots and the registry open right alongside it as editor tabs, so everything happens in one window.
-6. In the `custom1.h` (or `custom2.h` / `custom3.h`) tab, paste the C++ output **as-is**. Grab the pattern's namespace name from the bottom of the file (`} // namespace YourPatternName`), paste it into that slot's `PATTERN_ENTRY(...)` line in the `pattern_registry.h` tab, and hit flash. To add more slots, see [`firmware/patternflow/README.md`](firmware/patternflow/README.md).
+5. Put it on the device — **from the browser**, or from the Arduino IDE if you prefer:
+
+**From the browser** — in **Pattern Lab**, press **Build firmware**, paste the C++ your assistant returned, and press build. A server compiles a complete firmware image with your pattern in it — about fifteen seconds — and your browser writes it to the board over USB. Nothing to install: no IDE, no board package, no editing the pattern registry by hand. Community patterns marked `.h` skip the conversion entirely and offer **Flash to my board** directly. Needs desktop Chrome or Edge (browser flashing uses Web Serial) and a USB cable — wireless updates are [planned, not built](../../issues/232).
+
+**From the Arduino IDE** — open `firmware/patternflow/patternflow.ino`; the custom slots and the registry open alongside it as editor tabs. Paste the C++ into `custom1.h` (or `custom2.h` / `custom3.h`) **as-is**, take the namespace from the bottom of the file (`} // namespace YourPatternName`), add it to that slot's `PATTERN_ENTRY(...)` line in `pattern_registry.h`, and flash. Still the route for changing anything beyond a pattern, or working offline. See [`firmware/patternflow/README.md`](firmware/patternflow/README.md).
 
 No GLSL or rendering pipeline knowledge needed. The template handles the encoder mapping, brightness curve, and HUB75 buffer interface; you describe the visuals.
 
-Custom patterns require a local Arduino IDE compile/upload step for now.
+Either way you are flashing a whole firmware image, so the custom slots are replaced — the preset library always comes along.
 
 ## The website
 

--- a/docs/assembly/README.md
+++ b/docs/assembly/README.md
@@ -11,9 +11,9 @@ Once you build these two components, you simply flash the firmware to bring your
 
 | Enclosure | Electronics | Firmware | Status |
 | --- | --- | --- | --- |
-| [3D printed enclosure](enclosure/3d-print.md) | [Custom PCB, hand-soldered](electronics/pcb.md) | [Arduino IDE / Custom patterns](firmware/custom-patterns.md) | Supported now |
+| [3D printed enclosure](enclosure/3d-print.md) | [Custom PCB, hand-soldered](electronics/pcb.md) | [Browser or Arduino IDE / Custom patterns](firmware/custom-patterns.md) | Supported now |
 
-This is the same path as the original build guide: PLA parts printed on a Bambu P1S or similar FDM printer, a hand-soldered Patternflow PCB, and firmware compiled/uploaded via Arduino IDE to support custom generative patterns.
+This is the same path as the original build guide: PLA parts printed on a Bambu P1S or similar FDM printer, a hand-soldered Patternflow PCB, and firmware flashed from the browser — or compiled locally in the Arduino IDE — to run custom generative patterns.
 
 ## Build Combinations
 
@@ -30,9 +30,11 @@ The custom PCB path is stable. PCBA may become a later electronics path for peop
 
 ## Firmware & Custom Patterns
 
-To bring your Patternflow hardware to life, you will compile and upload the firmware using the Arduino IDE. This setup allows you to **create and run your own generative patterns using AI coding assistants**.
+To bring your Patternflow hardware to life you flash it with firmware, and you can **create and run your own generative patterns using AI coding assistants**.
 
-- **[Create Custom Patterns (Recommended)](firmware/custom-patterns.md)** — Use our interactive web Live Editor and an AI assistant (Claude, ChatGPT, etc.) to generate, preview, and install your own visual patterns using the Arduino IDE.
+Custom patterns no longer need a local toolchain: the server compiles a firmware image containing your pattern and the browser writes it over USB. The Arduino IDE route remains for firmware development and offline work.
+
+- **[Create Custom Patterns (Recommended)](firmware/custom-patterns.md)** — Use our interactive web Live Editor and an AI assistant (Claude, ChatGPT, etc.) to generate, preview and install your own visual patterns, either straight from the browser or via the Arduino IDE.
 
 ## Legacy Guide
 

--- a/docs/assembly/firmware/custom-patterns.md
+++ b/docs/assembly/firmware/custom-patterns.md
@@ -4,12 +4,22 @@ Status: supported now.
 
 Use this path when you want to run your own pattern on Patternflow hardware.
 
-The important distinction:
+Two routes, and the browser one is new:
 
-- The browser flasher installs the official release firmware.
-- Custom patterns require a local Arduino IDE build.
+- **From the browser** — the server compiles a firmware image containing your pattern and the browser flashes it over USB. Nothing to install.
+- **From the Arduino IDE** — a local build. Still the route for firmware development, config changes, or working offline.
 
-## Workflow
+## Workflow — from the browser
+
+1. Open the Patternflow Live Editor at [patternflow.work](https://patternflow.work).
+2. Make or tune a JavaScript pattern.
+3. Click **Copy C++ prompt** and use an AI assistant to convert the pattern.
+4. In **Pattern Lab**, press **Build firmware**, paste the C++, and build. Takes about fifteen seconds.
+5. Press **Flash to my Patternflow** and pick the serial port.
+
+Needs desktop Chrome or Edge — browser flashing uses Web Serial, which Firefox and Safari do not implement — and a USB cable. A community pattern already marked `.h` skips steps 2–4 and offers **Flash to my board** directly.
+
+## Workflow — from the Arduino IDE
 
 1. Open the Patternflow Live Editor at [patternflow.work](https://patternflow.work).
 2. Make or tune a JavaScript pattern.

--- a/firmware/CUSTOM_PATTERNS.md
+++ b/firmware/CUSTOM_PATTERNS.md
@@ -5,6 +5,8 @@ Patternflow includes a workflow for creating patterns without writing low-level 
 - **AI-assisted** — describe the pattern in plain language, paste the AI's output into the editor, tune knobs, copy to C++, flash. No shader knowledge required.
 - **Direct** — write the JavaScript pattern by hand in the editor, then convert to C++. For anyone comfortable with fragment-shader-style code.
 
+> **New: you no longer need the Arduino IDE.** The last step — turning a pattern into firmware and getting it onto the board — now runs in the browser: the server compiles, your browser flashes over USB. See [step 5](#5-convert-to-c-and-flash). The Arduino IDE route still works and is still the right one for firmware development.
+
 The 5-step path below is the AI-assisted route. The direct route reuses the same editor; skip to [Direct coding](#direct-coding-no-ai) if you don't need AI help.
 
 ---
@@ -42,11 +44,29 @@ When you're happy with how it looks:
 
 1. Click **Copy C++ prompt**. This bundles your final JS together with a conversion prompt and copies the whole thing to your clipboard.
 2. Paste into your AI assistant again. It returns C++ in Patternflow's namespace format.
-3. Save that C++ output as `pattern_yourname.h` inside `firmware/patternflow/`.
-4. Open `pattern_registry.h` and add two lines (see [Installing your pattern](#installing-your-pattern) below).
-5. Open `patternflow.ino` in Arduino IDE, select your ESP32-S3 port, and upload.
+3. Put it on the device. **Two routes, same result** — pick either:
+
+#### Route A — from the browser (nothing to install)
+
+In **Pattern Lab**, press **Build firmware**, paste the C++ your assistant returned, and press build. A server compiles a complete firmware image with your pattern in it — about fifteen seconds — and the browser writes it to the board over USB.
+
+No Arduino IDE, no board package, no editing `pattern_registry.h`: the registry entry is generated from the namespace in your header. A community pattern already marked `.h` skips steps 1–2 entirely and offers **Flash to my board**.
+
+Requirements: desktop **Chrome or Edge** (browser flashing needs Web Serial, which Firefox and Safari do not implement) and a USB cable. Wireless updates are [planned but not built](../../issues/232).
+
+If the build fails you get the compiler's own error. The usual causes are a helper the firmware already provides being redefined, or a type that differs from the JavaScript original.
+
+#### Route B — from the Arduino IDE (local build)
+
+1. Save the C++ output as `pattern_yourname.h` inside `firmware/patternflow/`.
+2. Open `pattern_registry.h` and add two lines (see [Installing your pattern](#installing-your-pattern) below).
+3. Open `patternflow.ino` in Arduino IDE, select your ESP32-S3 port, and upload.
+
+Still the route for changing anything beyond a pattern — firmware development, config edits, working offline, or building for a board you cannot plug into this machine.
 
 Long-press encoder 4 on the device to cycle to your new pattern.
+
+> Either route flashes a **whole firmware image**, so whatever was in the custom slots is replaced. The preset library is compiled in every time, so you never lose those.
 
 ---
 

--- a/web/src/app/pattern-lab/PatternLab.module.css
+++ b/web/src/app/pattern-lab/PatternLab.module.css
@@ -758,6 +758,29 @@
   background: #d9c8a4 !important;
 }
 
+.editorHeader .pasteButton {
+  background: #e8552e !important;
+  color: #ffffff !important;
+  border-color: #e8552e !important;
+  font-weight: 600;
+}
+
+.editorHeader .pasteButton:hover {
+  background: #d44722 !important;
+  border-color: #d44722 !important;
+}
+
+.editorHeader .clearButton {
+  background: #ffffff !important;
+  color: #171512 !important;
+  border: 1px solid rgba(23, 21, 18, 0.3) !important;
+}
+
+.editorHeader .clearButton:hover {
+  background: #f0eae1 !important;
+  border-color: #171512 !important;
+}
+
 .sweepBar {
   margin-top: 12px;
   padding-top: 12px;
@@ -1370,6 +1393,17 @@
   .editorHeader {
     align-items: flex-start;
     flex-direction: column;
+  }
+
+  .editorActions {
+    width: 100%;
+    gap: 8px;
+  }
+
+  .editorHeader button {
+    min-height: 32px;
+    padding: 0 10px;
+    font-size: 11px;
   }
 
   .workspace {

--- a/web/src/app/pattern-lab/PatternLabClient.tsx
+++ b/web/src/app/pattern-lab/PatternLabClient.tsx
@@ -524,6 +524,8 @@ export default function PatternLabClient() {
   const [copied, setCopied] = useState(false);
   const [promptCopied, setPromptCopied] = useState(false);
   const [cppPromptCopied, setCppPromptCopied] = useState(false);
+  const [pasted, setPasted] = useState(false);
+  const [cleared, setCleared] = useState(false);
   const [buttonHelpOpen, setButtonHelpOpen] = useState(false);
   const [shareOpen, setShareOpen] = useState(false);
   const [communityShareOpen, setCommunityShareOpen] = useState(false);
@@ -1451,6 +1453,34 @@ export default function PatternLabClient() {
     window.setTimeout(() => setPromptCopied(false), 1200);
   };
 
+  const pasteFromClipboard = async () => {
+    try {
+      if (typeof navigator !== "undefined" && navigator.clipboard?.readText) {
+        const text = await navigator.clipboard.readText();
+        if (text) {
+          updateCode(text);
+          setPasted(true);
+          window.setTimeout(() => setPasted(false), 1200);
+          return;
+        }
+      }
+    } catch {
+      // Permission blocked or unsupported in WebView — fall back to window.prompt
+    }
+    const fallbackText = window.prompt("붙여넣을 패턴 코드를 아래 상자에 입력하거나 붙여넣어 주세요:");
+    if (fallbackText !== null) {
+      updateCode(fallbackText);
+      setPasted(true);
+      window.setTimeout(() => setPasted(false), 1200);
+    }
+  };
+
+  const clearCode = () => {
+    updateCode("");
+    setCleared(true);
+    window.setTimeout(() => setCleared(false), 1200);
+  };
+
   const openKeyModal = () => {
     setKeyDraft(geminiKey);
     setKeyModalOpen(true);
@@ -2295,6 +2325,22 @@ ${codeWithMatrix(activeCode)}
                       ›
                     </button>
                   </div>
+                  <button
+                    type="button"
+                    className={styles.pasteButton}
+                    onClick={pasteFromClipboard}
+                    title="Paste pattern code directly from clipboard"
+                  >
+                    {pasted ? "Pasted ✓" : "Paste"}
+                  </button>
+                  <button
+                    type="button"
+                    className={styles.clearButton}
+                    onClick={clearCode}
+                    title="Clear all code in the editor"
+                  >
+                    {cleared ? "Cleared ✓" : "Clear"}
+                  </button>
                   <button type="button" onClick={copyVariantPrompt}>
                     {promptCopied ? "Copied" : "Copy prompt"}
                   </button>


### PR DESCRIPTION
Two changes that landed together.

## Documentation

Every guide still told people that putting a custom pattern on the device meant installing the Arduino IDE. That was true right up until #234 shipped, and it is the first thing a newcomer reads — so the docs were actively steering people into the hour-long path we just removed.

Updated: `README.md`, `BUILD_GUIDE.md`, `firmware/CUSTOM_PATTERNS.md`, `docs/assembly/README.md`, `docs/assembly/firmware/custom-patterns.md`.

They now lead with the browser route — paste the C++, the server compiles a firmware image in about fifteen seconds, the browser flashes it over USB — and keep the Arduino IDE as the route for firmware development, config changes and offline work. It is presented as two ways to do the same thing rather than a replacement, because for anyone touching the firmware itself the IDE is still the answer.

Three things that were previously left for people to discover are now stated:

- Browser flashing needs **desktop Chrome or Edge**; it uses Web Serial, which Firefox and Safari do not implement.
- It is **wired USB** — wireless is [planned, not built](../../issues/232), and saying so beats letting people assume otherwise.
- Either route writes a **whole firmware image**, so the custom slots are replaced. The preset library is compiled in every time, so nothing is lost there.

`BUILD_GUIDE_v2.md` is left alone — it documents the v2 hardware revision.

## Pattern Lab

Paste-from-clipboard and clear-code buttons, which matter most on mobile where selecting all the code by hand is awkward.

## Effect on this deployment

Docs plus two buttons. The build service itself remains gated behind `BUILD_ENABLED` / `NEXT_PUBLIC_BUILD_ENABLED`, neither of which is set here.