### PR TITLE
Wireless firmware updates from the browser (#232 §1) + roadmap overhaul

### DIFF
--- a/firmware/README.md
+++ b/firmware/README.md
@@ -63,8 +63,9 @@ firmware/patternflow/
     ├── core_wifi.h          # Shared Wi-Fi bring-up (single WiFi.begin for all features)
     ├── core_improv.h        # Improv-Serial Wi-Fi provisioning from the browser flasher
     ├── core_osc.h           # OSC sidechannel (UDP send when PF_OSC_ENABLED)
-    ├── core_audio_ws.h      # Browser audio-react HTTP/WebSocket server
-    ├── audio_index.h        # Built-in patternflow.local audio UI bundle
+    ├── core_audio_ws.h      # Device web console HTTP server + audio-react WebSocket
+    ├── home_index.h         # patternflow.local landing page (console home)
+    ├── audio_index.h        # Audio-react UI bundle (served at /audio)
     ├── core_ota.h           # ArduinoOTA wireless flashing (PF_OTA_ENABLED)
     ├── core_web_update.h    # Browser self-update via patternflow.local/update
     └── web_update_index.h   # Built-in update page bundle (drop a .bin)
@@ -340,13 +341,12 @@ Numeric arguments may be int or float (floats are rounded) — Max patches commo
 Once the device is on Wi-Fi, it can flash itself from any browser on the same network — no Arduino IDE, no USB cable, no TLS setup ([#232](https://github.com/engmung/Patternflow/issues/232)).
 
 1. Get a firmware `.bin`: build one on [patternflow.work](https://patternflow.work) and hit *Download .bin*, or export one locally (`arduino-cli compile --output-dir …` — use the app image, not a merged full-flash image).
-2. Open `http://patternflow.local/update` (the update page also shows the device's raw IP fallback — use `http://<ip>/update` if `.local` doesn't resolve, which is common on Android).
-3. On the device: hold **K2** → NETWORK screen, then turn **K4** → **UPDATE** screen. This *arms* the upload endpoint; the page's status chip flips to ARMED. The screen shows both `patternflow.local/update` and the device IP.
-4. Drop the `.bin` on the page. The panel shows flash progress; the device verifies, reboots, and comes back on the new firmware in about ten seconds.
+2. Open `http://patternflow.local` — the device serves a small console (audio sync / firmware update) — and pick **Firmware Update**, or go straight to `/update`. If `.local` doesn't resolve (common on Android), use `http://<ip>/update`; the device shows its IP on the NETWORK screen (hold K2) and on the UPDATE screen.
+3. Drop the `.bin` on the page. The panel shows flash progress; the device verifies, reboots, and comes back on the new firmware in about ten seconds.
 
 Notes:
 
-- **The endpoint is closed unless you arm it from the device.** Anyone on your Wi-Fi can *see* the page, but a firmware POST is refused (`403`) unless someone physically opened the UPDATE screen — leaving the screen (K4 click, or the 10-minute idle timeout) disarms it again. That is the security model: flashing requires a person at the device.
+- **Uploads are accepted at any time by default** (`PF_WEBUPDATE_ALWAYS_ARMED 1`): drop a .bin whenever, no trip to the device. The flip side, stated plainly: anyone on the same Wi-Fi can flash the device from a phone browser — the same exposure ArduinoOTA's no-password default already has. On shared, office, or exhibition Wi-Fi, build with `#define PF_WEBUPDATE_ALWAYS_ARMED 0` in `patternflow_secrets.h`: uploads are then refused (`403`) unless the UPDATE screen is open on the device (hold **K2** → NETWORK, turn **K4**) — a physical arming switch only someone at the device can flip; leaving the screen (K4 click, or the 10-minute idle timeout) disarms it again.
 - A failed or interrupted upload leaves the old firmware running — `Update.h` only switches the boot partition after a complete, verified image. Power loss *during* the flash write is the one case to avoid; the panel says so while flashing.
 - Like all wireless paths, this capability has to arrive over USB once (it ships in the stock release).
 - Set `#define PF_WEBUPDATE_ENABLED 0` in `patternflow_secrets.h` to compile it out.

--- a/firmware/README.md
+++ b/firmware/README.md
@@ -44,7 +44,7 @@ The experimental audio-react WebSocket control uses:
 firmware/patternflow/
 ├── patternflow.ino          # Main sketch: input routing, mode dispatch
 ├── config.h                 # Hardware configuration (pin mappings, limits)
-├── net_config.h             # Wi-Fi / OTA / OSC / audio-react config + defaults
+├── net_config.h             # Wi-Fi / OTA / OSC / audio-react / self-update config + defaults
 ├── pattern_registry.h       # Function-pointer table — register patterns here
 ├── pattern_origin.h         # Built-in pattern: radial sine grids
 ├── pattern_wave_saw.h       # Built-in pattern: directional saw bands
@@ -65,7 +65,9 @@ firmware/patternflow/
     ├── core_osc.h           # OSC sidechannel (UDP send when PF_OSC_ENABLED)
     ├── core_audio_ws.h      # Browser audio-react HTTP/WebSocket server
     ├── audio_index.h        # Built-in patternflow.local audio UI bundle
-    └── core_ota.h           # ArduinoOTA wireless flashing (PF_OTA_ENABLED)
+    ├── core_ota.h           # ArduinoOTA wireless flashing (PF_OTA_ENABLED)
+    ├── core_web_update.h    # Browser self-update via patternflow.local/update
+    └── web_update_index.h   # Built-in update page bundle (drop a .bin)
 ```
 
 The `src/` subfolder holds the foundation that patterns build on. Arduino IDE compiles everything underneath the sketch folder, but `.h` files inside subfolders **do not appear as tabs** — so the IDE stays focused on the files you actually edit (the sketch, config, registry, and patterns) while the foundation stays out of the way. Patterns and the main sketch reference these helpers via `#include "src/core_*.h"`.
@@ -332,6 +334,22 @@ The device also listens on `PF_OSC_LOCAL_PORT` (default 9001) so an external hos
 ```
 
 Numeric arguments may be int or float (floats are rounded) — Max patches commonly send floats, and silently dropping them was a debugging trap. Knob deltas are applied on top of any physical encoder motion in the same frame, at the raw 1×-per-detent rate (no acceleration). Useful for Ableton automation lanes that drive a pattern parameter from a Live track. Unknown addresses (and `#bundle` packets) are ignored silently. Receive buffer is 256 bytes per packet; up to 8 datagrams are drained per frame so fast automation streams don't build up queue latency.
+
+## Wireless update from the browser
+
+Once the device is on Wi-Fi, it can flash itself from any browser on the same network — no Arduino IDE, no USB cable, no TLS setup ([#232](https://github.com/engmung/Patternflow/issues/232)).
+
+1. Get a firmware `.bin`: build one on [patternflow.work](https://patternflow.work) and hit *Download .bin*, or export one locally (`arduino-cli compile --output-dir …` — use the app image, not a merged full-flash image).
+2. Open `http://patternflow.local/update` (the update page also shows the device's raw IP fallback — use `http://<ip>/update` if `.local` doesn't resolve, which is common on Android).
+3. On the device: hold **K2** → NETWORK screen, then turn **K4** → **UPDATE** screen. This *arms* the upload endpoint; the page's status chip flips to ARMED. The screen shows both `patternflow.local/update` and the device IP.
+4. Drop the `.bin` on the page. The panel shows flash progress; the device verifies, reboots, and comes back on the new firmware in about ten seconds.
+
+Notes:
+
+- **The endpoint is closed unless you arm it from the device.** Anyone on your Wi-Fi can *see* the page, but a firmware POST is refused (`403`) unless someone physically opened the UPDATE screen — leaving the screen (K4 click, or the 10-minute idle timeout) disarms it again. That is the security model: flashing requires a person at the device.
+- A failed or interrupted upload leaves the old firmware running — `Update.h` only switches the boot partition after a complete, verified image. Power loss *during* the flash write is the one case to avoid; the panel says so while flashing.
+- Like all wireless paths, this capability has to arrive over USB once (it ships in the stock release).
+- Set `#define PF_WEBUPDATE_ENABLED 0` in `patternflow_secrets.h` to compile it out.
 
 ## OTA Updates (For Developers)
 

--- a/firmware/patternflow/README.md
+++ b/firmware/patternflow/README.md
@@ -109,6 +109,11 @@ Two things to know:
 `PFCanvas::present()` restores the panel frame, so a `setFrame` can never leak
 into the next pattern, and a pattern that never calls it is unaffected.
 
+**Tried either of these? Please report back.** There is more variety in panels
+and driver ICs than one desk can test, so results from real hardware are the
+only way this gets trustworthy — working or broken, both are useful:
+[#224 Custom panel sizes and pattern frames](https://github.com/engmung/Patternflow/issues/224).
+
 ## Registry
 
 `pattern_registry.h` keeps `customPatterns[]` and `presetPatterns[]` as two

--- a/firmware/patternflow/config.h
+++ b/firmware/patternflow/config.h
@@ -56,6 +56,8 @@ constexpr float EULER      = 2.71828182845904523536f;
 // (A pattern composed for a grid that ISN'T the panel — a 64x128 portrait
 // pattern on this 128x64 panel, say — is a separate matter, handled per
 // pattern with PFCanvas::setFrame(). See README.md.)
+// Running a non-stock panel? Please report how it went, working or not:
+// https://github.com/engmung/Patternflow/issues/224
 #define PANEL_RES_W 128
 #define PANEL_RES_H 64
 #define PANEL_CHAIN 1

--- a/firmware/patternflow/custom2.h
+++ b/firmware/patternflow/custom2.h
@@ -6,147 +6,164 @@
 #include "src/core_encoders.h"
 #include "src/core_canvas.h"
 #include "src/core_math.h"
-#include "src/core_tables.h"
+#include "src/core_noise.h"
 
-namespace RippleCellGrid {
+namespace CyberpunkCity {
 
-const char* NAME = "Cell Ripple";
-const char* const KNOB_LABELS[4] = {"Speed", "Size", "Ripple", "Density"};
+const char* NAME = "Cyber City";
+const char* const KNOB_LABELS[4] = {"Buildings", "Speed", "Rain Density", "Glow"};
+
+static float g_buildings = 6.507f;
+static float g_speed = 0.939f;
+static float g_rainDensity = 0.397f;
+static float g_glow = 1.226f;
+static float g_timeAcc = 0.0f;
 
 static const uint8_t RAMP_LUT[256][3] = {
-  {0,0,0},{0,0,0},{0,0,0},{0,0,0},{0,0,0},{0,0,0},{0,0,0},{0,0,0},
-  {0,0,0},{0,0,0},{0,0,0},{0,0,0},{0,0,0},{0,0,0},{0,0,0},{0,0,0},
-  {0,0,0},{0,0,0},{0,0,0},{3,3,3},{24,22,22},{45,37,37},{67,49,49},{88,58,58},
-  {109,62,62},{130,64,64},{152,61,61},{173,56,56},{194,46,46},{216,33,33},{237,17,17},{255,0,1},
-  {255,0,10},{255,0,19},{255,0,27},{255,0,36},{255,0,45},{255,0,53},{255,0,62},{255,0,71},
-  {255,0,79},{255,0,88},{255,0,96},{255,0,105},{255,0,114},{255,0,122},{255,0,131},{255,0,140},
-  {255,0,148},{255,0,157},{255,0,166},{255,0,174},{255,0,183},{255,0,192},{255,0,200},{255,0,209},
-  {255,0,218},{255,0,226},{255,0,235},{255,0,244},{255,0,252},{249,0,255},{240,0,255},{232,0,255},
-  {223,0,255},{214,0,255},{206,0,255},{197,0,255},{188,0,255},{180,0,255},{171,0,255},{163,0,255},
-  {154,0,255},{145,0,255},{137,0,255},{128,0,255},{119,0,255},{111,0,255},{102,0,255},{93,0,255},
-  {85,0,255},{76,0,255},{67,0,255},{59,0,255},{50,0,255},{41,0,255},{33,0,255},{24,0,255},
-  {15,0,255},{7,0,255},{0,2,255},{0,11,255},{0,19,255},{0,28,255},{0,37,255},{0,45,255},
-  {0,54,255},{0,63,255},{0,71,255},{0,80,255},{0,88,255},{0,97,255},{0,106,255},{0,114,255},
-  {0,123,255},{0,132,255},{0,140,255},{0,149,255},{0,158,255},{0,166,255},{0,175,255},{0,184,255},
-  {0,192,255},{0,201,255},{0,210,255},{0,218,255},{0,225,255},{0,223,253},{0,221,252},{0,219,251},
-  {0,217,249},{0,215,248},{0,213,247},{0,211,246},{0,209,244},{0,207,243},{0,205,242},{0,204,240},
-  {0,202,239},{0,200,238},{0,198,236},{0,196,235},{0,194,234},{0,193,232},{0,191,231},{0,189,230},
-  {0,187,228},{0,185,227},{0,184,226},{0,182,225},{0,180,223},{0,178,222},{0,177,221},{0,175,219},
-  {0,173,218},{0,171,217},{0,170,215},{0,168,214},{0,166,213},{0,165,211},{0,163,210},{0,161,209},
-  {0,160,207},{0,158,206},{0,156,205},{0,155,204},{0,153,202},{0,151,201},{0,150,200},{0,148,198},
-  {0,147,197},{0,145,196},{0,143,194},{0,142,193},{0,140,192},{0,139,190},{0,137,189},{0,136,188},
-  {0,134,186},{0,133,185},{0,131,184},{0,130,183},{0,128,181},{0,127,180},{0,125,179},{0,124,177},
-  {0,122,176},{0,121,175},{0,119,173},{0,118,172},{0,116,171},{0,115,169},{0,114,168},{0,112,167},
-  {0,111,165},{0,109,164},{0,108,163},{0,107,162},{0,105,160},{0,104,159},{0,103,158},{0,101,156},
-  {0,100,155},{0,99,154},{0,97,152},{0,96,151},{0,95,150},{0,93,148},{0,92,147},{0,91,146},
-  {0,89,144},{0,88,143},{0,87,142},{0,86,141},{0,84,139},{0,83,138},{0,82,137},{0,81,135},
-  {0,80,134},{0,78,133},{0,77,131},{0,76,130},{0,75,129},{0,74,127},{0,73,126},{0,71,125},
-  {0,70,123},{0,69,122},{0,68,121},{0,67,120},{0,66,118},{0,65,117},{0,64,116},{0,63,114},
-  {0,62,113},{0,60,112},{0,59,110},{0,58,109},{0,57,108},{0,56,106},{0,55,105},{0,54,104},
-  {0,53,102},{0,52,101},{0,51,100},{0,50,99},{0,49,97},{0,48,96},{0,47,95},{0,46,93},
-  {0,45,92},{0,45,91},{0,44,89},{0,43,88},{0,42,87},{0,42,87},{0,42,87},{0,42,87},
-  {0,42,87},{0,42,87},{0,42,87},{0,42,87},{0,42,87},{0,42,87},{0,42,87},{0,42,87},
+  {8,24,64},{10,24,64},{12,25,63},{13,25,63},{15,26,62},{17,26,62},{19,26,61},{20,27,61},
+  {22,27,60},{24,27,60},{26,28,59},{27,28,59},{29,29,59},{31,29,58},{33,29,58},{34,30,57},
+  {36,30,57},{38,30,56},{40,31,56},{41,31,55},{43,32,55},{45,32,54},{47,32,54},{49,33,54},
+  {50,33,53},{52,33,53},{54,34,52},{56,34,52},{57,35,51},{59,35,51},{61,35,50},{63,36,50},
+  {64,36,49},{66,36,49},{68,37,48},{70,37,48},{71,38,48},{73,38,47},{75,38,47},{77,39,46},
+  {78,39,46},{80,39,45},{82,40,45},{84,40,44},{85,41,44},{87,41,43},{89,41,43},{91,42,43},
+  {93,42,42},{94,43,42},{96,43,41},{98,43,41},{100,44,40},{101,44,40},{103,44,39},{105,45,39},
+  {107,45,38},{108,46,38},{110,46,38},{112,46,37},{114,47,37},{115,47,36},{117,47,36},{119,48,35},
+  {121,48,35},{122,49,34},{124,49,34},{126,49,33},{128,50,33},{130,50,33},{131,50,32},{133,51,32},
+  {135,51,31},{137,52,31},{138,52,30},{140,52,30},{142,53,29},{144,53,29},{145,53,28},{147,54,28},
+  {149,54,27},{151,55,27},{152,55,27},{154,55,26},{156,56,26},{158,56,25},{159,56,25},{161,57,24},
+  {163,57,24},{165,58,23},{167,58,23},{168,58,22},{170,59,22},{172,59,22},{174,60,21},{175,60,21},
+  {177,60,20},{179,61,20},{181,61,19},{182,61,19},{184,62,18},{186,62,18},{188,63,17},{189,63,17},
+  {191,63,17},{193,64,16},{195,64,16},{196,64,15},{198,65,15},{200,65,14},{202,66,14},{203,66,13},
+  {205,66,13},{207,67,12},{209,67,12},{211,67,12},{212,68,11},{214,68,11},{216,69,10},{218,69,10},
+  {219,69,9},{221,70,9},{223,70,8},{225,70,8},{226,71,7},{228,71,7},{230,72,7},{232,72,6},
+  {233,72,6},{235,73,5},{237,73,5},{239,74,4},{240,74,4},{242,74,3},{244,75,3},{246,75,2},
+  {248,75,2},{249,76,1},{251,76,1},{253,77,1},{255,77,0},{255,78,1},{255,79,2},{255,81,4},
+  {255,82,5},{255,83,6},{255,85,8},{255,86,9},{255,87,10},{255,89,12},{255,90,13},{255,92,14},
+  {255,93,16},{255,94,17},{255,96,18},{255,97,20},{255,98,21},{255,100,22},{255,101,24},{255,102,25},
+  {255,104,27},{255,105,28},{255,106,29},{255,108,31},{255,109,32},{255,110,33},{255,112,35},{255,113,36},
+  {255,114,37},{255,116,39},{255,117,40},{255,119,41},{255,120,43},{255,121,44},{255,123,45},{255,124,47},
+  {255,125,48},{255,127,49},{255,128,51},{255,129,52},{255,131,53},{255,132,55},{255,133,56},{255,135,57},
+  {255,136,59},{255,137,60},{255,139,61},{255,140,63},{255,141,64},{255,143,65},{255,144,67},{255,146,68},
+  {255,147,69},{255,148,71},{255,150,72},{255,151,73},{255,152,75},{255,154,76},{255,155,78},{255,156,79},
+  {255,158,80},{255,159,82},{255,160,83},{255,161,84},{255,163,86},{255,164,87},{255,166,88},{255,167,90},
+  {255,169,91},{255,170,92},{255,171,94},{255,173,95},{255,174,96},{255,175,98},{255,177,99},{255,178,100},
+  {255,179,102},{255,181,103},{255,182,104},{255,183,106},{255,185,107},{255,186,108},{255,187,110},{255,189,111},
+  {255,190,112},{255,191,114},{255,193,115},{255,194,116},{255,196,118},{255,197,119},{255,198,120},{255,200,122},
+  {255,201,123},{255,202,124},{255,204,126},{255,205,127},{255,206,129},{255,208,130},{255,209,131},{255,210,133},
+  {255,212,134},{255,213,135},{255,214,137},{255,216,138},{255,217,139},{255,218,141},{255,220,142},{255,221,143},
+  {255,223,145},{255,224,146},{255,225,147},{255,227,149},{255,228,150},{255,229,151},{255,231,153},{255,232,154},
 };
 
-static float speedParam   = 2.0f;
-static float sizeParam    = 5.0f;
-static float rippleParam  = 5.0f;
-static float densityParam = 3.0f;
-
-static constexpr float CELLGRID_SPEED_STEP   = 0.05f;
-static constexpr float CELLGRID_SIZE_STEP    = 0.1f;
-static constexpr float CELLGRID_RIPPLE_STEP  = 0.05f;
-static constexpr float CELLGRID_DENSITY_STEP = 0.05f;
-
-static constexpr float CELLGRID_SPEED_MIN    = 0.0f;
-static constexpr float CELLGRID_SPEED_MAX    = 2.0f;
-static constexpr float CELLGRID_SIZE_MIN     = 3.0f;
-static constexpr float CELLGRID_SIZE_MAX     = 6.0f;
-static constexpr float CELLGRID_RIPPLE_MIN   = 0.0f;
-static constexpr float CELLGRID_RIPPLE_MAX   = 5.0f;
-static constexpr float CELLGRID_DENSITY_MIN  = 0.5f;
-static constexpr float CELLGRID_DENSITY_MAX  = 3.0f;
-
-static constexpr float CELLGRID_T_WRAP = 4.0f * PI;
-
-static float t = 0.0f;
-
 void setup() {
-  PFMath::buildSinLUT();
-  PFTables::init();
+    PFMath::buildSinLUT();
 }
 
 void update(float dt, const InputFrame& input) {
-  speedParam  += input.knobDeltas[0] * CELLGRID_SPEED_STEP;
-  if (speedParam < CELLGRID_SPEED_MIN) speedParam = CELLGRID_SPEED_MIN;
-  if (speedParam > CELLGRID_SPEED_MAX) speedParam = CELLGRID_SPEED_MAX;
+    g_buildings += input.knobDeltas[0] * 0.05f;
+    g_buildings = fmaxf(4.0f, fminf(16.0f, g_buildings));
 
-  sizeParam   += input.knobDeltas[1] * CELLGRID_SIZE_STEP;
-  if (sizeParam < CELLGRID_SIZE_MIN) sizeParam = CELLGRID_SIZE_MIN;
-  if (sizeParam > CELLGRID_SIZE_MAX) sizeParam = CELLGRID_SIZE_MAX;
+    g_speed += input.knobDeltas[1] * 0.1f;
+    g_speed = fmaxf(0.1f, fminf(5.0f, g_speed));
 
-  rippleParam += input.knobDeltas[2] * CELLGRID_RIPPLE_STEP;
-  if (rippleParam < CELLGRID_RIPPLE_MIN) rippleParam = CELLGRID_RIPPLE_MIN;
-  if (rippleParam > CELLGRID_RIPPLE_MAX) rippleParam = CELLGRID_RIPPLE_MAX;
+    g_rainDensity += input.knobDeltas[2] * 0.05f;
+    g_rainDensity = fmaxf(0.0f, fminf(1.0f, g_rainDensity));
 
-  densityParam += input.knobDeltas[3] * CELLGRID_DENSITY_STEP;
-  if (densityParam < CELLGRID_DENSITY_MIN) densityParam = CELLGRID_DENSITY_MIN;
-  if (densityParam > CELLGRID_DENSITY_MAX) densityParam = CELLGRID_DENSITY_MAX;
+    g_glow += input.knobDeltas[3] * 0.05f;
+    g_glow = fmaxf(0.5f, fminf(3.0f, g_glow));
 
-  t += dt * speedParam;
-  if (t > CELLGRID_T_WRAP) t -= CELLGRID_T_WRAP;
+    g_timeAcc += dt * g_speed;
+    const float maxPeriod = 10.0f * TWO_PI;
+    if (g_timeAcc > maxPeriod) {
+        g_timeAcc -= maxPeriod;
+    }
 }
 
 void draw() {
-  const float t_local = t;
-  const float ripple = rippleParam;
-  const float cellSpacing = sizeParam * 2.5f;
-  const float edgeWidth = densityParam * 2.5f;
-  const float edgeWidthInv = 1.0f / edgeWidth;
-  const float halfSpacing = cellSpacing * 0.5f;
-  const int total = PANEL_RES_W * PANEL_RES_H;
+    const int w = PANEL_RES_W;
+    const int h = PANEL_RES_H;
+    const float hInv = 1.0f / (float)h;
 
-  for (int i = 0; i < total; i++) {
-    // pixel distance from fixed center
-    float r = PFTables::rT[i] * (float)PANEL_RES_H;
-    float th = PFTables::thetaT[i];
+    const float t = g_timeAcc;
+    const float searchlightPhase = PFMath::fastSin(t * 0.8f) * 4.0f;
+    const float farBuildingWidth = 128.0f / g_buildings;
+    const int nearWidth = (int)(100.0f / g_buildings);
+    const int nearWidthHalf = nearWidth / 2;
+    const float invGlow = 1.0f / g_glow;
+    const float rainThreshold = g_rainDensity * 0.15f;
+    const bool beaconOn = ((int)(t * 4.0f) % 2) == 0;
 
-    float rippleOffset = ripple * 4.0f * PFMath::fastSin(r * 0.08f - t_local * 1.5f);
-    float rr = r + rippleOffset;
+    for (int y = 0; y < h; y++) {
+        const float normY = y * hInv;
+        const int yMod4 = y % 4;
+        const int yMod5 = y % 5;
+        const int rainY = (int)((y + t * 40.0f) * 0.25f);
 
-    float rx = rr * PFMath::fastCos(th);
-    float ry = rr * PFMath::fastSin(th);
+        for (int x = 0; x < w; x++) {
+            float val = 0.05f;
 
-    // cell center snapped to grid
-    float cx0 = floorf(rx / cellSpacing) * cellSpacing + halfSpacing;
-    float cy0 = floorf(ry / cellSpacing) * cellSpacing + halfSpacing;
+            // 1. Sky / Searchlight layer
+            if (normY < 0.7f) {
+                float lightBeam = PFMath::fastSin((x * 0.04f) + searchlightPhase - normY * 3.0f);
+                if (lightBeam > 0.82f) {
+                    val += (lightBeam - 0.82f) * 2.0f;
+                }
+            }
 
-    // search 3x3 neighborhood for minimum distance (squared)
-    float minDistSq = 1e12f;
-    for (int dy = -1; dy <= 1; dy++) {
-      for (int dx = -1; dx <= 1; dx++) {
-        float nx = cx0 + dx * cellSpacing;
-        float ny = cy0 + dy * cellSpacing;
-        float ddx = rx - nx;
-        float ddy = ry - ny;
-        float dsq = ddx*ddx + ddy*ddy;
-        if (dsq < minDistSq) minDistSq = dsq;
-      }
+            // 2. Far Skyline (Layer 1 - Slow Scroll)
+            const int farX = (int)(x + t * 4.0f);
+            const int farBuildingId = (int)(farX / farBuildingWidth);
+            const float farHeight = 0.3f + (PFMath::fastSin(farBuildingId * 17.31f) * 0.5f + 0.5f) * 0.35f;
+
+            if (normY > (1.0f - farHeight)) {
+                val = 0.25f;
+                if ((farX % 3 == 0) && (yMod4 == 0) && normY < 0.9f) {
+                    float winFlicker = (PFMath::fastSin(farBuildingId + t * 2.0f) > 0.1f) ? 0.6f : 0.2f;
+                    val = winFlicker;
+                }
+            }
+
+            // 3. Near Cityscape (Layer 2 - Fast Scroll with Antennas & Signage)
+            const int nearX = (int)(x + t * 12.0f);
+            const int nearBuildingId = nearWidth > 0 ? (nearX / nearWidth) : 0;
+            const float nearHeight = 0.2f + (PFMath::fastSin(nearBuildingId * 91.7f) * 0.5f + 0.5f) * 0.5f;
+            const int relX = nearWidth > 0 ? (nearX % nearWidth) : 0;
+
+            if (normY > (1.0f - nearHeight)) {
+                if (relX == 0 || relX == nearWidth - 1) {
+                    val = 0.1f;
+                } else {
+                    val = 0.4f;
+                    int winX = relX % 4;
+                    int winY = yMod5;
+                    if (winX > 1 && winY > 1) {
+                        float signGlow = PFMath::fastSin(nearBuildingId * 3.0f + t * 5.0f) * 0.5f + 0.5f;
+                        val = 0.7f + signGlow * 0.3f;
+                    }
+                }
+            } else if (normY > (1.0f - nearHeight - 0.1f) && relX == nearWidthHalf) {
+                val = beaconOn ? 0.9f : 0.3f;
+            }
+
+            // 4. Downpouring Pixel Rain overlay
+            if (g_rainDensity > 0.05f) {
+                float rainSeed = PFNoise::cellHash(x, rainY);
+                if (rainSeed < rainThreshold) {
+                    val += 0.4f;
+                }
+            }
+
+            val = fmaxf(0.0f, fminf(1.0f, val));
+            val = PFMath::fastPow(val, invGlow);
+
+            int li = (int)(val * 255.0f + 0.5f);
+            if (li < 0) li = 0;
+            if (li > 255) li = 255;
+
+            PFCanvas::setPixel(x, y, RAMP_LUT[li][0], RAMP_LUT[li][1], RAMP_LUT[li][2]);
+        }
     }
 
-    float minDist = sqrtf(minDistSq);
-    float val = (minDist < edgeWidth) ? 1.0f - (minDist * edgeWidthInv) * 0.9f : 0.05f;
-
-    if (val < 0.0f) val = 0.0f;
-    if (val > 1.0f) val = 1.0f;
-
-    int li = (int)(val * 255.0f + 0.5f);
-    int y = i / PANEL_RES_W;
-    int x = i - y * PANEL_RES_W;
-    PFCanvas::setPixel(x, y, RAMP_LUT[li][0], RAMP_LUT[li][1], RAMP_LUT[li][2]);
-  }
-
-  PFCanvas::present();
+    PFCanvas::present();
 }
 
-} // namespace RippleCellGrid
+} // namespace CyberpunkCity

--- a/firmware/patternflow/custom3.h
+++ b/firmware/patternflow/custom3.h
@@ -7,39 +7,49 @@
 #include "src/core_canvas.h"
 #include "src/core_math.h"
 
-namespace RippleGrid {
+namespace CrystalCascade {
 
-const char* NAME = "Ripple Grid";
-const char* const KNOB_LABELS[4] = {"Speed", "Size", "Ripple", "Mirror"};
+const char* NAME = "Crystal Cascade";
+const char* const KNOB_LABELS[4] = {"CellSize", "DownSpeed", "PhaseWarp", "EdgeGlow"};
+
+constexpr int FRAME_W = 64;
+constexpr int FRAME_H = 128;
+
+static float knobCellSize = 4.0f;
+static float knobDownSpeed = 0.96f;
+static float knobPhaseWarp = 4.096f;
+static float knobEdgeGlow = 2.0f;
+
+static float patternTime = 0.0f;
 
 static const uint8_t RAMP_LUT[256][3] = {
-  {0,0,0},{0,0,0},{0,0,0},{0,0,0},{0,0,0},{0,0,0},{0,0,0},{0,0,0},
-  {0,0,0},{0,0,0},{0,0,0},{0,0,0},{0,0,0},{0,0,0},{0,0,0},{0,0,0},
-  {0,0,0},{0,0,0},{1,1,1},{4,4,4},{7,7,8},{10,10,11},{12,13,14},{15,16,17},
-  {17,18,20},{19,21,23},{21,23,26},{23,26,30},{24,28,33},{26,30,36},{27,32,39},{28,34,42},
-  {29,36,45},{30,38,48},{31,40,51},{31,41,55},{32,43,58},{32,44,61},{32,46,64},{32,47,67},
-  {32,48,70},{31,49,73},{31,50,77},{30,51,80},{29,52,83},{28,53,86},{27,54,89},{26,54,92},
-  {24,55,95},{23,55,99},{21,56,102},{19,56,105},{17,56,108},{15,56,111},{12,56,114},{10,56,117},
-  {7,56,120},{4,56,124},{1,55,127},{0,56,128},{0,57,129},{0,57,130},{0,58,130},{0,59,131},
-  {0,60,132},{0,61,132},{0,62,133},{0,63,134},{0,64,134},{0,65,135},{0,66,136},{0,67,136},
-  {0,68,137},{0,69,137},{0,70,138},{0,71,139},{0,72,139},{0,74,140},{0,75,141},{0,76,141},
-  {0,77,142},{0,78,143},{0,79,143},{0,80,144},{0,81,145},{0,82,145},{0,83,146},{0,84,147},
-  {0,86,147},{0,87,148},{0,88,149},{0,89,149},{0,90,150},{0,91,150},{0,93,151},{0,94,152},
-  {0,95,152},{0,96,153},{0,97,154},{0,98,154},{0,100,155},{0,101,156},{0,102,156},{0,103,157},
-  {0,105,158},{0,106,158},{0,107,159},{0,108,160},{0,110,160},{0,111,161},{0,112,162},{0,113,162},
-  {0,115,163},{0,116,163},{0,117,164},{0,119,165},{0,120,165},{0,121,166},{0,123,167},{0,124,167},
-  {0,125,168},{0,127,169},{0,128,169},{0,129,170},{0,131,171},{0,132,171},{0,133,172},{0,135,173},
-  {0,136,173},{0,138,174},{0,139,174},{0,140,175},{0,142,176},{0,143,176},{0,145,177},{0,146,178},
-  {0,148,178},{0,149,179},{3,150,180},{5,152,181},{8,153,182},{10,154,183},{13,155,184},{15,157,185},
-  {18,158,186},{20,159,187},{23,161,188},{26,162,189},{28,163,190},{31,165,191},{34,166,192},{37,167,193},
-  {39,168,194},{42,170,195},{45,171,196},{48,172,198},{51,174,199},{54,175,200},{57,177,201},{60,178,202},
-  {63,179,203},{66,181,204},{69,182,205},{72,183,206},{75,185,207},{79,186,208},{82,187,209},{85,189,210},
-  {88,190,211},{92,192,212},{95,193,213},{98,194,214},{102,196,215},{105,197,216},{108,199,217},{112,200,218},
-  {115,202,219},{119,203,220},{122,205,221},{126,206,222},{129,207,223},{133,209,224},{137,210,225},{140,212,226},
-  {144,213,227},{148,215,228},{152,216,229},{155,218,230},{159,219,231},{163,221,232},{167,222,233},{171,224,234},
-  {175,225,235},{179,227,236},{183,228,237},{187,230,238},{191,231,239},{195,233,241},{199,234,242},{203,236,243},
-  {207,237,244},{211,239,245},{215,241,246},{220,242,247},{224,244,248},{228,245,249},{232,247,250},{237,248,251},
-  {241,250,252},{246,252,253},{250,253,254},{254,255,255},{255,255,255},{255,255,255},{255,255,255},{255,255,255},
+  {0,0,0},{0,0,3},{0,1,5},{0,1,8},{0,2,11},{0,2,14},{0,3,16},{0,3,19},
+  {0,4,22},{0,4,25},{0,5,27},{0,5,30},{0,5,33},{0,6,36},{0,6,38},{0,7,41},
+  {0,7,44},{0,8,47},{0,8,49},{0,9,52},{0,9,55},{0,10,58},{0,10,60},{0,10,63},
+  {0,11,66},{0,11,69},{0,12,71},{0,12,74},{0,13,77},{0,13,80},{0,14,82},{0,14,85},
+  {0,14,88},{0,15,91},{0,15,93},{0,16,96},{0,16,99},{0,17,102},{0,17,104},{0,18,107},
+  {0,18,110},{0,19,113},{0,19,115},{0,19,118},{0,20,121},{0,20,124},{0,21,126},{0,21,129},
+  {0,22,132},{0,22,135},{0,23,137},{0,23,140},{0,24,143},{0,24,146},{0,24,148},{0,25,151},
+  {0,25,154},{0,26,157},{0,26,159},{0,27,162},{0,27,165},{0,28,168},{0,28,170},{0,29,173},
+  {0,29,176},{0,29,179},{0,30,181},{0,30,184},{0,31,187},{0,31,190},{0,32,192},{0,32,195},
+  {0,33,198},{0,33,201},{0,33,203},{0,34,206},{0,34,209},{0,35,212},{0,35,214},{0,36,217},
+  {0,36,220},{0,37,223},{0,37,225},{0,38,228},{0,38,231},{0,38,234},{0,39,236},{0,39,239},
+  {0,40,242},{0,40,245},{0,41,247},{0,41,250},{0,42,253},{1,42,255},{3,44,253},{6,46,251},
+  {9,48,249},{12,49,247},{15,51,246},{17,53,244},{20,55,242},{23,57,240},{26,58,238},{29,60,237},
+  {32,62,235},{34,64,233},{37,66,231},{40,67,229},{43,69,228},{46,71,226},{49,73,224},{51,74,222},
+  {54,76,220},{57,78,219},{60,80,217},{63,82,215},{65,83,213},{68,85,211},{71,87,210},{74,89,208},
+  {77,90,206},{80,92,204},{82,94,202},{85,96,201},{88,98,199},{91,99,197},{94,101,195},{97,103,193},
+  {99,105,191},{102,107,190},{105,108,188},{108,110,186},{111,112,184},{114,114,182},{116,115,181},{119,117,179},
+  {122,119,177},{125,121,175},{128,123,173},{130,124,172},{133,126,170},{136,128,168},{139,130,166},{142,131,164},
+  {145,133,163},{147,135,161},{150,137,159},{153,139,157},{156,140,155},{159,142,154},{162,144,152},{164,146,150},
+  {167,148,148},{170,149,146},{173,151,145},{176,153,143},{178,155,141},{181,156,139},{184,158,137},{187,160,135},
+  {190,162,134},{193,164,132},{195,165,130},{198,167,128},{201,169,126},{204,171,125},{207,173,123},{210,174,121},
+  {212,176,119},{215,178,117},{218,180,116},{221,181,114},{224,183,112},{226,185,110},{229,187,108},{232,189,107},
+  {235,190,105},{238,192,103},{241,194,101},{243,196,99},{246,197,98},{249,199,96},{252,201,94},{255,203,92},
+  {255,210,115},{255,219,141},{255,227,166},{255,235,192},{255,243,218},{255,251,243},{255,255,255},{255,255,255},
+  {255,255,255},{255,255,255},{255,255,255},{255,255,255},{255,255,255},{255,255,255},{255,255,255},{255,255,255},
+  {255,255,255},{255,255,255},{255,255,255},{255,255,255},{255,255,255},{255,255,255},{255,255,255},{255,255,255},
+  {255,255,255},{255,255,255},{255,255,255},{255,255,255},{255,255,255},{255,255,255},{255,255,255},{255,255,255},
   {255,255,255},{255,255,255},{255,255,255},{255,255,255},{255,255,255},{255,255,255},{255,255,255},{255,255,255},
   {255,255,255},{255,255,255},{255,255,255},{255,255,255},{255,255,255},{255,255,255},{255,255,255},{255,255,255},
   {255,255,255},{255,255,255},{255,255,255},{255,255,255},{255,255,255},{255,255,255},{255,255,255},{255,255,255},
@@ -47,86 +57,76 @@ static const uint8_t RAMP_LUT[256][3] = {
   {255,255,255},{255,255,255},{255,255,255},{255,255,255},{255,255,255},{255,255,255},{255,255,255},{255,255,255},
 };
 
-static float speedParam   = 8.0f;
-static float sizeParam    = 2.0f;
-static float rippleParam  = 0.731f;
-static float mirrorParam  = 1.0f;
-
-static constexpr float RIPPLEGRID_SPEED_STEP   = 0.05f;
-static constexpr float RIPPLEGRID_SIZE_STEP    = 0.1f;
-static constexpr float RIPPLEGRID_RIPPLE_STEP  = 0.05f;
-static constexpr float RIPPLEGRID_MIRROR_STEP  = 0.05f;
-
-static constexpr float RIPPLEGRID_SPEED_MIN    = 0.1f;
-static constexpr float RIPPLEGRID_SPEED_MAX    = 8.0f;
-static constexpr float RIPPLEGRID_SIZE_MIN     = 2.0f;
-static constexpr float RIPPLEGRID_SIZE_MAX     = 6.0f;
-static constexpr float RIPPLEGRID_RIPPLE_MIN   = 0.0f;
-static constexpr float RIPPLEGRID_RIPPLE_MAX   = 10.0f;
-static constexpr float RIPPLEGRID_MIRROR_MIN   = 1.0f;
-static constexpr float RIPPLEGRID_MIRROR_MAX   = 4.0f;
-
-static constexpr float RIPPLEGRID_T_WRAP = 4.0f * PI;
-
-static float t = 0.0f;
-
 void setup() {
   PFMath::buildSinLUT();
+  patternTime = 0.0f;
 }
 
 void update(float dt, const InputFrame& input) {
-  speedParam  += input.knobDeltas[0] * RIPPLEGRID_SPEED_STEP;
-  if (speedParam < RIPPLEGRID_SPEED_MIN) speedParam = RIPPLEGRID_SPEED_MIN;
-  if (speedParam > RIPPLEGRID_SPEED_MAX) speedParam = RIPPLEGRID_SPEED_MAX;
+  knobCellSize += input.knobDeltas[0] * 0.05f;
+  knobCellSize = fminf(16.0f, fmaxf(4.0f, knobCellSize));
 
-  sizeParam   += input.knobDeltas[1] * RIPPLEGRID_SIZE_STEP;
-  if (sizeParam < RIPPLEGRID_SIZE_MIN) sizeParam = RIPPLEGRID_SIZE_MIN;
-  if (sizeParam > RIPPLEGRID_SIZE_MAX) sizeParam = RIPPLEGRID_SIZE_MAX;
+  knobDownSpeed += input.knobDeltas[1] * 0.1f;
+  knobDownSpeed = fminf(3.0f, fmaxf(0.2f, knobDownSpeed));
 
-  rippleParam += input.knobDeltas[2] * RIPPLEGRID_RIPPLE_STEP;
-  if (rippleParam < RIPPLEGRID_RIPPLE_MIN) rippleParam = RIPPLEGRID_RIPPLE_MIN;
-  if (rippleParam > RIPPLEGRID_RIPPLE_MAX) rippleParam = RIPPLEGRID_RIPPLE_MAX;
+  knobPhaseWarp += input.knobDeltas[2] * 0.05f;
+  knobPhaseWarp = fminf(6.0f, fmaxf(0.5f, knobPhaseWarp));
 
-  mirrorParam += input.knobDeltas[3] * RIPPLEGRID_MIRROR_STEP;
-  if (mirrorParam < RIPPLEGRID_MIRROR_MIN) mirrorParam = RIPPLEGRID_MIRROR_MIN;
-  if (mirrorParam > RIPPLEGRID_MIRROR_MAX) mirrorParam = RIPPLEGRID_MIRROR_MAX;
+  knobEdgeGlow += input.knobDeltas[3] * 0.05f;
+  knobEdgeGlow = fminf(2.0f, fmaxf(0.0f, knobEdgeGlow));
 
-  t += dt * speedParam;
-  if (t > RIPPLEGRID_T_WRAP) t -= RIPPLEGRID_T_WRAP;
+  patternTime += dt * knobDownSpeed;
+
+  constexpr float WRAP_PERIOD = TWO_PI * 1000.0f;
+  if (patternTime > WRAP_PERIOD) {
+    patternTime -= WRAP_PERIOD;
+  }
 }
 
 void draw() {
-  const float cx = PANEL_RES_W * 0.5f;
-  const float cy = PANEL_RES_H * 0.5f;
-  const float t_local = t;
-  const float ripple = rippleParam;
-  const float size = sizeParam;
-  const int mirror = (int)mirrorParam;
+  PFCanvas::setFrame(FRAME_W, FRAME_H);
 
-  for (int y = 0; y < PANEL_RES_H; y++) {
-    for (int x = 0; x < PANEL_RES_W; x++) {
-      float dx = (float)x - cx;
-      float dy = (float)y - cy;
+  const float size = knobCellSize;
+  const float warp = knobPhaseWarp;
+  const float glow = fmaxf(0.001f, knobEdgeGlow);
+  const float invSize = 1.0f / size;
+  const float halfSize = size * 0.5f;
+  const float invGlowDiv = 1.0f / (glow * 0.4f);
+  const float t20 = patternTime * 20.0f;
+  const float tWarp = patternTime * warp;
+  const float frameWf = (float)FRAME_W;
 
-      float dist = sqrtf(dx * dx + dy * dy);
-      float angle = PFMath::fastAtan2(dy, dx);
-      float rippleOffset = ripple * 4.0f * PFMath::fastSin(dist * 0.08f - t_local * 1.5f);
+  for (int y = 0; y < FRAME_H; y++) {
+    const float yShift = (float)y + t20;
+    const int row = (int)floorf(yShift * invSize);
+    const int rowMod2 = row % 2;
+    const float rowOffset = (float)rowMod2 * halfSize;
+    const float cy = (float)row * size + halfSize;
+    const float dy = fabsf(yShift - cy);
+    const float rowPhase = (float)row * 0.5f + tWarp;
 
-      float rx = (dist + rippleOffset) * PFMath::fastCos(angle);
-      float ry = (dist + rippleOffset) * PFMath::fastSin(angle);
+    for (int x = 0; x < FRAME_W; x++) {
+      const int col = (int)floorf(((float)x + rowOffset) * invSize);
+      const float cx = (float)col * size + rowOffset + halfSize;
 
-      int mx = (int)fabsf(rx * (size * 0.1f));
-      int my = (int)fabsf(ry * (size * 0.1f));
+      float cxMod = fmodf(cx, frameWf);
+      if (cxMod < 0.0f) cxMod += frameWf;
 
-      float val = 0.0f;
-      if (((mx & my) % mirror) == 0) {
-        val = 1.0f - ((mx ^ my) % 8) / 8.0f;
-      }
+      const float dx = fabsf((float)x - cxMod);
+      const float edgeDist = fmaxf(dx, dy) / halfSize;
 
-      if (val < 0.0f) val = 0.0f;
-      if (val > 1.0f) val = 1.0f;
+      const float angle = (float)col * 0.7f + rowPhase;
+      const float phase = PFMath::fastSin(angle);
 
-      int li = (int)(val * 255.0f + 0.5f);
+      float v = expf(-fabsf(edgeDist - 0.8f) * invGlowDiv);
+      v *= (0.5f + 0.5f * phase);
+
+      v = fminf(1.0f, fmaxf(0.0f, v));
+
+      int li = (int)(v * 255.0f + 0.5f);
+      if (li < 0) li = 0;
+      if (li > 255) li = 255;
+
       PFCanvas::setPixel(x, y, RAMP_LUT[li][0], RAMP_LUT[li][1], RAMP_LUT[li][2]);
     }
   }
@@ -134,4 +134,4 @@ void draw() {
   PFCanvas::present();
 }
 
-} // namespace RippleGrid
+} // namespace CrystalCascade

--- a/firmware/patternflow/net_config.h
+++ b/firmware/patternflow/net_config.h
@@ -2,8 +2,9 @@
 // PatternFlow - Network feature configuration
 //
 // One place for everything Wi-Fi touches: the shared Wi-Fi connection
-// and the three features that ride on it — OTA (wireless flashing),
-// OSC (Ableton/Max sidechannel), and the audio-react WebSocket server.
+// and the features that ride on it — OTA (wireless flashing), OSC
+// (Ableton/Max sidechannel), the audio-react WebSocket server, and the
+// browser self-update page.
 //
 // Per-device secrets and toggles live in patternflow_secrets.h (gitignored).
 // That file is included FIRST below, so anything it #defines wins; the
@@ -73,6 +74,19 @@
 // upload from the command line instead (see firmware/README.md).
 #ifndef PF_OTA_PASSWORD
 #define PF_OTA_PASSWORD ""
+#endif
+
+// ── Browser self-update (drop a .bin onto patternflow.local/update) ──
+// The device serves an update page over plain LAN HTTP; dropping a firmware
+// .bin there flashes it via Update.h and reboots (issue #232). No TLS, no
+// certificates — the browser fetches the build over HTTPS, the device only
+// sees a same-origin LAN upload. The POST endpoint only accepts firmware
+// while the UPDATE screen is open on the device (hold K2 → NETWORK, turn
+// K4), so nobody on the Wi-Fi can reflash a device that is just sitting
+// there. Shares the audio-react HTTP server (port 80) when that is enabled;
+// otherwise runs its own. Uses PF_OTA_HOSTNAME for the .local name.
+#ifndef PF_WEBUPDATE_ENABLED
+#define PF_WEBUPDATE_ENABLED 1
 #endif
 
 // ── OSC (Ableton/Max sidechannel) ────────────────────────────

--- a/firmware/patternflow/net_config.h
+++ b/firmware/patternflow/net_config.h
@@ -88,6 +88,17 @@
 #ifndef PF_WEBUPDATE_ENABLED
 #define PF_WEBUPDATE_ENABLED 1
 #endif
+// With 1 (the default) /update accepts firmware at any time — drop a .bin
+// whenever, no trip to the device. The tradeoff, stated plainly: anyone on
+// the same Wi-Fi can flash the device from a phone browser. That is the
+// same exposure ArduinoOTA's no-password default already has, and on a
+// home/studio network it is the right UX call. Set 0 on shared, office, or
+// exhibition Wi-Fi: uploads are then refused unless the UPDATE screen is
+// open on the device (hold K2 → NETWORK, turn K4) — a physical arming
+// switch only someone at the device can flip.
+#ifndef PF_WEBUPDATE_ALWAYS_ARMED
+#define PF_WEBUPDATE_ALWAYS_ARMED 1
+#endif
 
 // ── OSC (Ableton/Max sidechannel) ────────────────────────────
 // Sends knob/button/state out and accepts knob/pattern/content commands back.

--- a/firmware/patternflow/pattern_registry.h
+++ b/firmware/patternflow/pattern_registry.h
@@ -69,8 +69,8 @@ struct PatternEntry {
 // ── CUSTOM (your own — edit these) ──
 PatternEntry customPatterns[] = {
   PATTERN_ENTRY(FractalHoles),
-  PATTERN_ENTRY(RippleCellGrid),
-  PATTERN_ENTRY(RippleGrid),
+  PATTERN_ENTRY(CyberpunkCity),
+  PATTERN_ENTRY(CrystalCascade),
 };
 const int NUM_CUSTOM = sizeof(customPatterns) / sizeof(customPatterns[0]);
 

--- a/firmware/patternflow/patternflow.ino
+++ b/firmware/patternflow/patternflow.ino
@@ -738,11 +738,14 @@ void loop() {
     } else {
       frameDrawn = false;
     }
-  } else if (updateShowing) {
+  } else if (updateShowing || PatternflowWebUpdate::isRebootPending()) {
     // Same throttled-redraw scheme as the NETWORK screen. This only paints
     // the idle / done / failed states — during an actual flash the loop is
     // blocked inside handleClient(), and the progress callback installed in
-    // setup() draws instead.
+    // setup() draws instead. The isRebootPending() arm covers always-armed
+    // uploads that land while a pattern is running: the DONE / REBOOTING
+    // card shows for the ~1.2 s before restart instead of snapping back to
+    // the pattern.
     if (updateDirty || (now - updateDrawnAtMs) >= NET_INFO_REDRAW_MS) {
       drawUpdateScreen(-1);
       updateDrawnAtMs = now;

--- a/firmware/patternflow/patternflow.ino
+++ b/firmware/patternflow/patternflow.ino
@@ -8,6 +8,7 @@
 #include "src/core_osc.h"
 #include "src/core_ota.h"
 #include "src/core_audio_ws.h"
+#include "src/core_web_update.h"
 #include "pattern_registry.h"
 
 MatrixPanel_I2S_DMA *dma_display = nullptr;
@@ -60,12 +61,23 @@ uint32_t knobMapDrawnAtMs = 0;
 bool knobMapDirty = false;
 uint32_t knobMapActiveAtMs[4] = {0, 0, 0, 0};
 
+// UPDATE screen: entered from the NETWORK screen by turning K4. While it
+// shows, the /update endpoint is ARMED — that is the whole security model
+// (see core_web_update.h): flashing over the LAN requires someone at the
+// device first. K4 click exits (disarming), except mid-flash. The idle
+// timeout is long because the user is at their computer fetching a .bin.
+bool updateShowing = false;
+uint32_t updateIdleAtMs = 0;
+uint32_t updateDrawnAtMs = 0;
+bool updateDirty = false;
+
 const uint32_t MODE_HOLD_MS = 1000;
 const uint32_t BRIGHTNESS_IDLE_MS = 5000;
 const uint32_t OSC_INFO_IDLE_MS = 8000;
 const uint32_t NET_INFO_REDRAW_MS = 250;
 const uint32_t KNOB_MAP_IDLE_MS = 8000;
 const uint32_t KNOB_MAP_HILITE_MS = 600;
+const uint32_t UPDATE_IDLE_MS = 600000;  // 10 min — downloading a build takes a while
 const float CONTENT_NOTICE_SECONDS = 1.0f;
 
 // Logical knob N = front-panel KN = physical encoder N. The PCB routes ENCn
@@ -83,6 +95,10 @@ Button* logicalButton(int logicalIdx) {
     default: return &btn4;
   }
 }
+
+// Defined below with the other screens; declared here because setup()
+// installs it as the upload progress callback.
+void drawUpdateScreen(int uploadPct);
 
 void setup() {
   Serial.begin(115200);
@@ -110,6 +126,16 @@ void setup() {
   // Improv-Serial: lets the browser flasher set Wi-Fi over USB after a web
   // flash. Just listens on Serial; no Wi-Fi required to be up yet.
   PatternflowImprov::begin();
+
+  // Wireless-update progress is drawn from inside the upload handler: the
+  // whole multipart POST is consumed in one handleClient() call, so the
+  // main loop never runs while the image streams in. This callback keeps
+  // the panel honest during those seconds (same task — drawing is safe).
+  PatternflowWebUpdate::progressCallback = [](int pct) {
+    drawUpdateScreen(pct);
+    dma_display->flipDMABuffer();
+    updateIdleAtMs = millis();
+  };
 
   buildPatternList();   // presets first (pattern 1 = Origin), custom appended last
   for (int i = 0; i < NUM_PATTERNS; i++) {
@@ -211,10 +237,82 @@ void drawNetworkInfo() {
     drawCenteredText(ip.substring(cut).c_str(), 70, gray, 1);
   }
 
-  // Hints — turn to toggle, click (or hold) K2 to leave.
-  drawCenteredText("TURN K2/K3", 96, dim, 1);
-  drawCenteredText("OSC / AUD", 106, dim, 1);
+  // Hints — turn to toggle, K4 for the update screen, click (or hold)
+  // K2 to leave.
+  drawCenteredText("TURN K2/K3", 86, dim, 1);
+  drawCenteredText("OSC / AUD", 96, dim, 1);
+  if (PatternflowWebUpdate::isCompiledIn()) {
+    drawCenteredText("K4=UPDATE", 107, dim, 1);
+  }
   drawCenteredText("K2 = EXIT", 118, dim, 1);
+
+  dma_display->setRotation(0);
+}
+
+// UPDATE screen (NETWORK screen → turn K4). Drawn PORTRAIT like the other
+// info screens. Idle: shows where to drop the .bin — the .local name AND
+// the raw IP, because mDNS is unreliable on Android (issue #232). During
+// a flash this is redrawn by the progress callback (uploadPct >= 0), since
+// the main loop is blocked inside handleClient() for the whole upload;
+// pass -1 when drawing from the loop.
+void drawUpdateScreen(int uploadPct) {
+  dma_display->setRotation(1);
+  dma_display->fillScreen(0);
+
+  uint16_t white = dma_display->color565(255, 255, 255);
+  uint16_t blue  = dma_display->color565(120, 180, 255);
+  uint16_t gray  = dma_display->color565(140, 140, 140);
+  uint16_t green = dma_display->color565(80, 220, 130);
+  uint16_t red   = dma_display->color565(255, 80, 80);
+  uint16_t dim   = dma_display->color565(90, 90, 90);
+
+  int w = dma_display->width();   // 64 in portrait
+  int h = dma_display->height();  // 128 in portrait
+
+  drawCenteredText("UPDATE", 4, white, 1);
+
+  if (uploadPct >= 0 || PatternflowWebUpdate::isUploading()) {
+    int pct = (uploadPct >= 0) ? uploadPct
+                               : (int)PatternflowWebUpdate::progressPercent();
+    drawCenteredText("FLASHING", 26, blue, 1);
+    char buf[8];
+    snprintf(buf, sizeof(buf), "%d%%", pct);
+    drawCenteredText(buf, 46, white, 2);
+    int bx = 6, by = 72, bw = w - 12, bh = 8;
+    dma_display->drawRect(bx, by, bw, bh, gray);
+    int fill = ((bw - 4) * constrain(pct, 0, 100)) / 100;
+    if (fill > 0) dma_display->fillRect(bx + 2, by + 2, fill, bh - 4, green);
+    drawCenteredText("KEEP POWER", h - 28, dim, 1);
+    drawCenteredText("ON", h - 18, dim, 1);
+  } else if (PatternflowWebUpdate::isRebootPending()) {
+    drawCenteredText("DONE", 40, green, 1);
+    drawCenteredText("REBOOTING", 56, white, 1);
+  } else {
+    bool wifiUp = PatternflowWifi::isConnected();
+    if (PatternflowWebUpdate::hasError()) {
+      drawCenteredText("FAILED", 16, red, 1);  // details went to the browser
+    } else {
+      drawCenteredText(wifiUp ? "ARMED" : "NO WIFI", 16, wifiUp ? green : red, 1);
+    }
+    if (wifiUp) {
+      drawCenteredText("DROP .BIN:", 34, gray, 1);
+      drawCenteredText(PF_OTA_HOSTNAME, 48, blue, 1);
+      drawCenteredText(".local", 58, blue, 1);
+      drawCenteredText("/update", 68, blue, 1);
+      // Raw IP as the mDNS fallback, split like the NETWORK screen.
+      String ip = PatternflowWifi::ipString();
+      if (ip.length() <= 10) {
+        drawCenteredText(ip.c_str(), 84, gray, 1);
+      } else {
+        int cut = ip.indexOf('.', ip.indexOf('.') + 1) + 1;
+        drawCenteredText(ip.substring(0, cut).c_str(), 84, gray, 1);
+        drawCenteredText(ip.substring(cut).c_str(), 94, gray, 1);
+      }
+    } else {
+      drawCenteredText(PatternflowWifi::statusText(), 48, blue, 1);
+    }
+    drawCenteredText("K4 = EXIT", h - 10, dim, 1);
+  }
 
   dma_display->setRotation(0);
 }
@@ -387,6 +485,7 @@ void loop() {
     PatternflowOsc::begin();
     PatternflowOta::begin();
     PatternflowAudio::begin();
+    PatternflowWebUpdate::begin();
     Serial.println("[NET] services started");
   }
 
@@ -403,6 +502,11 @@ void loop() {
   // (single-threaded — no separate core-0 task). Cheap when idle.
   PatternflowAudio::handle();
 
+  // Browser self-update housekeeping: boot-valid marking and the deferred
+  // post-flash reboot. (Upload traffic itself arrives through the shared
+  // HTTP server serviced just above.)
+  PatternflowWebUpdate::handle();
+
   unsigned long now = millis();
   float dt = (now - lastMs) / 1000.0f;
   lastMs = now;
@@ -415,8 +519,9 @@ void loop() {
   bool k1Clicked = logicalButton(0)->clicked();
   bool k2Clicked = logicalButton(1)->clicked();
   bool k3Clicked = logicalButton(2)->clicked();
+  bool k4Clicked = logicalButton(3)->clicked();
 
-  if (!oscInfoShowing && !knobMapShowing && logicalButton(0)->longPressed(MODE_HOLD_MS)) {
+  if (!oscInfoShowing && !knobMapShowing && !updateShowing && logicalButton(0)->longPressed(MODE_HOLD_MS)) {
     brightnessAdjusting = !brightnessAdjusting;
     brightnessIdleAtMs = now;
     Serial.printf(">>> BRIGHTNESS MODE: %s (%u%%)\n",
@@ -461,7 +566,7 @@ void loop() {
 
   // K2 longpress → enter/exit the NETWORK status + toggle screen.
   // A K2 click while inside also exits, instantly (mirrors brightness mode).
-  if (!knobMapShowing && logicalButton(1)->longPressed(MODE_HOLD_MS)) {
+  if (!knobMapShowing && !updateShowing && logicalButton(1)->longPressed(MODE_HOLD_MS)) {
     oscInfoShowing = !oscInfoShowing;
     oscInfoIdleAtMs = now;
     netInfoDirty = true;
@@ -472,6 +577,17 @@ void loop() {
   }
 
   if (oscInfoShowing) {
+    // Turn K4 → hand off to the UPDATE screen, which arms the /update
+    // endpoint (see core_web_update.h — the arming IS the security model).
+    if (input.knobDeltas[3] != 0 && PatternflowWebUpdate::isCompiledIn()) {
+      oscInfoShowing = false;
+      updateShowing = true;
+      updateIdleAtMs = now;
+      updateDirty = true;
+      PatternflowWebUpdate::arm();
+      Serial.println(">>> UPDATE SCREEN: ON");
+    }
+
     // Toggles use knob ROTATION, not clicks — so holding K2 to exit can't
     // accidentally flip a setting. Turn right = ON, left = OFF.
     if (input.knobDeltas[1] != 0) {                  // K2 turn → OSC
@@ -508,7 +624,7 @@ void loop() {
   }
 
   // K3 longpress → enter/exit the KNOB MAP screen. A K3 click inside exits.
-  if (!oscInfoShowing && logicalButton(2)->longPressed(MODE_HOLD_MS)) {
+  if (!oscInfoShowing && !updateShowing && logicalButton(2)->longPressed(MODE_HOLD_MS)) {
     knobMapShowing = !knobMapShowing;
     knobMapIdleAtMs = now;
     knobMapDirty = true;
@@ -536,7 +652,32 @@ void loop() {
     }
   }
 
-  if (!oscInfoShowing && !knobMapShowing && logicalButton(3)->longPressed(MODE_HOLD_MS)) {
+  if (updateShowing) {
+    // Locked in while a flash is in flight or the reboot is pending — the
+    // device must not disarm (or navigate away) under an active upload.
+    bool busy = PatternflowWebUpdate::isUploading() ||
+                PatternflowWebUpdate::isRebootPending();
+    if (k4Clicked && !busy) {
+      updateShowing = false;
+      PatternflowWebUpdate::disarm();
+      Serial.println(">>> UPDATE SCREEN: OFF (click)");
+    }
+
+    // Swallow all knob input; any activity keeps the screen alive.
+    for (int i = 0; i < 4; i++) {
+      if (input.knobDeltas[i] != 0) updateIdleAtMs = now;
+      input.knobDeltas[i] = 0;
+      input.btnPressed[i] = false;
+    }
+
+    if (updateShowing && !busy && (now - updateIdleAtMs) > UPDATE_IDLE_MS) {
+      updateShowing = false;
+      PatternflowWebUpdate::disarm();
+      Serial.println(">>> UPDATE SCREEN: OFF (idle)");
+    }
+  }
+
+  if (!oscInfoShowing && !knobMapShowing && !updateShowing && logicalButton(3)->longPressed(MODE_HOLD_MS)) {
     if (currentMode == MODE_RUNNING) {
       currentMode = MODE_SELECTING;
       contentNoticeTimer = 0.0f;
@@ -594,6 +735,18 @@ void loop() {
       drawKnobMap();
       knobMapDrawnAtMs = now;
       knobMapDirty = false;
+    } else {
+      frameDrawn = false;
+    }
+  } else if (updateShowing) {
+    // Same throttled-redraw scheme as the NETWORK screen. This only paints
+    // the idle / done / failed states — during an actual flash the loop is
+    // blocked inside handleClient(), and the progress callback installed in
+    // setup() draws instead.
+    if (updateDirty || (now - updateDrawnAtMs) >= NET_INFO_REDRAW_MS) {
+      drawUpdateScreen(-1);
+      updateDrawnAtMs = now;
+      updateDirty = false;
     } else {
       frameDrawn = false;
     }

--- a/firmware/patternflow/patternflow.ino
+++ b/firmware/patternflow/patternflow.ino
@@ -177,6 +177,35 @@ void drawCenteredTextScrim(const char* text, int y, uint16_t color, int textSize
   dma_display->print(text);
 }
 
+// ── Panel palette + shared chrome for the info screens ──────────────
+// The on-device screens borrow the patternflow.work design system's motifs
+// at 64×128 scale: one LED-orange accent (#E8552E), hairline rules, and a
+// glowing-dot-plus-title header (the web's version tag). Green/red stay
+// reserved for live state (on/off, ok/error); orange is brand + progress.
+uint16_t pfLedC()   { return dma_display->color565(232, 85, 46); }
+uint16_t pfWhiteC() { return dma_display->color565(255, 255, 255); }
+uint16_t pfGrayC()  { return dma_display->color565(140, 140, 140); }
+uint16_t pfDimC()   { return dma_display->color565(90, 90, 90); }
+uint16_t pfRuleC()  { return dma_display->color565(60, 60, 60); }
+uint16_t pfGreenC() { return dma_display->color565(80, 220, 130); }
+uint16_t pfRedC()   { return dma_display->color565(255, 80, 80); }
+uint16_t pfBlueC()  { return dma_display->color565(120, 180, 255); }
+
+// LED dot + centered title + hairline rule at the top of a portrait info
+// screen (NETWORK / UPDATE). Content starts below y=15.
+void drawScreenHeader(const char* title) {
+  int16_t x1, y1;
+  uint16_t tw, th;
+  dma_display->setTextSize(1);
+  dma_display->getTextBounds(title, 0, 0, &x1, &y1, &tw, &th);
+  int x = (dma_display->width() - (int)(tw + 6)) / 2;
+  dma_display->fillRect(x, 7, 2, 2, pfLedC());
+  dma_display->setTextColor(pfWhiteC());
+  dma_display->setCursor(x + 6, 4);
+  dma_display->print(title);
+  dma_display->drawFastHLine(4, 15, dma_display->width() - 8, pfRuleC());
+}
+
 // Notices sit on the same tight scrim the SELECT overlay uses (text bounds
 // + 2px) instead of a full-width black band — less of the live pattern is
 // blotted out and every overlay text now shares one look.
@@ -184,11 +213,28 @@ void drawContentNotice() {
   drawCenteredTextScrim(currentContentName(), 30, dma_display->color565(255, 255, 255), 1);
 }
 
+// Label plus a thin LED-orange level bar on one shared scrim — the bar
+// makes the level readable at a glance mid-turn, without watching digits.
 void drawBrightnessNotice() {
   char buf[24];
   int pct = (int)((currentBrightness * 100 + 127) / 255);
   snprintf(buf, sizeof(buf), "BRIGHTNESS %d%%", pct);
-  drawCenteredTextScrim(buf, dma_display->height() - 10, dma_display->color565(255, 255, 255), 1);
+
+  int16_t x1, y1;
+  uint16_t w, h;
+  dma_display->setTextSize(1);
+  dma_display->getTextBounds(buf, 0, 0, &x1, &y1, &w, &h);
+  int x = (dma_display->width() - (int)w) / 2;
+  int y = dma_display->height() - 16;
+  dma_display->fillRect(x - 2, y - 2, w + 4, h + 9, 0);
+  dma_display->setTextColor(pfWhiteC());
+  dma_display->setCursor(x, y);
+  dma_display->print(buf);
+
+  int by = y + (int)h + 3;
+  dma_display->drawFastHLine(x, by, w, pfDimC());
+  int fw = ((int)w * pct) / 100;
+  if (fw > 0) dma_display->drawFastHLine(x, by, fw, pfLedC());
 }
 
 // NETWORK info + toggle screen (K2 longpress). Shows Wi-Fi / OSC / audio
@@ -201,50 +247,57 @@ void drawNetworkInfo() {
   dma_display->setRotation(1);
   dma_display->fillScreen(0);
 
-  uint16_t white = dma_display->color565(255, 255, 255);
-  uint16_t blue  = dma_display->color565(120, 180, 255);
-  uint16_t gray  = dma_display->color565(140, 140, 140);
-  uint16_t green = dma_display->color565(80, 220, 130);
-  uint16_t red   = dma_display->color565(255, 80, 80);
-  uint16_t dim   = dma_display->color565(90, 90, 90);
+  int w = dma_display->width();   // 64 in portrait
 
+  drawScreenHeader("NETWORK");
+
+  // Feature rows: status dot + name on the left, state right-aligned in
+  // the state's color — reads like the web console's tag pills.
+  struct FeatureRow { const char* name; bool compiled; bool on; };
+  const FeatureRow rows[2] = {
+    { "OSC", PatternflowOsc::isCompiledIn(),   PatternflowOsc::isRuntimeEnabled() },
+    { "AUD", PatternflowAudio::isCompiledIn(), PatternflowAudio::isRuntimeEnabled() },
+  };
   dma_display->setTextSize(1);
-  drawCenteredText("NETWORK", 4, white, 1);
-
-  // OSC / AUDIO state rows.
-  bool oscC = PatternflowOsc::isCompiledIn();
-  bool oscOn = oscC && PatternflowOsc::isRuntimeEnabled();
-  dma_display->setTextColor(white);  dma_display->setCursor(8, 20);  dma_display->print("OSC");
-  dma_display->setTextColor(oscC ? (oscOn ? green : red) : dim);
-  dma_display->setCursor(38, 20);    dma_display->print(oscC ? (oscOn ? "ON" : "OFF") : "N/A");
-
-  bool audC = PatternflowAudio::isCompiledIn();
-  bool audOn = audC && PatternflowAudio::isRuntimeEnabled();
-  dma_display->setTextColor(white);  dma_display->setCursor(8, 30);  dma_display->print("AUD");
-  dma_display->setTextColor(audC ? (audOn ? green : red) : dim);
-  dma_display->setCursor(38, 30);    dma_display->print(audC ? (audOn ? "ON" : "OFF") : "N/A");
+  for (int i = 0; i < 2; i++) {
+    int y = 22 + i * 11;
+    bool on = rows[i].compiled && rows[i].on;
+    uint16_t st = rows[i].compiled ? (on ? pfGreenC() : pfRedC()) : pfDimC();
+    dma_display->fillRect(8, y + 2, 2, 2, st);
+    dma_display->setTextColor(pfWhiteC());
+    dma_display->setCursor(14, y);
+    dma_display->print(rows[i].name);
+    const char* val = rows[i].compiled ? (on ? "ON" : "OFF") : "N/A";
+    int16_t x1, y1;
+    uint16_t tw, th;
+    dma_display->getTextBounds(val, 0, 0, &x1, &y1, &tw, &th);
+    dma_display->setTextColor(st);
+    dma_display->setCursor(w - 8 - (int)tw, y);
+    dma_display->print(val);
+  }
 
   // Wi-Fi status + IP. A full IPv4 (up to 15 chars) doesn't fit one
   // portrait line — split after the second octet's dot.
   bool wifiUp = PatternflowWifi::isConnected();
-  drawCenteredText(PatternflowWifi::statusText(), 48, wifiUp ? green : blue, 1);
+  drawCenteredText(PatternflowWifi::statusText(), 50, wifiUp ? pfGreenC() : pfBlueC(), 1);
   String ip = PatternflowWifi::ipString();
   if (ip.length() <= 10) {
-    drawCenteredText(ip.c_str(), 60, gray, 1);
+    drawCenteredText(ip.c_str(), 62, pfGrayC(), 1);
   } else {
     int cut = ip.indexOf('.', ip.indexOf('.') + 1) + 1;
-    drawCenteredText(ip.substring(0, cut).c_str(), 60, gray, 1);
-    drawCenteredText(ip.substring(cut).c_str(), 70, gray, 1);
+    drawCenteredText(ip.substring(0, cut).c_str(), 62, pfGrayC(), 1);
+    drawCenteredText(ip.substring(cut).c_str(), 72, pfGrayC(), 1);
   }
 
-  // Hints — turn to toggle, K4 for the update screen, click (or hold)
-  // K2 to leave.
-  drawCenteredText("TURN K2/K3", 86, dim, 1);
-  drawCenteredText("OSC / AUD", 96, dim, 1);
+  // Hints under a hairline rule — turn to toggle, K4 for the update
+  // screen, click (or hold) K2 to leave.
+  dma_display->drawFastHLine(4, 82, w - 8, pfRuleC());
+  drawCenteredText("TURN K2/K3", 87, pfDimC(), 1);
+  drawCenteredText("OSC / AUD", 97, pfDimC(), 1);
   if (PatternflowWebUpdate::isCompiledIn()) {
-    drawCenteredText("K4=UPDATE", 107, dim, 1);
+    drawCenteredText("K4=UPDATE", 107, pfDimC(), 1);
   }
-  drawCenteredText("K2 = EXIT", 118, dim, 1);
+  drawCenteredText("K2 = EXIT", 118, pfDimC(), 1);
 
   dma_display->setRotation(0);
 }
@@ -259,59 +312,56 @@ void drawUpdateScreen(int uploadPct) {
   dma_display->setRotation(1);
   dma_display->fillScreen(0);
 
-  uint16_t white = dma_display->color565(255, 255, 255);
-  uint16_t blue  = dma_display->color565(120, 180, 255);
-  uint16_t gray  = dma_display->color565(140, 140, 140);
-  uint16_t green = dma_display->color565(80, 220, 130);
-  uint16_t red   = dma_display->color565(255, 80, 80);
-  uint16_t dim   = dma_display->color565(90, 90, 90);
-
   int w = dma_display->width();   // 64 in portrait
   int h = dma_display->height();  // 128 in portrait
 
-  drawCenteredText("UPDATE", 4, white, 1);
+  drawScreenHeader("UPDATE");
 
   if (uploadPct >= 0 || PatternflowWebUpdate::isUploading()) {
     int pct = (uploadPct >= 0) ? uploadPct
                                : (int)PatternflowWebUpdate::progressPercent();
-    drawCenteredText("FLASHING", 26, blue, 1);
+    drawCenteredText("FLASHING", 26, pfGrayC(), 1);
     char buf[8];
     snprintf(buf, sizeof(buf), "%d%%", pct);
-    drawCenteredText(buf, 46, white, 2);
-    int bx = 6, by = 72, bw = w - 12, bh = 8;
-    dma_display->drawRect(bx, by, bw, bh, gray);
+    drawCenteredText(buf, 44, pfWhiteC(), 2);
+    // LED-orange fill on a hairline frame — same accent as the web page's
+    // progress bar.
+    int bx = 8, by = 70, bw = w - 16;
+    dma_display->drawRect(bx, by, bw, 7, pfRuleC());
     int fill = ((bw - 4) * constrain(pct, 0, 100)) / 100;
-    if (fill > 0) dma_display->fillRect(bx + 2, by + 2, fill, bh - 4, green);
-    drawCenteredText("KEEP POWER", h - 28, dim, 1);
-    drawCenteredText("ON", h - 18, dim, 1);
+    if (fill > 0) dma_display->fillRect(bx + 2, by + 2, fill, 3, pfLedC());
+    dma_display->drawFastHLine(4, h - 26, w - 8, pfRuleC());
+    drawCenteredText("KEEP POWER", h - 21, pfDimC(), 1);
+    drawCenteredText("ON", h - 11, pfDimC(), 1);
   } else if (PatternflowWebUpdate::isRebootPending()) {
-    drawCenteredText("DONE", 40, green, 1);
-    drawCenteredText("REBOOTING", 56, white, 1);
+    drawCenteredText("DONE", 46, pfGreenC(), 1);
+    drawCenteredText("REBOOTING", 60, pfWhiteC(), 1);
   } else {
     bool wifiUp = PatternflowWifi::isConnected();
     if (PatternflowWebUpdate::hasError()) {
-      drawCenteredText("FAILED", 16, red, 1);  // details went to the browser
+      drawCenteredText("FAILED", 21, pfRedC(), 1);  // details went to the browser
     } else {
-      drawCenteredText(wifiUp ? "ARMED" : "NO WIFI", 16, wifiUp ? green : red, 1);
+      drawCenteredText(wifiUp ? "READY" : "NO WIFI", 21, wifiUp ? pfGreenC() : pfRedC(), 1);
     }
     if (wifiUp) {
-      drawCenteredText("DROP .BIN:", 34, gray, 1);
-      drawCenteredText(PF_OTA_HOSTNAME, 48, blue, 1);
-      drawCenteredText(".local", 58, blue, 1);
-      drawCenteredText("/update", 68, blue, 1);
+      drawCenteredText("DROP .BIN:", 36, pfDimC(), 1);
+      drawCenteredText(PF_OTA_HOSTNAME, 48, pfWhiteC(), 1);
+      drawCenteredText(".local", 58, pfWhiteC(), 1);
+      drawCenteredText("/update", 68, pfWhiteC(), 1);
       // Raw IP as the mDNS fallback, split like the NETWORK screen.
       String ip = PatternflowWifi::ipString();
       if (ip.length() <= 10) {
-        drawCenteredText(ip.c_str(), 84, gray, 1);
+        drawCenteredText(ip.c_str(), 82, pfGrayC(), 1);
       } else {
         int cut = ip.indexOf('.', ip.indexOf('.') + 1) + 1;
-        drawCenteredText(ip.substring(0, cut).c_str(), 84, gray, 1);
-        drawCenteredText(ip.substring(cut).c_str(), 94, gray, 1);
+        drawCenteredText(ip.substring(0, cut).c_str(), 82, pfGrayC(), 1);
+        drawCenteredText(ip.substring(cut).c_str(), 92, pfGrayC(), 1);
       }
     } else {
-      drawCenteredText(PatternflowWifi::statusText(), 48, blue, 1);
+      drawCenteredText(PatternflowWifi::statusText(), 52, pfBlueC(), 1);
     }
-    drawCenteredText("K4 = EXIT", h - 10, dim, 1);
+    dma_display->drawFastHLine(4, h - 16, w - 8, pfRuleC());
+    drawCenteredText("K4 = EXIT", h - 11, pfDimC(), 1);
   }
 
   dma_display->setRotation(0);
@@ -325,16 +375,26 @@ void drawKnobMap() {
   dma_display->setRotation(1);
   dma_display->fillScreen(0);
 
-  uint16_t white = dma_display->color565(255, 255, 255);
-  uint16_t green = dma_display->color565(80, 220, 130);
-  uint16_t dim   = dma_display->color565(90, 90, 90);
-
   int w = dma_display->width();   // 64 in portrait
   int h = dma_display->height();  // 128 in portrait
 
-  drawCenteredText("KNOB MAP", (h / 2) - 10, white, 1);
-  drawCenteredText("TURN = SHOW", (h / 2) + 2, dim, 1);
-  drawCenteredText("K3 = EXIT", (h / 2) + 12, dim, 1);
+  // Center lockup: LED dot + title (the top header strip would collide
+  // with the corner circles, so the lockup sits mid-screen instead).
+  {
+    const char* title = "KNOB MAP";
+    int16_t x1, y1;
+    uint16_t tw, th;
+    dma_display->setTextSize(1);
+    dma_display->getTextBounds(title, 0, 0, &x1, &y1, &tw, &th);
+    int x = (w - (int)(tw + 6)) / 2;
+    int y = (h / 2) - 10;
+    dma_display->fillRect(x, y + 3, 2, 2, pfLedC());
+    dma_display->setTextColor(pfWhiteC());
+    dma_display->setCursor(x + 6, y);
+    dma_display->print(title);
+  }
+  drawCenteredText("TURN = SHOW", (h / 2) + 2, pfDimC(), 1);
+  drawCenteredText("K3 = EXIT", (h / 2) + 12, pfDimC(), 1);
 
   // Front-view corners: K1 top-right, K2 top-left, K3 bottom-right,
   // K4 bottom-left (indices are logical = physical after the identity map).
@@ -345,11 +405,12 @@ void drawKnobMap() {
   for (int i = 0; i < 4; i++) {
     bool active = knobMapActiveAtMs[i] != 0 &&
                   (now - knobMapActiveAtMs[i]) < KNOB_MAP_HILITE_MS;
-    uint16_t col = active ? green : white;
-    if (active) dma_display->fillCircle(cx[i], cy[i], 10, dma_display->color565(15, 55, 30));
-    dma_display->drawCircle(cx[i], cy[i], 10, col);
+    // Active knob lights LED-orange (brand accent) with a soft fill; the
+    // digit stays white for contrast either way.
+    if (active) dma_display->fillCircle(cx[i], cy[i], 10, dma_display->color565(74, 27, 15));
+    dma_display->drawCircle(cx[i], cy[i], 10, active ? pfLedC() : pfWhiteC());
     dma_display->setTextSize(1);
-    dma_display->setTextColor(col);
+    dma_display->setTextColor(pfWhiteC());
     dma_display->setCursor(cx[i] - 2, cy[i] - 3);
     dma_display->print((char)('1' + i));
   }
@@ -366,6 +427,22 @@ void drawSelectingMode() {
   char pageStr[16];
   snprintf(pageStr, sizeof(pageStr), "%d / %d", currentPatternIdx + 1, NUM_PATTERNS);
   drawCenteredTextScrim(pageStr, 10, dma_display->color565(190, 190, 190), 1);
+
+  // Position track under the page indicator: a hairline with an LED-orange
+  // marker at the highlighted pattern's place in the list — browsing with
+  // K4 reads as sliding along the line. Drawn on its own small scrim so it
+  // stays legible over the live preview.
+  {
+    int trackW = 40;
+    int tx = (dma_display->width() - trackW) / 2;
+    int ty = 23;
+    dma_display->fillRect(tx - 2, ty - 2, trackW + 4, 5, 0);
+    dma_display->drawFastHLine(tx, ty, trackW, pfDimC());
+    int mx = (NUM_PATTERNS > 1)
+             ? tx + ((trackW - 3) * currentPatternIdx) / (NUM_PATTERNS - 1)
+             : tx;
+    dma_display->fillRect(mx, ty - 1, 3, 3, pfLedC());
+  }
 
   const char* name = patterns[currentPatternIdx].name;
   int nameSize = strlen(name) > 8 ? 1 : 2;

--- a/firmware/patternflow/src/audio_index.h
+++ b/firmware/patternflow/src/audio_index.h
@@ -24,50 +24,56 @@ const char AUDIO_INDEX_HTML[] PROGMEM = R"HTML(<!doctype html>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Patternflow Audio</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 <style>
-  :root{--bg:#0a0a0a;--card:#0d0d0d;--fg:#e8e8e8;--mut:#666;--ln:#1f1f1f;--accent:#5fdb89;--bad:#ff5d5d;--bar:#3a3a3a;--bar-on:#7adb9a}
+  /* patternflow.work design system tokens (web/docs/patternflow-styleguide.html):
+     cream + ink + LED accent. --accent doubles as the alert color; healthy
+     states read as ink, meters and attention states as the LED orange. */
+  :root{--bg:#F4EFE6;--card:#ffffff;--card2:#EDE7DB;--fg:#141414;--mut:#6B655A;--faint:#A69F90;--ln:#D9D1C0;--accent:#E8552E;--bad:#E8552E;--bar:#E5DDC9;--bar-on:#E8552E}
   *{box-sizing:border-box}
-  body{margin:0;background:var(--bg);color:var(--fg);font:13px/1.5 ui-monospace,SFMono-Regular,Menlo,monospace;padding:20px;max-width:720px;margin:0 auto}
-  h1{font-size:11px;letter-spacing:.4em;opacity:.5;font-weight:normal;margin:0 0 4px}
+  body{margin:0;background:var(--bg);color:var(--fg);font:13px/1.5 'JetBrains Mono',ui-monospace,SFMono-Regular,Menlo,monospace;-webkit-font-smoothing:antialiased;padding:20px;max-width:720px;margin:0 auto}
+  h1{font-size:11px;letter-spacing:.4em;opacity:.6;font-weight:normal;margin:0 0 4px}
   .sub{font-size:11px;color:var(--mut);margin-bottom:20px}
-  #status{position:fixed;top:14px;right:14px;font-size:10px;padding:7px 11px;border:1px solid var(--ln);background:var(--card);letter-spacing:.15em;z-index:10}
-  .ok{color:var(--accent)} .bad{color:var(--bad)}
+  #status{position:fixed;top:14px;right:14px;font-size:10px;padding:7px 11px;border:1px solid var(--faint);background:var(--card);letter-spacing:.15em;z-index:10}
+  .ok{color:var(--fg);border-color:var(--fg)!important} .bad{color:var(--bad);border-color:var(--bad)!important}
 
   .section{margin:14px 0;padding:14px;border:1px solid var(--ln);background:var(--card)}
   .section h2{font-size:10px;letter-spacing:.25em;color:var(--mut);font-weight:normal;text-transform:uppercase;margin:0 0 12px}
 
   .sources{display:flex;gap:8px;flex-wrap:wrap}
-  .sources button{flex:1;min-width:120px;padding:10px;background:#1a1a1a;color:var(--fg);border:1px solid #333;font-family:inherit;font-size:11px;letter-spacing:.1em;text-transform:uppercase;cursor:pointer}
-  .sources button:hover{background:#222}
-  .sources button.active{background:var(--fg);color:var(--bg);border-color:var(--fg)}
+  .sources button{flex:1;min-width:120px;padding:10px;background:transparent;color:var(--mut);border:1px solid var(--ln);font-family:inherit;font-size:11px;letter-spacing:.1em;text-transform:uppercase;cursor:pointer;transition:color .15s ease,border-color .15s ease}
+  .sources button:hover{color:var(--fg);border-color:var(--fg)}
+  .sources button.active{background:var(--fg);color:var(--card);border-color:var(--fg)}
   .source-info{margin-top:10px;font-size:11px;color:var(--mut);min-height:18px}
 
   audio{width:100%;margin-top:10px}
 
-  .band{margin:12px 0;padding:12px;border:1px solid var(--ln);background:#0c0c0c}
+  .band{margin:12px 0;padding:12px;border:1px solid var(--ln);background:var(--bg)}
   .band-head{display:flex;justify-content:space-between;align-items:baseline;margin-bottom:10px;gap:10px;flex-wrap:wrap}
   .band-title{font-size:11px;letter-spacing:.2em;color:var(--fg);text-transform:uppercase}
   .band-target{font-size:11px;color:var(--mut)}
-  .band-target select{background:#1a1a1a;color:var(--fg);border:1px solid #333;padding:4px 8px;font-family:inherit;font-size:11px}
+  .band-target select{background:var(--card);color:var(--fg);border:1px solid var(--ln);padding:4px 8px;font-family:inherit;font-size:11px}
 
   .row{display:grid;grid-template-columns:60px 1fr 70px;align-items:center;gap:10px;margin:6px 0;font-size:11px}
   .row .lbl{color:var(--mut);letter-spacing:.1em;text-transform:uppercase}
   .row .v{text-align:right;color:var(--fg);font-variant-numeric:tabular-nums}
-  .row input[type=range]{width:100%;accent-color:#888}
+  .row input[type=range]{width:100%;accent-color:var(--fg)}
   .hz-presets{display:flex;gap:4px;flex-wrap:wrap;margin-top:4px;grid-column:1 / -1}
   .hz-presets button{padding:3px 8px;background:transparent;color:var(--mut);border:1px solid var(--ln);font-family:inherit;font-size:10px;letter-spacing:.05em;cursor:pointer}
-  .hz-presets button:hover{background:#1a1a1a;color:var(--fg)}
+  .hz-presets button:hover{color:var(--fg);border-color:var(--fg)}
 
   .meter{height:6px;background:var(--bar);overflow:hidden;margin-top:8px;position:relative}
   .meter-fill{height:100%;background:var(--bar-on);transition:width 0.05s linear;width:0%}
   .meter-out{height:3px;background:var(--bar);margin-top:2px;position:relative}
   .meter-out-fill{height:100%;background:var(--accent);width:0%;transition:width 0.05s linear}
 
-  .release{width:100%;padding:11px;background:#1a1a1a;color:var(--fg);border:1px solid #333;font-family:inherit;font-size:11px;letter-spacing:.15em;text-transform:uppercase;cursor:pointer;margin-top:16px}
-  .release:hover{background:#222}
+  .release{width:100%;padding:11px;background:transparent;color:var(--fg);border:1px solid var(--fg);font-family:inherit;font-size:11px;letter-spacing:.15em;text-transform:uppercase;cursor:pointer;margin-top:16px;transition:background .15s ease,color .15s ease}
+  .release:hover{background:var(--fg);color:var(--card)}
 
   .note{margin-top:18px;font-size:11px;color:var(--mut);line-height:1.6}
-  .note code{background:#1a1a1a;padding:1px 5px;color:var(--fg)}
+  .note code{background:var(--card2);padding:1px 5px;color:var(--fg)}
 </style></head>
 <body>
 <h1>PATTERNFLOW · AUDIO</h1>

--- a/firmware/patternflow/src/audio_index.h
+++ b/firmware/patternflow/src/audio_index.h
@@ -71,7 +71,7 @@ const char AUDIO_INDEX_HTML[] PROGMEM = R"HTML(<!doctype html>
 </style></head>
 <body>
 <h1>PATTERNFLOW · AUDIO</h1>
-<div class="sub">Stream music into the device. Map four FFT bands onto the four knobs.</div>
+<div class="sub">Stream music into the device. Map four FFT bands onto the four knobs. <a href="/update" style="color:inherit">firmware update &rarr;</a></div>
 <div id="status" class="bad">DISCONNECTED</div>
 
 <div class="section">

--- a/firmware/patternflow/src/audio_index.h
+++ b/firmware/patternflow/src/audio_index.h
@@ -1,7 +1,7 @@
 // ═══════════════════════════════════════════════════════════
 // PatternFlow - Audio-react browser UI (PROGMEM HTML bundle)
 //
-// Served at http://patternflow.local/ by core_audio_ws.h. The UI:
+// Served at http://patternflow.local/audio by core_audio_ws.h. The UI:
 //   - audio source: file upload or mic
 //   - four frequency bands, each routed to a target knob (1..4)
 //   - per band: Hz min/max sliders, base value, ±range modulation
@@ -71,7 +71,7 @@ const char AUDIO_INDEX_HTML[] PROGMEM = R"HTML(<!doctype html>
 </style></head>
 <body>
 <h1>PATTERNFLOW · AUDIO</h1>
-<div class="sub">Stream music into the device. Map four FFT bands onto the four knobs. <a href="/update" style="color:inherit">firmware update &rarr;</a></div>
+<div class="sub"><a href="/" style="color:inherit;text-decoration:none">&larr; console</a> &nbsp;&middot;&nbsp; Stream music into the device. Map four FFT bands onto the four knobs.</div>
 <div id="status" class="bad">DISCONNECTED</div>
 
 <div class="section">

--- a/firmware/patternflow/src/core_audio_ws.h
+++ b/firmware/patternflow/src/core_audio_ws.h
@@ -1,9 +1,11 @@
 // Patternflow - Audio-react WebSocket server (single-threaded)
 //
-// Hosts a small browser UI on port 80 (audio_index.h) and a WebSocket
-// endpoint on port 81. Browsers connect, send normalized 0..1 knob values
-// per frame, and patterns read those through InputFrame::knobAudioActive /
-// knobAudioValue.
+// Hosts the device web console on port 80 — a landing page at "/"
+// (home_index.h) and the audio-react UI at "/audio" (audio_index.h) —
+// plus a WebSocket endpoint on port 81. (core_web_update.h registers its
+// /update routes on this same server.) Browsers connect, send normalized
+// 0..1 knob values per frame, and patterns read those through
+// InputFrame::knobAudioActive / knobAudioValue.
 //
 // Threading: everything runs in the main Arduino loop via handle(). An
 // earlier version pushed this into a pinned core-0 FreeRTOS task guarded by
@@ -32,6 +34,7 @@
 #include <WebServer.h>
 #include <WebSocketsServer.h>
 #include "audio_index.h"
+#include "home_index.h"
 #endif
 
 namespace PatternflowAudio {
@@ -138,6 +141,10 @@ inline void onEvent(uint8_t num, WStype_t type, uint8_t* payload, size_t length)
 }
 
 inline void handleRoot() {
+  httpServer.send_P(200, "text/html", HOME_INDEX_HTML);
+}
+
+inline void handleAudio() {
   httpServer.send_P(200, "text/html", AUDIO_INDEX_HTML);
 }
 
@@ -221,6 +228,7 @@ inline void begin() {
   if (WiFi.status() != WL_CONNECTED) return;
 
   httpServer.on("/", handleRoot);
+  httpServer.on("/audio", handleAudio);
   httpServer.onNotFound([]() {
     httpServer.send(404, "text/plain", "Not found");
   });

--- a/firmware/patternflow/src/core_audio_ws.h
+++ b/firmware/patternflow/src/core_audio_ws.h
@@ -140,11 +140,16 @@ inline void onEvent(uint8_t num, WStype_t type, uint8_t* payload, size_t length)
   }
 }
 
+// no-store on every console page: the HTML ships inside the firmware, so
+// it changes exactly when the firmware does — a cached copy (or a partial
+// one from a load interrupted by the post-flash reboot) must never stick.
 inline void handleRoot() {
+  httpServer.sendHeader("Cache-Control", "no-store");
   httpServer.send_P(200, "text/html", HOME_INDEX_HTML);
 }
 
 inline void handleAudio() {
+  httpServer.sendHeader("Cache-Control", "no-store");
   httpServer.send_P(200, "text/html", AUDIO_INDEX_HTML);
 }
 

--- a/firmware/patternflow/src/core_web_update.h
+++ b/firmware/patternflow/src/core_web_update.h
@@ -10,12 +10,14 @@
 // sees a same-origin LAN upload, so there is no certificate to get wrong and
 // no mixed-content wall to hit.
 //
-// Safety catch: the POST endpoint only accepts firmware while the device is
-// ARMED — the user must physically open the UPDATE screen first (hold K2 →
-// NETWORK, turn K4). An always-open unauthenticated /update would let anyone
-// on the Wi-Fi reflash the device; arming from an encoder makes flashing an
-// explicit, present-at-the-device act, and doubles as the "ready now" signal.
-// The GET page itself is always served (harmless, and it tells you how to arm).
+// Access: by default (PF_WEBUPDATE_ALWAYS_ARMED 1) the POST endpoint accepts
+// firmware at any time — drop-a-.bin-whenever is the UX the project chose,
+// accepting that anyone on the LAN can flash the device (ArduinoOTA's
+// no-password default has the same exposure). Builds for shared networks set
+// the flag to 0, and then uploads are only accepted while the device is
+// ARMED — the UPDATE screen physically opened from an encoder (hold K2 →
+// NETWORK, turn K4). The GET page itself is always served (harmless, and it
+// tells you how to arm when arming is required).
 //
 // Rollback, honestly: once the app has been up for a few seconds, handle()
 // calls esp_ota_mark_app_valid_cancel_rollback(). With a bootloader built
@@ -98,7 +100,9 @@ inline void disarm() {
   Serial.println("[UPDATE] disarmed");
 }
 
-inline bool isArmed()         { return armed; }
+// Effective gate: the physical UPDATE screen, or the opt-in always-armed
+// build flag (see net_config.h for what that trades away).
+inline bool isArmed()         { return armed || PF_WEBUPDATE_ALWAYS_ARMED != 0; }
 inline bool isUploading()     { return uploading; }
 inline bool isRebootPending() { return rebootAtMs != 0; }
 inline bool hasError()        { return lastError.length() > 0; }
@@ -116,7 +120,7 @@ inline void handleUpload() {
   HTTPUpload& up = server().upload();
   switch (up.status) {
     case UPLOAD_FILE_START: {
-      rejected = !armed || uploading || rebootAtMs != 0;
+      rejected = !isArmed() || uploading || rebootAtMs != 0;
       if (rejected) {
         Serial.println("[UPDATE] upload refused (not armed)");
         break;
@@ -203,7 +207,7 @@ inline void handleUploadDone() {
 inline void handleStatus() {
   char buf[96];
   snprintf(buf, sizeof(buf), "{\"armed\":%s,\"busy\":%s,\"version\":\"%s\"}",
-           armed ? "true" : "false",
+           isArmed() ? "true" : "false",
            (uploading || rebootAtMs != 0) ? "true" : "false",
            PF_IMPROV_FW_VERSION);
   server().send(200, "application/json", buf);

--- a/firmware/patternflow/src/core_web_update.h
+++ b/firmware/patternflow/src/core_web_update.h
@@ -1,0 +1,292 @@
+// ═══════════════════════════════════════════════════════════
+// PatternFlow - Browser self-update (drop a .bin onto patternflow.local/update)
+//
+// Wireless upload without TLS (issue #232). The device already serves plain
+// HTTP on the LAN (the audio-react UI on port 80); this module adds /update
+// to that same server: a GET page with a drop zone, and a POST handler that
+// streams the multipart body straight into Update.h (U_FLASH). The artifact
+// is the application image the web build service already emits — the browser
+// downloads it over HTTPS from wherever it likes, and the device only ever
+// sees a same-origin LAN upload, so there is no certificate to get wrong and
+// no mixed-content wall to hit.
+//
+// Safety catch: the POST endpoint only accepts firmware while the device is
+// ARMED — the user must physically open the UPDATE screen first (hold K2 →
+// NETWORK, turn K4). An always-open unauthenticated /update would let anyone
+// on the Wi-Fi reflash the device; arming from an encoder makes flashing an
+// explicit, present-at-the-device act, and doubles as the "ready now" signal.
+// The GET page itself is always served (harmless, and it tells you how to arm).
+//
+// Rollback, honestly: once the app has been up for a few seconds, handle()
+// calls esp_ota_mark_app_valid_cancel_rollback(). With a bootloader built
+// with CONFIG_BOOTLOADER_APP_ROLLBACK_ENABLE that makes a crash-looping
+// image fall back to the previous slot; the stock Arduino core's bootloader
+// does not enable it, so there the call is a harmless no-op and the real
+// protection is Update.h's own checks (magic byte, complete write) rejecting
+// truncated or wrong files before the boot partition ever changes.
+//
+// Progress display: the entire POST is consumed inside ONE handleClient()
+// call, so the main loop cannot redraw the panel while the image streams in.
+// The sketch installs progressCallback to draw from inside the upload
+// handler instead (same task, so touching the DMA display is safe).
+//
+// License: MIT
+// ═══════════════════════════════════════════════════════════
+#pragma once
+
+#include <Arduino.h>
+#include "config.h"
+#include "core_wifi.h"
+
+#if PF_WEBUPDATE_ENABLED
+#include <WiFi.h>
+#include <WebServer.h>
+#include <Update.h>
+#include <ESPmDNS.h>
+#include <esp_ota_ops.h>
+#include "web_update_index.h"
+#if PF_AUDIO_ENABLED
+#include "core_audio_ws.h"
+#endif
+#endif
+
+namespace PatternflowWebUpdate {
+
+#if PF_WEBUPDATE_ENABLED
+
+// Rides on the audio-react server when that is compiled in (one port-80
+// server total); otherwise owns a WebServer of its own.
+#if PF_AUDIO_ENABLED
+constexpr uint16_t HTTP_PORT = PF_AUDIO_HTTP_PORT;
+inline WebServer& server() { return PatternflowAudio::httpServer; }
+#else
+constexpr uint16_t HTTP_PORT = 80;
+inline WebServer ownServer(HTTP_PORT);
+inline WebServer& server() { return ownServer; }
+#endif
+
+// How long the app must stay up before this image is declared good (see the
+// rollback note in the header comment). Reaching the main loop and staying
+// there for this long is the "successful boot" signal.
+constexpr uint32_t BOOT_VALID_AFTER_MS = 8000;
+
+inline bool initialized = false;
+inline bool armed = false;        // set only from the on-device UPDATE screen
+inline bool uploading = false;
+inline bool rejected = false;     // this POST arrived while not armed
+inline bool completedOk = false;
+inline bool bootMarkedValid = false;
+inline unsigned progressPct = 0;
+inline size_t expectedBytes = 0;
+inline size_t receivedBytes = 0;
+inline uint32_t rebootAtMs = 0;   // nonzero = flash landed, reboot scheduled
+inline String lastError;
+
+// Installed by the sketch: draws upload progress on the panel from inside
+// the upload handler (see header comment). pct is 0..100, or -1 when the
+// client sent no ?size= and the total is unknown.
+inline void (*progressCallback)(int pct) = nullptr;
+
+inline void arm() {
+  armed = true;
+  lastError = "";
+  Serial.println("[UPDATE] armed — /update accepts firmware");
+}
+
+inline void disarm() {
+  armed = false;
+  Serial.println("[UPDATE] disarmed");
+}
+
+inline bool isArmed()         { return armed; }
+inline bool isUploading()     { return uploading; }
+inline bool isRebootPending() { return rebootAtMs != 0; }
+inline bool hasError()        { return lastError.length() > 0; }
+inline unsigned progressPercent() { return progressPct; }
+
+inline void failUpload(const char* stage) {
+  lastError = String(stage) + ": " + Update.errorString();
+  Update.abort();
+  uploading = false;
+  Serial.printf("[UPDATE] failed — %s\n", lastError.c_str());
+}
+
+// Upload body handler — called per multipart chunk by WebServer.
+inline void handleUpload() {
+  HTTPUpload& up = server().upload();
+  switch (up.status) {
+    case UPLOAD_FILE_START: {
+      rejected = !armed || uploading || rebootAtMs != 0;
+      if (rejected) {
+        Serial.println("[UPDATE] upload refused (not armed)");
+        break;
+      }
+      lastError = "";
+      completedOk = false;
+      receivedBytes = 0;
+      progressPct = 0;
+      // The page sends the file size as ?size= because HTTPUpload has no
+      // total; with it Update erases exactly what it needs, and the panel
+      // can show a real percentage.
+      expectedBytes = server().hasArg("size")
+                      ? (size_t)strtoul(server().arg("size").c_str(), nullptr, 10)
+                      : 0;
+      uploading = true;
+      if (!Update.begin(expectedBytes ? expectedBytes : UPDATE_SIZE_UNKNOWN,
+                        U_FLASH)) {
+        failUpload("begin");
+        break;
+      }
+      Serial.printf("[UPDATE] receiving \"%s\" (%u bytes)\n",
+                    up.filename.c_str(), (unsigned)expectedBytes);
+      if (progressCallback) progressCallback(expectedBytes ? 0 : -1);
+      break;
+    }
+    case UPLOAD_FILE_WRITE: {
+      if (!uploading) break;  // refused or already failed — drain silently
+      if (Update.write(up.buf, up.currentSize) != up.currentSize) {
+        failUpload("write");
+        break;
+      }
+      receivedBytes += up.currentSize;
+      if (expectedBytes) {
+        unsigned pct = (unsigned)((uint64_t)receivedBytes * 100 / expectedBytes);
+        if (pct > 100) pct = 100;
+        if (pct != progressPct) {
+          progressPct = pct;
+          if (progressCallback) progressCallback((int)pct);
+        }
+      }
+      break;
+    }
+    case UPLOAD_FILE_END: {
+      if (!uploading) break;
+      if (Update.end(true)) {
+        completedOk = true;
+        progressPct = 100;
+        uploading = false;
+        Serial.printf("[UPDATE] flashed %u bytes OK\n", (unsigned)receivedBytes);
+        if (progressCallback) progressCallback(100);
+      } else {
+        failUpload("end");
+      }
+      break;
+    }
+    case UPLOAD_FILE_ABORTED: {
+      if (uploading) {
+        Update.abort();
+        uploading = false;
+        lastError = "upload aborted";
+        Serial.println("[UPDATE] upload aborted by client");
+      }
+      break;
+    }
+  }
+}
+
+// Completion handler — runs after the whole POST body is consumed.
+inline void handleUploadDone() {
+  if (rejected) {
+    server().send(403, "application/json",
+        "{\"error\":\"locked - on the device: hold K2 for NETWORK, then turn K4 for UPDATE\"}");
+    return;
+  }
+  if (completedOk) {
+    server().send(200, "application/json", "{\"ok\":true}");
+    rebootAtMs = millis() + 1200;  // let the response flush before restarting
+    return;
+  }
+  server().send(500, "application/json",
+                "{\"error\":\"" + lastError + "\"}");
+}
+
+inline void handleStatus() {
+  char buf[96];
+  snprintf(buf, sizeof(buf), "{\"armed\":%s,\"busy\":%s,\"version\":\"%s\"}",
+           armed ? "true" : "false",
+           (uploading || rebootAtMs != 0) ? "true" : "false",
+           PF_IMPROV_FW_VERSION);
+  server().send(200, "application/json", buf);
+}
+
+#endif  // PF_WEBUPDATE_ENABLED
+
+inline bool isCompiledIn() {
+#if PF_WEBUPDATE_ENABLED
+  return true;
+#else
+  return false;
+#endif
+}
+
+// Register routes (and, standalone, start the server). Wi-Fi is owned by
+// PatternflowWifi; this runs on the connect edge. Idempotent.
+inline void begin() {
+#if PF_WEBUPDATE_ENABLED
+  if (initialized) return;
+  if (WiFi.status() != WL_CONNECTED) return;
+
+#if !PF_OTA_ENABLED
+  // ArduinoOTA normally brings up mDNS; with OTA compiled out, start it
+  // here so patternflow.local still resolves.
+  MDNS.begin(PF_OTA_HOSTNAME);
+#endif
+  MDNS.addService("http", "tcp", HTTP_PORT);
+
+  server().on("/update", HTTP_GET, []() {
+    server().send_P(200, "text/html", WEB_UPDATE_HTML);
+  });
+  server().on("/update", HTTP_POST, handleUploadDone, handleUpload);
+  server().on("/update/status", HTTP_GET, handleStatus);
+
+#if !PF_AUDIO_ENABLED
+  // Standalone server: everything else redirects to the update page.
+  server().onNotFound([]() {
+    server().sendHeader("Location", "/update");
+    server().send(302, "text/plain", "");
+  });
+  server().begin();
+#endif
+
+  initialized = true;
+  Serial.printf("[UPDATE] Ready — http://%s.local/update (IP %s)\n",
+                PF_OTA_HOSTNAME, WiFi.localIP().toString().c_str());
+#endif
+}
+
+// Called every main loop: services the standalone server (shared-server
+// traffic is pumped by PatternflowAudio::handle()), marks the running image
+// valid after a healthy stretch of uptime, and fires the deferred reboot.
+inline void handle() {
+#if PF_WEBUPDATE_ENABLED
+#if !PF_AUDIO_ENABLED
+  if (initialized) server().handleClient();
+#endif
+
+  if (!bootMarkedValid && millis() > BOOT_VALID_AFTER_MS) {
+    bootMarkedValid = true;
+    // No-op unless the bootloader has rollback enabled — see header comment.
+    esp_ota_mark_app_valid_cancel_rollback();
+  }
+
+  if (rebootAtMs != 0 && (int32_t)(millis() - rebootAtMs) >= 0) {
+    Serial.println("[UPDATE] rebooting into new firmware");
+    Serial.flush();
+    ESP.restart();
+  }
+#endif
+}
+
+#if !PF_WEBUPDATE_ENABLED
+// Stubs so the sketch compiles unchanged with the feature off.
+inline void (*progressCallback)(int) = nullptr;
+inline void arm() {}
+inline void disarm() {}
+inline bool isArmed()         { return false; }
+inline bool isUploading()     { return false; }
+inline bool isRebootPending() { return false; }
+inline bool hasError()        { return false; }
+inline unsigned progressPercent() { return 0; }
+#endif
+
+} // namespace PatternflowWebUpdate

--- a/firmware/patternflow/src/core_web_update.h
+++ b/firmware/patternflow/src/core_web_update.h
@@ -238,6 +238,9 @@ inline void begin() {
   MDNS.addService("http", "tcp", HTTP_PORT);
 
   server().on("/update", HTTP_GET, []() {
+    // no-store: the page ships inside the firmware and changes with it; a
+    // cached (or reboot-truncated) copy must never stick in the browser.
+    server().sendHeader("Cache-Control", "no-store");
     server().send_P(200, "text/html", WEB_UPDATE_HTML);
   });
   server().on("/update", HTTP_POST, handleUploadDone, handleUpload);

--- a/firmware/patternflow/src/core_wifi.h
+++ b/firmware/patternflow/src/core_wifi.h
@@ -22,7 +22,7 @@
 #include <Arduino.h>
 #include "config.h"
 
-#if PF_OSC_ENABLED || PF_OTA_ENABLED || PF_AUDIO_ENABLED
+#if PF_OSC_ENABLED || PF_OTA_ENABLED || PF_AUDIO_ENABLED || PF_WEBUPDATE_ENABLED
 #define PF_WIFI_NEEDED 1
 #include <WiFi.h>
 #include <Preferences.h>

--- a/firmware/patternflow/src/home_index.h
+++ b/firmware/patternflow/src/home_index.h
@@ -1,0 +1,83 @@
+// ═══════════════════════════════════════════════════════════
+// PatternFlow - Device web console home (PROGMEM HTML bundle)
+//
+// Served at http://patternflow.local/ by core_audio_ws.h. A landing page
+// with one big card per device feature:
+//   01  AUDIO SYNC       → /audio   (audio_index.h)
+//   02  FIRMWARE UPDATE  → /update  (web_update_index.h)
+//   03  REMOTE COMPUTE   — placeholder, external computing link planned
+//
+// Shares the design language of the other device pages: dark, monospace,
+// letter-spaced, thin borders. The version tag is fetched from
+// /update/status so the page doubles as a "what am I running" check.
+//
+// License: MIT
+// ═══════════════════════════════════════════════════════════
+#pragma once
+#include <pgmspace.h>
+
+const char HOME_INDEX_HTML[] PROGMEM = R"HTML(<!doctype html>
+<html lang="en"><head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Patternflow</title>
+<style>
+  :root{--bg:#0a0a0a;--card:#0e0e0e;--fg:#e8e8e8;--mut:#666;--ln:#212121;--accent:#5fdb89;--blue:#6ab7ff}
+  *{box-sizing:border-box}
+  body{margin:0;min-height:100vh;background:var(--bg);color:var(--fg);
+       font:14px/1.5 ui-monospace,SFMono-Regular,Menlo,monospace;
+       display:flex;flex-direction:column;align-items:center;justify-content:center;
+       padding:36px 20px;
+       background-image:radial-gradient(ellipse 90% 55% at 50% -12%,#151515 0%,transparent 65%)}
+  .wordmark{font-size:16px;letter-spacing:.55em;text-indent:.55em;font-weight:normal;margin:0 0 8px;color:var(--fg)}
+  .tag{font-size:10px;color:var(--mut);letter-spacing:.25em;text-indent:.25em;margin-bottom:44px;text-align:center}
+  .cards{width:100%;max-width:400px;display:flex;flex-direction:column;gap:14px}
+  .card{display:block;position:relative;padding:22px 24px 20px;border:1px solid var(--ln);
+        background:var(--card);text-decoration:none;color:var(--fg);
+        transition:border-color .16s,transform .16s,background .16s}
+  a.card:hover{transform:translateY(-2px);background:#101010}
+  a.card.audio:hover{border-color:var(--accent)}
+  a.card.fw:hover{border-color:var(--blue)}
+  .num{position:absolute;top:22px;right:24px;font-size:10px;color:#3a3a3a;letter-spacing:.2em}
+  .card h2{margin:0 0 7px;font-size:12px;letter-spacing:.28em;font-weight:normal}
+  a.card.audio h2{color:var(--accent)}
+  a.card.fw h2{color:var(--blue)}
+  .card p{margin:0;font-size:11px;color:var(--mut);line-height:1.7}
+  .soon{opacity:.55}
+  .soon h2{color:var(--fg)}
+  .badge{display:inline-block;font-size:9px;letter-spacing:.2em;color:var(--bg);background:#4a4a4a;padding:2px 8px;margin-left:10px;vertical-align:2px}
+  footer{margin-top:46px;font-size:10px;letter-spacing:.2em}
+  footer a{color:#3a3a3a;text-decoration:none}
+  footer a:hover{color:var(--mut)}
+</style></head><body>
+
+<h1 class="wordmark">PATTERNFLOW</h1>
+<div class="tag" id="tag">DEVICE CONSOLE</div>
+
+<nav class="cards">
+  <a class="card audio" href="/audio">
+    <span class="num">01</span>
+    <h2>AUDIO SYNC</h2>
+    <p>Stream music from this browser. Four FFT bands drive the four knobs in real time.</p>
+  </a>
+  <a class="card fw" href="/update">
+    <span class="num">02</span>
+    <h2>FIRMWARE UPDATE</h2>
+    <p>Drop a firmware .bin &mdash; the device flashes itself over the LAN and reboots.</p>
+  </a>
+  <div class="card soon">
+    <span class="num">03</span>
+    <h2>REMOTE COMPUTE<span class="badge">SOON</span></h2>
+    <p>Link an external computer to drive patterns with more horsepower.</p>
+  </div>
+</nav>
+
+<footer><a href="https://patternflow.work" target="_blank" rel="noopener">patternflow.work</a></footer>
+
+<script>
+fetch('/update/status',{cache:'no-store'}).then(function(r){return r.json()}).then(function(s){
+  if(s.version)document.getElementById('tag').textContent='DEVICE CONSOLE · v'+s.version;
+}).catch(function(){});
+</script>
+</body></html>
+)HTML";

--- a/firmware/patternflow/src/home_index.h
+++ b/firmware/patternflow/src/home_index.h
@@ -2,14 +2,16 @@
 // PatternFlow - Device web console home (PROGMEM HTML bundle)
 //
 // Served at http://patternflow.local/ by core_audio_ws.h. A landing page
-// with one big card per device feature:
+// with one ghost-numeral row per device feature:
 //   01  AUDIO SYNC       → /audio   (audio_index.h)
 //   02  FIRMWARE UPDATE  → /update  (web_update_index.h)
 //   03  REMOTE COMPUTE   — placeholder, external computing link planned
 //
-// Shares the design language of the other device pages: dark, monospace,
-// letter-spaced, thin borders. The version tag is fetched from
-// /update/status so the page doubles as a "what am I running" check.
+// Styled to the patternflow.work design system (web/docs/
+// patternflow-styleguide.html): cream + ink + one LED accent, thin rules,
+// Pretendard wordmark, JetBrains Mono kickers, pf-row ghost numerals.
+// Webfonts load from Google/jsDelivr exactly like the styleguide; on an
+// offline LAN the system font stacks take over and nothing breaks.
 //
 // License: MIT
 // ═══════════════════════════════════════════════════════════
@@ -21,62 +23,84 @@ const char HOME_INDEX_HTML[] PROGMEM = R"HTML(<!doctype html>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Patternflow</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 <style>
-  :root{--bg:#0a0a0a;--card:#0e0e0e;--fg:#e8e8e8;--mut:#666;--ln:#212121;--accent:#5fdb89;--blue:#6ab7ff}
-  *{box-sizing:border-box}
-  body{margin:0;min-height:100vh;background:var(--bg);color:var(--fg);
-       font:14px/1.5 ui-monospace,SFMono-Regular,Menlo,monospace;
-       display:flex;flex-direction:column;align-items:center;justify-content:center;
-       padding:36px 20px;
-       background-image:radial-gradient(ellipse 90% 55% at 50% -12%,#151515 0%,transparent 65%)}
-  .wordmark{font-size:16px;letter-spacing:.55em;text-indent:.55em;font-weight:normal;margin:0 0 8px;color:var(--fg)}
-  .tag{font-size:10px;color:var(--mut);letter-spacing:.25em;text-indent:.25em;margin-bottom:44px;text-align:center}
-  .cards{width:100%;max-width:400px;display:flex;flex-direction:column;gap:14px}
-  .card{display:block;position:relative;padding:22px 24px 20px;border:1px solid var(--ln);
-        background:var(--card);text-decoration:none;color:var(--fg);
-        transition:border-color .16s,transform .16s,background .16s}
-  a.card:hover{transform:translateY(-2px);background:#101010}
-  a.card.audio:hover{border-color:var(--accent)}
-  a.card.fw:hover{border-color:var(--blue)}
-  .num{position:absolute;top:22px;right:24px;font-size:10px;color:#3a3a3a;letter-spacing:.2em}
-  .card h2{margin:0 0 7px;font-size:12px;letter-spacing:.28em;font-weight:normal}
-  a.card.audio h2{color:var(--accent)}
-  a.card.fw h2{color:var(--blue)}
-  .card p{margin:0;font-size:11px;color:var(--mut);line-height:1.7}
-  .soon{opacity:.55}
-  .soon h2{color:var(--fg)}
-  .badge{display:inline-block;font-size:9px;letter-spacing:.2em;color:var(--bg);background:#4a4a4a;padding:2px 8px;margin-left:10px;vertical-align:2px}
-  footer{margin-top:46px;font-size:10px;letter-spacing:.2em}
-  footer a{color:#3a3a3a;text-decoration:none}
-  footer a:hover{color:var(--mut)}
+  @font-face{font-family:'Pretendard';font-weight:400;font-style:normal;font-display:swap;
+    src:url('https://cdn.jsdelivr.net/npm/pretendard@1.3.9/dist/web/static/woff2/Pretendard-Regular.woff2') format('woff2')}
+  @font-face{font-family:'Pretendard';font-weight:700;font-style:normal;font-display:swap;
+    src:url('https://cdn.jsdelivr.net/npm/pretendard@1.3.9/dist/web/static/woff2/Pretendard-Bold.woff2') format('woff2')}
+  :root{--cream:#F4EFE6;--cream2:#EDE7DB;--ink:#141414;--muted:#6B655A;--faint:#A69F90;--ghost:#C9C2B0;--rule:#D9D1C0;--led:#E8552E;
+        --sans:'Inter','Pretendard',ui-sans-serif,system-ui,sans-serif;
+        --mono:'JetBrains Mono',ui-monospace,SFMono-Regular,Menlo,monospace;
+        --pretendard:'Pretendard',ui-sans-serif,system-ui,sans-serif}
+  *{box-sizing:border-box;margin:0;padding:0}
+  body{min-height:100vh;background:var(--cream);color:var(--ink);
+       font:15px/1.55 var(--sans);-webkit-font-smoothing:antialiased;text-rendering:geometricPrecision;
+       display:flex;align-items:center;justify-content:center;padding:72px 24px}
+  .version-tag{position:fixed;top:24px;left:32px;z-index:40;font-family:var(--mono);font-size:10px;
+       letter-spacing:.14em;text-transform:uppercase;color:var(--muted);pointer-events:none}
+  .version-tag .dot{display:inline-block;width:5px;height:5px;border-radius:50%;background:var(--led);
+       margin-right:8px;vertical-align:1px;box-shadow:0 0 6px var(--led)}
+  .panel{width:100%;max-width:560px;background:#ffffff;padding:56px 48px 44px}
+  h1{font-family:var(--pretendard);font-size:44px;font-weight:700;letter-spacing:-.035em;line-height:1;margin-bottom:10px}
+  .kicker{font-family:var(--pretendard);font-size:20px;font-weight:400;letter-spacing:-.015em;margin-bottom:44px}
+  .pf-kicker{display:block;font-family:var(--mono);font-size:11px;letter-spacing:.14em;text-transform:uppercase;
+       color:var(--muted);margin-bottom:6px}
+  .pf-row{display:block;position:relative;padding:18px 96px 18px 0;border-bottom:1px solid var(--rule);
+       color:var(--muted);text-decoration:none;overflow:hidden;transition:color .15s ease}
+  .pf-row:first-of-type{border-top:1px solid var(--rule)}
+  a.pf-row:hover{color:var(--ink)}
+  a.pf-row:hover .pf-ghost{color:var(--ink)}
+  .pf-ghost{position:absolute;right:-2px;top:50%;transform:translateY(-50%);color:var(--ghost);
+       font-size:56px;font-weight:300;letter-spacing:-.04em;line-height:1;pointer-events:none;transition:color .15s ease}
+  .pf-row-t{font-size:18px;font-weight:500;letter-spacing:-.01em;line-height:1.3;color:inherit}
+  .pf-row-d{max-width:34ch;margin-top:3px;color:var(--muted);font-size:14px;line-height:1.45}
+  .pf-row.soon,.pf-row.soon .pf-row-d{color:var(--faint)}
+  .tag{display:inline-block;font-family:var(--mono);font-size:10px;letter-spacing:.08em;text-transform:uppercase;
+       border:1px solid var(--faint);color:var(--muted);padding:3px 8px 2px;margin-left:10px;vertical-align:2px}
+  footer{margin-top:36px;display:flex;justify-content:space-between;gap:16px;
+       font-family:var(--mono);font-size:11px;letter-spacing:.08em;text-transform:uppercase;color:var(--faint)}
+  footer a{color:var(--muted);text-decoration:none}
+  footer a:hover{color:var(--ink);text-decoration:underline;text-underline-offset:3px}
+  @media(max-width:560px){body{padding:56px 16px}.panel{padding:40px 24px 36px}
+       h1{font-size:36px}.kicker{font-size:18px;margin-bottom:36px}
+       .pf-ghost{font-size:44px}.pf-row{padding-right:72px}}
 </style></head><body>
 
-<h1 class="wordmark">PATTERNFLOW</h1>
-<div class="tag" id="tag">DEVICE CONSOLE</div>
+<div class="version-tag"><span class="dot"></span>device &middot; <span id="ver">console</span></div>
 
-<nav class="cards">
-  <a class="card audio" href="/audio">
-    <span class="num">01</span>
-    <h2>AUDIO SYNC</h2>
-    <p>Stream music from this browser. Four FFT bands drive the four knobs in real time.</p>
-  </a>
-  <a class="card fw" href="/update">
-    <span class="num">02</span>
-    <h2>FIRMWARE UPDATE</h2>
-    <p>Drop a firmware .bin &mdash; the device flashes itself over the LAN and reboots.</p>
-  </a>
-  <div class="card soon">
-    <span class="num">03</span>
-    <h2>REMOTE COMPUTE<span class="badge">SOON</span></h2>
-    <p>Link an external computer to drive patterns with more horsepower.</p>
-  </div>
-</nav>
+<main class="panel">
+  <h1>Patternflow</h1>
+  <div class="kicker">Device console.</div>
 
-<footer><a href="https://patternflow.work" target="_blank" rel="noopener">patternflow.work</a></footer>
+  <span class="pf-kicker">Console</span>
+  <nav>
+    <a class="pf-row" href="/audio">
+      <span class="pf-ghost">01</span>
+      <div class="pf-row-t">Audio sync</div>
+      <div class="pf-row-d">Stream music from this browser &mdash; four FFT bands drive the four knobs.</div>
+    </a>
+    <a class="pf-row" href="/update">
+      <span class="pf-ghost">02</span>
+      <div class="pf-row-t">Firmware update</div>
+      <div class="pf-row-d">Drop a .bin &mdash; the device flashes itself over the LAN and reboots.</div>
+    </a>
+    <div class="pf-row soon">
+      <span class="pf-ghost">03</span>
+      <div class="pf-row-t">Remote compute<span class="tag">Soon</span></div>
+      <div class="pf-row-d">Link an external computer to drive patterns with more horsepower.</div>
+    </div>
+  </nav>
+
+  <footer><span id="host"></span><a href="https://patternflow.work" target="_blank" rel="noopener">patternflow.work</a></footer>
+</main>
 
 <script>
+document.getElementById('host').textContent=location.hostname;
 fetch('/update/status',{cache:'no-store'}).then(function(r){return r.json()}).then(function(s){
-  if(s.version)document.getElementById('tag').textContent='DEVICE CONSOLE · v'+s.version;
+  if(s.version)document.getElementById('ver').textContent='v'+s.version;
 }).catch(function(){});
 </script>
 </body></html>

--- a/firmware/patternflow/src/web_update_index.h
+++ b/firmware/patternflow/src/web_update_index.h
@@ -63,6 +63,13 @@ const char WEB_UPDATE_HTML[] PROGMEM = R"HTML(<!doctype html>
   #armHint{display:none;margin:20px 0 0;border:1px dashed var(--rule);background:var(--cream);
        padding:14px 16px;font-family:var(--mono);font-size:11.5px;line-height:1.6;color:var(--muted)}
   #armHint b{font-weight:500;color:var(--ink)}
+  #handoff{display:none;margin:0 0 24px;padding:16px 18px;border:1px solid var(--rule);background:var(--cream)}
+  #handoffFrom{font-family:var(--mono);font-size:11px;color:var(--muted);word-break:break-all;margin:6px 0 14px;line-height:1.6}
+  #handoffGo{font-family:var(--mono);font-size:11px;letter-spacing:.12em;text-transform:uppercase;
+       background:var(--ink);color:var(--cream);border:1px solid var(--ink);padding:12px 16px;cursor:pointer;
+       transition:background .15s ease,color .15s ease}
+  #handoffGo:hover{background:transparent;color:var(--ink)}
+  #handoffGo:disabled{opacity:.5;cursor:default}
   #drop{margin-top:28px;min-height:176px;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:8px;
        border:1px dashed var(--rule);background:var(--cream);cursor:pointer;text-align:center;padding:24px;
        transition:border-color .16s ease,background .16s ease}
@@ -88,6 +95,14 @@ const char WEB_UPDATE_HTML[] PROGMEM = R"HTML(<!doctype html>
   <h2>Firmware update.</h2>
   <p class="sub">Drop a firmware .bin &mdash; the device flashes itself over the LAN and reboots on the new build.</p>
 
+  <!-- Shown when the build page hands a firmware URL over via ?src= —
+       the phone never touches a file picker. -->
+  <div id="handoff">
+    <span class="pf-kicker">Linked build</span>
+    <div id="handoffFrom"></div>
+    <button id="handoffGo" type="button">Fetch &amp; flash</button>
+  </div>
+
   <span class="pf-kicker">Two steps</span>
   <div class="step"><span class="n">01</span><p>Build &amp; download a <b>.bin</b> &mdash; patternflow.work &rarr; Build, or an <b>arduino-cli</b> export.</p></div>
   <div class="step"><span class="n">02</span><p>Drop it below. Keep the device powered; it verifies, flashes, and reboots itself.</p></div>
@@ -98,10 +113,12 @@ const char WEB_UPDATE_HTML[] PROGMEM = R"HTML(<!doctype html>
     <span class="big">Drop .bin here</span>
     <span class="small">or click to choose a file</span>
   </div>
-  <!-- No accept attribute: Android maps unknown extensions like .bin to a
-       media-only picker (camera/gallery), hiding the file manager. The JS
-       validates extension and size instead. -->
-  <input id="file" type="file" style="display:none">
+  <!-- accept="*/*", not ".bin": Android maps unknown extensions to a
+       media-only picker (camera/gallery), and on some devices NO accept
+       does the same — an explicit any-type accept is what reliably brings
+       up the full chooser with the file manager. The JS validates
+       extension and size instead. -->
+  <input id="file" type="file" accept="*/*" style="display:none">
   <div id="bar"><div id="fill"></div></div>
   <div id="msg"></div>
 </main>
@@ -179,6 +196,39 @@ function waitForReboot(){
     }).catch(function(){});
   },2000);
 }
+
+// ?src= handoff from the build page ("Send over Wi-Fi"): this page fetches
+// the .bin itself and feeds it into the same upload path — no file picker,
+// which some Android systems cannot show for arbitrary files. The firmware
+// route serves public CORS for exactly this fetch.
+var srcUrl=null;
+try{
+  var s=new URLSearchParams(location.search).get('src');
+  if(s&&/^https?:\/\//i.test(s)){
+    srcUrl=s;
+    document.getElementById('handoffFrom').textContent=s.replace(/^https?:\/\//i,'');
+    document.getElementById('handoff').style.display='block';
+  }
+}catch(e){}
+document.getElementById('handoffGo').addEventListener('click',function(){
+  if(!srcUrl||uploading)return;
+  if(!armed){setMsg('Device is locked - see the arming note above.','bad');return}
+  var btn=this;
+  btn.disabled=true;
+  setPill('FETCHING','warn');
+  setMsg('Downloading the build from '+srcUrl.split('/')[2]+' ...');
+  fetch(srcUrl).then(function(r){
+    if(!r.ok)throw new Error('HTTP '+r.status);
+    return r.blob();
+  }).then(function(b){
+    btn.disabled=false;
+    upload(new File([b],'firmware.bin',{type:'application/octet-stream'}));
+  }).catch(function(e){
+    btn.disabled=false;
+    poll();
+    setMsg('Could not download the build ('+e.message+'). Download the .bin on this device and drop it above instead.','bad');
+  });
+});
 </script>
 </body></html>
 )HTML";

--- a/firmware/patternflow/src/web_update_index.h
+++ b/firmware/patternflow/src/web_update_index.h
@@ -7,10 +7,14 @@
 //
 // The page polls /update/status: stock builds are always ready
 // (PF_WEBUPDATE_ALWAYS_ARMED 1); builds that opted into physical arming
-// show a LOCKED pill plus the how-to-arm hint until the UPDATE screen is
+// show a LOCKED tag plus the how-to-arm note until the UPDATE screen is
 // opened on the device. Upload progress is the XHR's own send progress —
 // the device flashes as it receives, so the bar tracks the actual write
 // within a buffer's worth.
+//
+// Styled to the patternflow.work design system (web/docs/
+// patternflow-styleguide.html): cream + ink + LED accent, thin rules,
+// mono kickers/tags, dashed placeholder-style drop zone.
 //
 // License: MIT
 // ═══════════════════════════════════════════════════════════
@@ -21,66 +25,86 @@ const char WEB_UPDATE_HTML[] PROGMEM = R"HTML(<!doctype html>
 <html lang="en"><head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
-<title>Patternflow Update</title>
+<title>Patternflow — Firmware update</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 <style>
-  :root{--bg:#0a0a0a;--card:#0e0e0e;--fg:#e8e8e8;--mut:#666;--ln:#212121;--accent:#5fdb89;--blue:#6ab7ff;--bad:#ff5d5d;--warn:#e8c35f}
-  *{box-sizing:border-box}
-  body{margin:0;min-height:100vh;background:var(--bg);color:var(--fg);
-       font:14px/1.5 ui-monospace,SFMono-Regular,Menlo,monospace;
-       display:flex;flex-direction:column;align-items:center;justify-content:center;
-       padding:36px 20px;
-       background-image:radial-gradient(ellipse 90% 55% at 50% -12%,#151515 0%,transparent 65%)}
-  .col{width:100%;max-width:400px}
-  .top{display:flex;align-items:baseline;justify-content:space-between;margin-bottom:6px}
-  .back{font-size:11px;color:var(--mut);text-decoration:none;letter-spacing:.1em}
-  .back:hover{color:var(--fg)}
-  #pill{font-size:9px;padding:4px 10px;border:1px solid var(--ln);letter-spacing:.2em;background:var(--card)}
-  h1{font-size:13px;letter-spacing:.35em;font-weight:normal;margin:18px 0 6px;color:var(--blue)}
-  .sub{font-size:11px;color:var(--mut);line-height:1.7;margin-bottom:22px}
-  .ok{color:var(--accent);border-color:#1e3a2a!important}
-  .bad{color:var(--bad);border-color:#3a1e1e!important}
-  .warn{color:var(--warn);border-color:#3a331e!important}
-  .steps{margin:0 0 16px;padding:16px 18px;border:1px solid var(--ln);background:var(--card)}
-  .steps div{display:flex;gap:12px;font-size:11px;color:var(--mut);line-height:1.7;margin:4px 0}
-  .steps .n{color:#3a3a3a;letter-spacing:.1em}
-  .steps b{color:var(--fg);font-weight:normal}
-  #armHint{display:none;margin:0 0 16px;padding:13px 18px;border:1px solid #3a331e;background:#12100a;font-size:11px;color:var(--warn);line-height:1.7}
-  #armHint b{font-weight:normal;color:var(--fg)}
-  #drop{min-height:170px;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:8px;
-        border:1px dashed #333;background:var(--card);cursor:pointer;text-align:center;padding:20px;
-        transition:border-color .16s,background .16s}
-  #drop .big{font-size:12px;letter-spacing:.2em;color:var(--fg)}
-  #drop .small{font-size:10px;color:var(--mut);letter-spacing:.1em}
-  #drop.hover{border-color:var(--blue);background:#0f1216}
+  :root{--cream:#F4EFE6;--cream2:#EDE7DB;--ink:#141414;--muted:#6B655A;--faint:#A69F90;--rule:#D9D1C0;--rule-soft:#E5DDC9;--led:#E8552E;
+        --sans:'Inter',ui-sans-serif,system-ui,sans-serif;
+        --mono:'JetBrains Mono',ui-monospace,SFMono-Regular,Menlo,monospace}
+  *{box-sizing:border-box;margin:0;padding:0}
+  body{min-height:100vh;background:var(--cream);color:var(--ink);
+       font:15px/1.55 var(--sans);-webkit-font-smoothing:antialiased;text-rendering:geometricPrecision;
+       display:flex;align-items:center;justify-content:center;padding:72px 24px}
+  .version-tag{position:fixed;top:24px;left:32px;z-index:40;font-family:var(--mono);font-size:10px;
+       letter-spacing:.14em;text-transform:uppercase;color:var(--muted);pointer-events:none}
+  .version-tag .dot{display:inline-block;width:5px;height:5px;border-radius:50%;background:var(--led);
+       margin-right:8px;vertical-align:1px;box-shadow:0 0 6px var(--led)}
+  .panel{width:100%;max-width:560px;background:#ffffff;padding:48px 48px 44px}
+  .top{display:flex;justify-content:space-between;align-items:baseline;margin-bottom:36px}
+  .back{font-family:var(--mono);font-size:11px;letter-spacing:.08em;text-transform:uppercase;
+       color:var(--muted);text-decoration:none}
+  .back:hover{color:var(--ink);text-decoration:underline;text-underline-offset:3px}
+  #pill{font-family:var(--mono);font-size:10.5px;letter-spacing:.12em;text-transform:uppercase;
+       padding:5px 10px 4px;border:1px solid var(--faint);color:var(--muted)}
+  #pill.ok{border-color:var(--ink);color:var(--ink)}
+  #pill.warn{border-color:var(--led);color:var(--led)}
+  #pill.bad{border-color:var(--faint);color:var(--faint)}
+  h2{font-size:34px;font-weight:500;letter-spacing:-.025em;line-height:1.05;margin-bottom:12px}
+  .sub{max-width:36ch;color:var(--muted);font-size:15px;line-height:1.5;margin-bottom:32px}
+  .pf-kicker{display:block;font-family:var(--mono);font-size:11px;letter-spacing:.14em;text-transform:uppercase;
+       color:var(--muted);margin-bottom:2px}
+  .step{display:grid;grid-template-columns:40px 1fr;gap:20px;padding:14px 0;border-bottom:1px solid var(--rule);align-items:baseline}
+  .step:first-of-type{border-top:1px solid var(--rule)}
+  .step .n{font-family:var(--mono);font-size:10px;letter-spacing:.12em;color:var(--muted)}
+  .step p{font-size:14px;line-height:1.5;color:var(--muted)}
+  .step b{font-weight:500;color:var(--ink)}
+  #armHint{display:none;margin:20px 0 0;border:1px dashed var(--rule);background:var(--cream);
+       padding:14px 16px;font-family:var(--mono);font-size:11.5px;line-height:1.6;color:var(--muted)}
+  #armHint b{font-weight:500;color:var(--ink)}
+  #drop{margin-top:28px;min-height:176px;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:8px;
+       border:1px dashed var(--rule);background:var(--cream);cursor:pointer;text-align:center;padding:24px;
+       transition:border-color .16s ease,background .16s ease}
+  #drop .big{font-family:var(--mono);font-size:12px;letter-spacing:.14em;text-transform:uppercase;color:var(--ink)}
+  #drop .small{font-family:var(--mono);font-size:10px;letter-spacing:.08em;text-transform:uppercase;color:var(--faint)}
+  #drop.hover{border-color:var(--ink);background:var(--cream2)}
   #drop.disabled{opacity:.45}
-  #bar{height:5px;background:#1a1a1a;margin:16px 0 8px;display:none}
-  #fill{height:100%;width:0%;background:var(--blue);transition:width .1s linear}
-  #msg{font-size:11px;min-height:18px;color:var(--mut);line-height:1.7}
-  #msg.ok{color:var(--accent)} #msg.bad{color:var(--bad)}
+  #bar{height:6px;background:var(--rule-soft);margin:20px 0 10px;display:none}
+  #fill{height:100%;width:0%;background:var(--led);transition:width .1s linear}
+  #msg{font-size:13px;min-height:20px;color:var(--muted);line-height:1.55;margin-top:12px}
+  #msg.ok{color:var(--ink)} #msg.bad{color:var(--led)}
+  @media(max-width:560px){body{padding:56px 16px}.panel{padding:36px 24px 32px}h2{font-size:28px}}
 </style></head><body>
-<div class="col">
+
+<div class="version-tag"><span class="dot"></span>device &middot; update</div>
+
+<main class="panel">
   <div class="top">
-    <a class="back" href="/">&larr; console</a>
+    <a class="back" href="/">&larr; Console</a>
     <span id="pill">&hellip;</span>
   </div>
-  <h1>FIRMWARE UPDATE</h1>
-  <div class="sub">Drop a firmware .bin &mdash; the device flashes itself over the LAN and reboots on the new build.</div>
 
-  <div class="steps">
-    <div><span class="n">01</span><span>Build &amp; download a <b>.bin</b> &mdash; patternflow.work &rarr; Build, or an <b>arduino-cli</b> export.</span></div>
-    <div><span class="n">02</span><span>Drop it below. Keep the device powered; it verifies, flashes, and reboots itself.</span></div>
-  </div>
+  <h2>Firmware update.</h2>
+  <p class="sub">Drop a firmware .bin &mdash; the device flashes itself over the LAN and reboots on the new build.</p>
+
+  <span class="pf-kicker">Two steps</span>
+  <div class="step"><span class="n">01</span><p>Build &amp; download a <b>.bin</b> &mdash; patternflow.work &rarr; Build, or an <b>arduino-cli</b> export.</p></div>
+  <div class="step"><span class="n">02</span><p>Drop it below. Keep the device powered; it verifies, flashes, and reboots itself.</p></div>
 
   <div id="armHint">This build requires arming first. On the device: hold <b>K2</b> &rarr; NETWORK, then turn <b>K4</b> &rarr; <b>UPDATE</b>.</div>
 
   <div id="drop">
-    <span class="big">DROP .BIN HERE</span>
+    <span class="big">Drop .bin here</span>
     <span class="small">or click to choose a file</span>
   </div>
-  <input id="file" type="file" accept=".bin" style="display:none">
+  <!-- No accept attribute: Android maps unknown extensions like .bin to a
+       media-only picker (camera/gallery), hiding the file manager. The JS
+       validates extension and size instead. -->
+  <input id="file" type="file" style="display:none">
   <div id="bar"><div id="fill"></div></div>
   <div id="msg"></div>
-</div>
+</main>
 
 <script>
 var drop=document.getElementById('drop'),fileIn=document.getElementById('file'),

--- a/firmware/patternflow/src/web_update_index.h
+++ b/firmware/patternflow/src/web_update_index.h
@@ -5,11 +5,12 @@
 // Drop a firmware .bin (the app image the web build service emits, or an
 // arduino-cli export) and the device flashes itself via Update.h.
 //
-// The page polls /update/status so the ARMED/LOCKED chip mirrors the
-// device: the POST endpoint only accepts firmware while the UPDATE screen
-// is open on the device (hold K2 → NETWORK, turn K4). Upload progress is
-// the XHR's own send progress — the device flashes as it receives, so the
-// bar tracks the actual write within a buffer's worth.
+// The page polls /update/status: stock builds are always ready
+// (PF_WEBUPDATE_ALWAYS_ARMED 1); builds that opted into physical arming
+// show a LOCKED pill plus the how-to-arm hint until the UPDATE screen is
+// opened on the device. Upload progress is the XHR's own send progress —
+// the device flashes as it receives, so the bar tracks the actual write
+// within a buffer's worth.
 //
 // License: MIT
 // ═══════════════════════════════════════════════════════════
@@ -22,63 +23,85 @@ const char WEB_UPDATE_HTML[] PROGMEM = R"HTML(<!doctype html>
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Patternflow Update</title>
 <style>
-  :root{--bg:#0a0a0a;--card:#0d0d0d;--fg:#e8e8e8;--mut:#666;--ln:#1f1f1f;--accent:#5fdb89;--bad:#ff5d5d;--warn:#e8c35f}
+  :root{--bg:#0a0a0a;--card:#0e0e0e;--fg:#e8e8e8;--mut:#666;--ln:#212121;--accent:#5fdb89;--blue:#6ab7ff;--bad:#ff5d5d;--warn:#e8c35f}
   *{box-sizing:border-box}
-  body{margin:0 auto;background:var(--bg);color:var(--fg);font:13px/1.5 ui-monospace,SFMono-Regular,Menlo,monospace;padding:20px;max-width:560px}
-  h1{font-size:11px;letter-spacing:.4em;opacity:.5;font-weight:normal;margin:0 0 4px}
-  .sub{font-size:11px;color:var(--mut);margin-bottom:20px}
-  a{color:var(--mut)}
-  #chip{position:fixed;top:14px;right:14px;font-size:10px;padding:7px 11px;border:1px solid var(--ln);background:var(--card);letter-spacing:.15em;z-index:10}
-  .ok{color:var(--accent)} .bad{color:var(--bad)} .warn{color:var(--warn)}
-  .section{margin:14px 0;padding:14px;border:1px solid var(--ln);background:var(--card)}
-  .section h2{font-size:10px;letter-spacing:.25em;color:var(--mut);font-weight:normal;text-transform:uppercase;margin:0 0 12px}
-  ol{margin:0;padding-left:18px;color:var(--mut);font-size:12px}
-  ol li{margin:4px 0}
-  ol b{color:var(--fg);font-weight:normal}
-  code{color:var(--fg)}
-  #drop{margin:14px 0;padding:38px 14px;border:1px dashed #333;background:var(--card);text-align:center;color:var(--mut);cursor:pointer;transition:border-color .15s}
-  #drop.hover{border-color:var(--accent);color:var(--fg)}
+  body{margin:0;min-height:100vh;background:var(--bg);color:var(--fg);
+       font:14px/1.5 ui-monospace,SFMono-Regular,Menlo,monospace;
+       display:flex;flex-direction:column;align-items:center;justify-content:center;
+       padding:36px 20px;
+       background-image:radial-gradient(ellipse 90% 55% at 50% -12%,#151515 0%,transparent 65%)}
+  .col{width:100%;max-width:400px}
+  .top{display:flex;align-items:baseline;justify-content:space-between;margin-bottom:6px}
+  .back{font-size:11px;color:var(--mut);text-decoration:none;letter-spacing:.1em}
+  .back:hover{color:var(--fg)}
+  #pill{font-size:9px;padding:4px 10px;border:1px solid var(--ln);letter-spacing:.2em;background:var(--card)}
+  h1{font-size:13px;letter-spacing:.35em;font-weight:normal;margin:18px 0 6px;color:var(--blue)}
+  .sub{font-size:11px;color:var(--mut);line-height:1.7;margin-bottom:22px}
+  .ok{color:var(--accent);border-color:#1e3a2a!important}
+  .bad{color:var(--bad);border-color:#3a1e1e!important}
+  .warn{color:var(--warn);border-color:#3a331e!important}
+  .steps{margin:0 0 16px;padding:16px 18px;border:1px solid var(--ln);background:var(--card)}
+  .steps div{display:flex;gap:12px;font-size:11px;color:var(--mut);line-height:1.7;margin:4px 0}
+  .steps .n{color:#3a3a3a;letter-spacing:.1em}
+  .steps b{color:var(--fg);font-weight:normal}
+  #armHint{display:none;margin:0 0 16px;padding:13px 18px;border:1px solid #3a331e;background:#12100a;font-size:11px;color:var(--warn);line-height:1.7}
+  #armHint b{font-weight:normal;color:var(--fg)}
+  #drop{min-height:170px;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:8px;
+        border:1px dashed #333;background:var(--card);cursor:pointer;text-align:center;padding:20px;
+        transition:border-color .16s,background .16s}
+  #drop .big{font-size:12px;letter-spacing:.2em;color:var(--fg)}
+  #drop .small{font-size:10px;color:var(--mut);letter-spacing:.1em}
+  #drop.hover{border-color:var(--blue);background:#0f1216}
   #drop.disabled{opacity:.45}
-  #bar{height:6px;background:#1a1a1a;margin:14px 0 6px;display:none}
-  #fill{height:100%;width:0%;background:var(--accent)}
-  #msg{font-size:12px;min-height:18px;color:var(--mut)}
+  #bar{height:5px;background:#1a1a1a;margin:16px 0 8px;display:none}
+  #fill{height:100%;width:0%;background:var(--blue);transition:width .1s linear}
+  #msg{font-size:11px;min-height:18px;color:var(--mut);line-height:1.7}
   #msg.ok{color:var(--accent)} #msg.bad{color:var(--bad)}
 </style></head><body>
-<h1>PATTERNFLOW &middot; UPDATE</h1>
-<div class="sub">Drop a firmware .bin &mdash; the device flashes itself over the LAN. <a href="/">audio-react &rarr;</a></div>
-<div id="chip">&hellip;</div>
+<div class="col">
+  <div class="top">
+    <a class="back" href="/">&larr; console</a>
+    <span id="pill">&hellip;</span>
+  </div>
+  <h1>FIRMWARE UPDATE</h1>
+  <div class="sub">Drop a firmware .bin &mdash; the device flashes itself over the LAN and reboots on the new build.</div>
 
-<div class="section"><h2>How</h2>
-<ol>
-<li>Build &amp; download a firmware <b>.bin</b> (patternflow.work &rarr; Build, or an <code>arduino-cli</code> export).</li>
-<li>On the device: hold <b>K2</b> &rarr; NETWORK, then turn <b>K4</b> &rarr; <b>UPDATE</b>. The chip above turns ARMED.</li>
-<li>Drop the file below. Keep the device powered; it reboots itself when done.</li>
-</ol></div>
+  <div class="steps">
+    <div><span class="n">01</span><span>Build &amp; download a <b>.bin</b> &mdash; patternflow.work &rarr; Build, or an <b>arduino-cli</b> export.</span></div>
+    <div><span class="n">02</span><span>Drop it below. Keep the device powered; it verifies, flashes, and reboots itself.</span></div>
+  </div>
 
-<div id="drop">drop firmware .bin here<br>or click to choose</div>
-<input id="file" type="file" accept=".bin" style="display:none">
-<div id="bar"><div id="fill"></div></div>
-<div id="msg"></div>
+  <div id="armHint">This build requires arming first. On the device: hold <b>K2</b> &rarr; NETWORK, then turn <b>K4</b> &rarr; <b>UPDATE</b>.</div>
+
+  <div id="drop">
+    <span class="big">DROP .BIN HERE</span>
+    <span class="small">or click to choose a file</span>
+  </div>
+  <input id="file" type="file" accept=".bin" style="display:none">
+  <div id="bar"><div id="fill"></div></div>
+  <div id="msg"></div>
+</div>
 
 <script>
 var drop=document.getElementById('drop'),fileIn=document.getElementById('file'),
-    chip=document.getElementById('chip'),bar=document.getElementById('bar'),
-    fill=document.getElementById('fill'),msg=document.getElementById('msg');
+    pill=document.getElementById('pill'),bar=document.getElementById('bar'),
+    fill=document.getElementById('fill'),msg=document.getElementById('msg'),
+    armHint=document.getElementById('armHint');
 var armed=false,busy=false,uploading=false;
-var ARM_HINT='Device is locked. On the device: hold K2 for NETWORK, then turn K4 for UPDATE.';
 
-function setChip(t,c){chip.textContent=t;chip.className=c||''}
+function setPill(t,c){pill.textContent=t;pill.className=c||''}
 function setMsg(t,c){msg.textContent=t;msg.className=c||''}
 
 function poll(){
   if(uploading)return;
   fetch('/update/status',{cache:'no-store'}).then(function(r){return r.json()}).then(function(s){
     armed=s.armed;busy=s.busy;
-    if(busy)setChip('BUSY','warn');
-    else if(armed)setChip('ARMED','ok');
-    else setChip('LOCKED','bad');
+    if(busy)setPill('BUSY','warn');
+    else if(armed)setPill('READY','ok');
+    else setPill('LOCKED','bad');
+    armHint.style.display=(!armed&&!busy)?'block':'none';
     drop.classList.toggle('disabled',!armed||busy);
-  }).catch(function(){setChip('OFFLINE','bad')});
+  }).catch(function(){setPill('OFFLINE','bad')});
 }
 setInterval(poll,2000);poll();
 
@@ -93,9 +116,9 @@ function upload(f){
   if(!/\.bin$/i.test(f.name)){setMsg('That is not a .bin file.','bad');return}
   if(f.size>3*1024*1024){setMsg('Too big for the 3 MB app partition. This looks like a merged full-flash image; upload the app .bin instead.','bad');return}
   if(f.size<200*1024){setMsg('Suspiciously small for Patternflow firmware. Wrong file?','bad');return}
-  if(!armed){setMsg(ARM_HINT,'bad');return}
+  if(!armed){setMsg('Device is locked - see the arming note above.','bad');return}
   uploading=true;
-  setChip('FLASHING','warn');
+  setPill('FLASHING','warn');
   bar.style.display='block';fill.style.width='0%';
   setMsg('Uploading '+f.name+' ('+(f.size/1048576).toFixed(2)+' MB). Keep this tab open and the device powered.');
   var xhr=new XMLHttpRequest();
@@ -128,7 +151,7 @@ function waitForReboot(){
   var t=setInterval(function(){
     if(++tries>30){clearInterval(t);return}
     fetch('/update/status',{cache:'no-store'}).then(function(r){
-      if(r.ok){clearInterval(t);setChip('BACK','ok');setMsg('Device is back online on the new firmware.','ok')}
+      if(r.ok){clearInterval(t);setPill('BACK','ok');setMsg('Device is back online on the new firmware.','ok')}
     }).catch(function(){});
   },2000);
 }

--- a/firmware/patternflow/src/web_update_index.h
+++ b/firmware/patternflow/src/web_update_index.h
@@ -1,0 +1,137 @@
+// ═══════════════════════════════════════════════════════════
+// PatternFlow - Browser self-update page (PROGMEM HTML bundle)
+//
+// Served at http://patternflow.local/update by core_web_update.h.
+// Drop a firmware .bin (the app image the web build service emits, or an
+// arduino-cli export) and the device flashes itself via Update.h.
+//
+// The page polls /update/status so the ARMED/LOCKED chip mirrors the
+// device: the POST endpoint only accepts firmware while the UPDATE screen
+// is open on the device (hold K2 → NETWORK, turn K4). Upload progress is
+// the XHR's own send progress — the device flashes as it receives, so the
+// bar tracks the actual write within a buffer's worth.
+//
+// License: MIT
+// ═══════════════════════════════════════════════════════════
+#pragma once
+#include <pgmspace.h>
+
+const char WEB_UPDATE_HTML[] PROGMEM = R"HTML(<!doctype html>
+<html lang="en"><head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Patternflow Update</title>
+<style>
+  :root{--bg:#0a0a0a;--card:#0d0d0d;--fg:#e8e8e8;--mut:#666;--ln:#1f1f1f;--accent:#5fdb89;--bad:#ff5d5d;--warn:#e8c35f}
+  *{box-sizing:border-box}
+  body{margin:0 auto;background:var(--bg);color:var(--fg);font:13px/1.5 ui-monospace,SFMono-Regular,Menlo,monospace;padding:20px;max-width:560px}
+  h1{font-size:11px;letter-spacing:.4em;opacity:.5;font-weight:normal;margin:0 0 4px}
+  .sub{font-size:11px;color:var(--mut);margin-bottom:20px}
+  a{color:var(--mut)}
+  #chip{position:fixed;top:14px;right:14px;font-size:10px;padding:7px 11px;border:1px solid var(--ln);background:var(--card);letter-spacing:.15em;z-index:10}
+  .ok{color:var(--accent)} .bad{color:var(--bad)} .warn{color:var(--warn)}
+  .section{margin:14px 0;padding:14px;border:1px solid var(--ln);background:var(--card)}
+  .section h2{font-size:10px;letter-spacing:.25em;color:var(--mut);font-weight:normal;text-transform:uppercase;margin:0 0 12px}
+  ol{margin:0;padding-left:18px;color:var(--mut);font-size:12px}
+  ol li{margin:4px 0}
+  ol b{color:var(--fg);font-weight:normal}
+  code{color:var(--fg)}
+  #drop{margin:14px 0;padding:38px 14px;border:1px dashed #333;background:var(--card);text-align:center;color:var(--mut);cursor:pointer;transition:border-color .15s}
+  #drop.hover{border-color:var(--accent);color:var(--fg)}
+  #drop.disabled{opacity:.45}
+  #bar{height:6px;background:#1a1a1a;margin:14px 0 6px;display:none}
+  #fill{height:100%;width:0%;background:var(--accent)}
+  #msg{font-size:12px;min-height:18px;color:var(--mut)}
+  #msg.ok{color:var(--accent)} #msg.bad{color:var(--bad)}
+</style></head><body>
+<h1>PATTERNFLOW &middot; UPDATE</h1>
+<div class="sub">Drop a firmware .bin &mdash; the device flashes itself over the LAN. <a href="/">audio-react &rarr;</a></div>
+<div id="chip">&hellip;</div>
+
+<div class="section"><h2>How</h2>
+<ol>
+<li>Build &amp; download a firmware <b>.bin</b> (patternflow.work &rarr; Build, or an <code>arduino-cli</code> export).</li>
+<li>On the device: hold <b>K2</b> &rarr; NETWORK, then turn <b>K4</b> &rarr; <b>UPDATE</b>. The chip above turns ARMED.</li>
+<li>Drop the file below. Keep the device powered; it reboots itself when done.</li>
+</ol></div>
+
+<div id="drop">drop firmware .bin here<br>or click to choose</div>
+<input id="file" type="file" accept=".bin" style="display:none">
+<div id="bar"><div id="fill"></div></div>
+<div id="msg"></div>
+
+<script>
+var drop=document.getElementById('drop'),fileIn=document.getElementById('file'),
+    chip=document.getElementById('chip'),bar=document.getElementById('bar'),
+    fill=document.getElementById('fill'),msg=document.getElementById('msg');
+var armed=false,busy=false,uploading=false;
+var ARM_HINT='Device is locked. On the device: hold K2 for NETWORK, then turn K4 for UPDATE.';
+
+function setChip(t,c){chip.textContent=t;chip.className=c||''}
+function setMsg(t,c){msg.textContent=t;msg.className=c||''}
+
+function poll(){
+  if(uploading)return;
+  fetch('/update/status',{cache:'no-store'}).then(function(r){return r.json()}).then(function(s){
+    armed=s.armed;busy=s.busy;
+    if(busy)setChip('BUSY','warn');
+    else if(armed)setChip('ARMED','ok');
+    else setChip('LOCKED','bad');
+    drop.classList.toggle('disabled',!armed||busy);
+  }).catch(function(){setChip('OFFLINE','bad')});
+}
+setInterval(poll,2000);poll();
+
+drop.addEventListener('click',function(){if(!uploading)fileIn.click()});
+fileIn.addEventListener('change',function(){if(fileIn.files.length)upload(fileIn.files[0])});
+['dragover','dragenter'].forEach(function(ev){drop.addEventListener(ev,function(e){e.preventDefault();drop.classList.add('hover')})});
+['dragleave','drop'].forEach(function(ev){drop.addEventListener(ev,function(e){e.preventDefault();drop.classList.remove('hover')})});
+drop.addEventListener('drop',function(e){if(!uploading&&e.dataTransfer.files.length)upload(e.dataTransfer.files[0])});
+
+function upload(f){
+  if(uploading)return;
+  if(!/\.bin$/i.test(f.name)){setMsg('That is not a .bin file.','bad');return}
+  if(f.size>3*1024*1024){setMsg('Too big for the 3 MB app partition. This looks like a merged full-flash image; upload the app .bin instead.','bad');return}
+  if(f.size<200*1024){setMsg('Suspiciously small for Patternflow firmware. Wrong file?','bad');return}
+  if(!armed){setMsg(ARM_HINT,'bad');return}
+  uploading=true;
+  setChip('FLASHING','warn');
+  bar.style.display='block';fill.style.width='0%';
+  setMsg('Uploading '+f.name+' ('+(f.size/1048576).toFixed(2)+' MB). Keep this tab open and the device powered.');
+  var xhr=new XMLHttpRequest();
+  xhr.open('POST','/update?size='+f.size);
+  xhr.upload.onprogress=function(e){if(e.lengthComputable)fill.style.width=Math.round(e.loaded*100/e.total)+'%'};
+  xhr.onload=function(){
+    uploading=false;
+    if(xhr.status===200){
+      fill.style.width='100%';
+      setMsg('Flashed. Rebooting - the device should be back in about 10 seconds.','ok');
+      waitForReboot();
+    }else{
+      var t='upload failed ('+xhr.status+')';
+      try{t=JSON.parse(xhr.responseText).error||t}catch(e){}
+      setMsg('Failed: '+t,'bad');
+      bar.style.display='none';
+    }
+  };
+  xhr.onerror=function(){
+    uploading=false;
+    setMsg('Connection lost during upload. The device still runs its old firmware unless it just rebooted - if in doubt, try again.','bad');
+    bar.style.display='none';
+  };
+  var fd=new FormData();fd.append('firmware',f,f.name);
+  xhr.send(fd);
+}
+
+function waitForReboot(){
+  var tries=0;
+  var t=setInterval(function(){
+    if(++tries>30){clearInterval(t);return}
+    fetch('/update/status',{cache:'no-store'}).then(function(r){
+      if(r.ok){clearInterval(t);setChip('BACK','ok');setMsg('Device is back online on the new firmware.','ok')}
+    }).catch(function(){});
+  },2000);
+}
+</script>
+</body></html>
+)HTML";

--- a/web/src/app/api/community/builds/[id]/firmware/route.ts
+++ b/web/src/app/api/community/builds/[id]/firmware/route.ts
@@ -1,21 +1,43 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { artifactDir, getBuild } from "@/lib/community/builds";
-import { preflight, withCors } from "@/lib/community/cors";
 import { communityEnabled } from "@/lib/community/db";
 
 // GET /api/community/builds/[id]/firmware — the built application image.
 //
 // No credential check by design: esp-web-tools fetches this itself, without
 // cookies and possibly cross-origin. The build id is the capability (see the
-// status route). No CORS *rejection* either, for the same reason — the flasher
-// must be able to read it from whichever origin the page was served from.
+// status route).
+//
+// CORS is deliberately PUBLIC (`*`, no credentials) instead of the allowlist
+// the rest of the community API uses: the device's own web console fetches
+// this URL to flash over Wi-Fi (#232 — "Send over Wi-Fi" hands the build off
+// to http://patternflow.local/update), and a LAN device origin — a raw IP,
+// different in every home — is exactly what an allowlist cannot enumerate.
+// Wildcard-without-credentials is safe here because the response needs no
+// cookie and the build id in the URL is the whole capability.
 
-export async function GET(request: Request, context: { params: Promise<{ id: string }> }) {
-  return withCors(request, await handleGet(context));
+const PUBLIC_CORS: Record<string, string> = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Expose-Headers": "Content-Length",
+};
+
+export async function GET(_request: Request, context: { params: Promise<{ id: string }> }) {
+  const response = await handleGet(context);
+  for (const [key, value] of Object.entries(PUBLIC_CORS)) response.headers.set(key, value);
+  return response;
 }
 
-export const OPTIONS = preflight;
+export function OPTIONS() {
+  return new Response(null, {
+    status: 204,
+    headers: {
+      ...PUBLIC_CORS,
+      "Access-Control-Allow-Methods": "GET, OPTIONS",
+      "Access-Control-Max-Age": "86400",
+    },
+  });
+}
 
 async function handleGet(context: { params: Promise<{ id: string }> }) {
   if (!communityEnabled()) {

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -23,7 +23,7 @@
     --ink-muted: #6B655A;
     --ink-faint: #A69F90;
     --rule: #D9D1C0;
-    --sans: 'Inter', ui-sans-serif, system-ui, sans-serif;
+    --sans: 'Inter', 'Pretendard', ui-sans-serif, system-ui, sans-serif;
     --mono: 'JetBrains Mono', ui-monospace, monospace;
     --serif: 'Newsreader', Georgia, serif;
     --led-hex: #E8552E;
@@ -36,7 +36,7 @@
     --pf-rule: #D9D1C0;
     --pf-rule-soft: #E5DDC9;
     --pf-led: #E8552E;
-    --pf-sans: 'Inter', ui-sans-serif, system-ui, -apple-system, sans-serif;
+    --pf-sans: 'Inter', 'Pretendard', ui-sans-serif, system-ui, -apple-system, sans-serif;
     --pf-mono: 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
     --pf-serif: 'Newsreader', Georgia, serif;
     --pf-fs-h2: 34px;

--- a/web/src/app/roadmap/Roadmap.module.css
+++ b/web/src/app/roadmap/Roadmap.module.css
@@ -201,6 +201,7 @@
 
 .mapSvg {
   display: block;
+  overflow: visible;
 }
 
 .tickText,
@@ -208,24 +209,38 @@
 .nowLabel,
 .gateLabel,
 .futureLabel {
-  font-family: var(--pf-mono);
-  letter-spacing: 0.06em;
+  letter-spacing: 0.04em;
   text-transform: uppercase;
 }
 
 .tickText {
-  font-size: 15px;
-  fill: var(--pf-ink-faint);
-}
-
-.laneLabel {
+  font-family: var(--pf-mono);
   font-size: 16px;
+  font-weight: 600;
   fill: var(--pf-ink-muted);
 }
 
-.gridLine {
+.laneLabel {
+  font-family: var(--pf-sans);
+  font-size: 17.5px;
+  font-weight: 600;
+  fill: var(--pf-ink);
+  letter-spacing: -0.01em;
+}
+
+.gridLine,
+.gridLineHorizontal {
   stroke: var(--pf-rule-soft);
   stroke-width: 1;
+  stroke-dasharray: 6 4;
+  opacity: 0.8;
+}
+
+.gridLineVertical {
+  stroke: var(--pf-rule-soft);
+  stroke-width: 1;
+  stroke-dasharray: 4 4;
+  opacity: 0.7;
 }
 
 .futureZone {
@@ -234,8 +249,10 @@
 }
 
 .futureLabel {
-  font-size: 15px;
-  fill: var(--pf-ink-faint);
+  font-family: var(--pf-mono);
+  font-size: 16px;
+  font-weight: 600;
+  fill: var(--pf-ink-muted);
 }
 
 .nowLine {
@@ -246,7 +263,9 @@
 }
 
 .nowLabel {
-  font-size: 15px;
+  font-family: var(--pf-mono);
+  font-size: 16px;
+  font-weight: 700;
   fill: var(--pf-ink);
 }
 

--- a/web/src/app/roadmap/Roadmap.module.css
+++ b/web/src/app/roadmap/Roadmap.module.css
@@ -356,9 +356,10 @@
 .nodeTextSecondary,
 .nodeTextPlannedSecondary,
 .nodeTextSelected {
-  font-family: var(--pf-mono);
-  font-size: 15px;
-  letter-spacing: 0.01em;
+  font-family: var(--pf-sans);
+  font-size: 14px;
+  font-weight: 500;
+  letter-spacing: -0.01em;
   pointer-events: none;
 }
 

--- a/web/src/app/roadmap/Roadmap.module.css
+++ b/web/src/app/roadmap/Roadmap.module.css
@@ -9,20 +9,21 @@
 .topBar {
   display: flex;
   align-items: center;
-  gap: 24px;
-  padding: 14px 24px;
+  gap: 20px;
+  padding: 12px 24px;
   border-bottom: 1px solid var(--pf-rule);
+  background: #fff;
+  z-index: 10;
 }
 
 .mapTitle {
   margin: 0;
-  font-size: 20px;
+  font-size: 19px;
   font-weight: 500;
   letter-spacing: -0.01em;
 }
 
-.back,
-.repoLink {
+.back {
   color: var(--pf-ink);
   font-family: var(--pf-mono);
   font-size: var(--pf-fs-mono);
@@ -31,16 +32,17 @@
   text-transform: uppercase;
 }
 
-.repoLink {
-  color: var(--pf-ink-muted);
-  margin-left: auto;
-}
-
-.back:hover,
-.repoLink:hover {
+.back:hover {
   color: var(--pf-ink);
   text-decoration: underline;
   text-underline-offset: 3px;
+}
+
+.headerRight {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-left: auto;
 }
 
 /* The page IS the canvas: the map fills everything under the top bar. */
@@ -51,19 +53,10 @@
   min-height: 0;
 }
 
-.controls {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  flex-wrap: wrap;
-  gap: 14px;
-  padding: 12px 24px;
-}
-
 .toggleGroup {
   display: inline-flex;
   border: 1px solid var(--pf-rule);
-  border-radius: 8px;
+  border-radius: 6px;
   overflow: hidden;
 }
 
@@ -71,11 +64,11 @@
   appearance: none;
   border: none;
   background: transparent;
-  padding: 9px 20px;
+  padding: 6px 14px;
   color: var(--pf-ink-muted);
   font-family: var(--pf-mono);
-  font-size: 13px;
-  letter-spacing: 0.06em;
+  font-size: 12px;
+  letter-spacing: 0.05em;
   text-transform: uppercase;
   cursor: pointer;
 }

--- a/web/src/app/roadmap/RoadmapMap.tsx
+++ b/web/src/app/roadmap/RoadmapMap.tsx
@@ -72,13 +72,19 @@ const MAX_ZOOM = 1.8;
 const laneY = (lane: LaneId) =>
   TOP + LANES.findIndex((l) => l.id === lane) * LANE_H + LANE_H / 2;
 
+const nodeTitle = (n: RoadmapNode, lang: 'ko' | 'en') =>
+  lang === 'ko' && n.titleKo ? n.titleKo : n.title;
+
+const nodeDetail = (n: RoadmapNode, lang: 'ko' | 'en') =>
+  lang === 'ko' && n.detailKo ? n.detailKo : n.detail;
+
 const nodeWidth = (title: string) => Math.round(title.length * 9.2) + 32;
 
 type PlacedNode = RoadmapNode & { x: number; y: number; w: number };
 
 // Nodes never get squeezed back into the frame — the canvas is pannable, so
 // the drawing just grows to whatever width the layout needs.
-function layoutNodes(detailed: boolean): {
+function layoutNodes(detailed: boolean, lang: 'ko' | 'en'): {
   nodes: PlacedNode[];
   width: number;
   innerW: number;
@@ -86,7 +92,8 @@ function layoutNodes(detailed: boolean): {
   const innerW = (detailed ? DETAILED_W : OVERVIEW_W) - GUTTER - RIGHT_PAD;
   const visible = NODES.filter((n) => detailed || n.level === 1);
   const placed: PlacedNode[] = visible.map((n) => {
-    const w = nodeWidth(n.title);
+    const titleText = nodeTitle(n, lang);
+    const w = nodeWidth(titleText);
     return { ...n, w, x: GUTTER + dateToT(n.date) * innerW - w / 2, y: laneY(n.lane) };
   });
   let maxRight = GUTTER + innerW + RIGHT_PAD;
@@ -104,6 +111,7 @@ function layoutNodes(detailed: boolean): {
 }
 
 export default function RoadmapMap() {
+  const [lang, setLang] = useState<'ko' | 'en'>('ko');
   const [detailed, setDetailed] = useState(false);
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [live, setLive] = useState<RoadmapApiData | null>(null);
@@ -148,7 +156,7 @@ export default function RoadmapMap() {
     };
   }, []);
 
-  const { nodes, width, innerW } = useMemo(() => layoutNodes(detailed), [detailed]);
+  const { nodes, width, innerW } = useMemo(() => layoutNodes(detailed, lang), [detailed, lang]);
   const byId = useMemo(() => new Map(nodes.map((n) => [n.id, n])), [nodes]);
   const selected = selectedId ? byId.get(selectedId) ?? null : null;
 
@@ -311,33 +319,51 @@ export default function RoadmapMap() {
   return (
     <div className={styles.map}>
       <div className={styles.controls}>
+        <div className={styles.toggleGroup} role="group" aria-label="Language">
+          <button
+            type="button"
+            className={`${styles.toggleBtn} ${lang === 'ko' ? styles.toggleOn : ''}`}
+            onClick={() => setLang('ko')}
+          >
+            한글
+          </button>
+          <button
+            type="button"
+            className={`${styles.toggleBtn} ${lang === 'en' ? styles.toggleOn : ''}`}
+            onClick={() => setLang('en')}
+          >
+            ENG
+          </button>
+        </div>
         <div className={styles.toggleGroup} role="group" aria-label="Map detail level">
           <button
             type="button"
             className={`${styles.toggleBtn} ${!detailed ? styles.toggleOn : ''}`}
             onClick={() => setDetailed(false)}
           >
-            Overview
+            {lang === 'ko' ? '개요' : 'Overview'}
           </button>
           <button
             type="button"
             className={`${styles.toggleBtn} ${detailed ? styles.toggleOn : ''}`}
             onClick={() => setDetailed(true)}
           >
-            Detailed
+            {lang === 'ko' ? '상세보기' : 'Detailed'}
           </button>
         </div>
         <div className={styles.legend}>
           <span className={styles.legendItem}>
-            <span className={styles.swatchDone} /> shipped
+            <span className={styles.swatchDone} /> {lang === 'ko' ? '배포됨' : 'shipped'}
           </span>
           <span className={styles.legendItem}>
-            <span className={styles.swatchPlanned} /> planned
+            <span className={styles.swatchPlanned} /> {lang === 'ko' ? '계획됨' : 'planned'}
           </span>
           <span className={styles.legendItem}>
-            <span className={styles.swatchDep} /> dependency
+            <span className={styles.swatchDep} /> {lang === 'ko' ? '의존성' : 'dependency'}
           </span>
-          <span className={styles.legendDrag}>drag to move · scroll to zoom</span>
+          <span className={styles.legendDrag}>
+            {lang === 'ko' ? '드래그로 이동 · 스크롤로 확대/축소' : 'drag to move · scroll to zoom'}
+          </span>
         </div>
         <div className={styles.zoomGroup} role="group" aria-label="Zoom">
           <button
@@ -415,7 +441,7 @@ export default function RoadmapMap() {
               y={TOP - 32}
               textAnchor="middle"
             >
-              future
+              {lang === 'ko' ? '미래 예정' : 'future'}
             </text>
 
             {TICKS.map((tick) => {
@@ -439,7 +465,7 @@ export default function RoadmapMap() {
 
             {LANES.map((lane) => (
               <text key={lane.id} className={styles.laneLabel} x={16} y={laneY(lane.id) + 5}>
-                {lane.label}
+                {lang === 'ko' ? lane.labelKo : lane.label}
               </text>
             ))}
 
@@ -474,7 +500,7 @@ export default function RoadmapMap() {
                   rx={16}
                 />
                 <text className={styles.gateLabel} x={gate.x + 6} y={gate.y - 14}>
-                  v3.0.0 — build release
+                  {lang === 'ko' ? 'v3.0.0 — 빌드 릴리스' : 'v3.0.0 — build release'}
                 </text>
               </g>
             )}
@@ -506,13 +532,12 @@ export default function RoadmapMap() {
               y2={HEIGHT - 24}
             />
             <text className={styles.nowLabel} x={nowX - 10} y={TOP - 32} textAnchor="end">
-              today
+              {lang === 'ko' ? '오늘' : 'today'}
             </text>
 
             {nodes.map((n) => {
               const isSelected = n.id === selectedId;
-              // Level 2 nodes only exist in the detailed view — give them a
-              // visibly secondary color so overview-level nodes keep priority.
+              const titleText = nodeTitle(n, lang);
               const secondary = n.level === 2 && !isSelected;
               const boxClass = isSelected
                 ? styles.nodeSelected
@@ -538,7 +563,7 @@ export default function RoadmapMap() {
                   className={styles.nodeGroup}
                   role="button"
                   tabIndex={0}
-                  aria-label={`${n.title}, ${n.status}`}
+                  aria-label={`${titleText}, ${n.status}`}
                   onClick={() => handleNodeClick(n.id)}
                   onKeyDown={(event) => {
                     if (event.key === 'Enter' || event.key === ' ') {
@@ -561,7 +586,7 @@ export default function RoadmapMap() {
                     y={n.y + 5}
                     textAnchor="middle"
                   >
-                    {n.title}
+                    {titleText}
                   </text>
                 </g>
               );
@@ -583,7 +608,7 @@ export default function RoadmapMap() {
           >
               <div className={styles.popupHead}>
                 <span className={styles.popupDate}>
-                  {selected.status === 'planned' ? 'future' : selected.date}
+                  {selected.status === 'planned' ? (lang === 'ko' ? '미래 예정' : 'future') : selected.date}
                 </span>
                 {selected.gate && <span className={styles.tagGate}>v3.0.0</span>}
                 <button
@@ -595,8 +620,8 @@ export default function RoadmapMap() {
                   ×
                 </button>
               </div>
-              <h2 className={styles.popupTitle}>{selected.title}</h2>
-              <p className={styles.popupBody}>{selected.detail}</p>
+              <h2 className={styles.popupTitle}>{nodeTitle(selected, lang)}</h2>
+              <p className={styles.popupBody}>{nodeDetail(selected, lang)}</p>
               {(selected.links?.length || selectedIssues.length > 0) && (
                 <div className={styles.popupLinks}>
                   {selected.links?.map((link) => (
@@ -619,9 +644,9 @@ export default function RoadmapMap() {
         )}
 
         <p className={styles.mapCaption}>
-          Hardware and guides gather into the v3.0.0 build release — what people physically build
-          from gets frozen per release. Firmware and pattern tools ship continuously. Planned
-          items are intentions, not promises.
+          {lang === 'ko'
+            ? '하드웨어와 가이드는 v3.0.0 빌드 릴리스로 통합 동결됩니다. 펌웨어와 패턴 도구는 지속적으로 배포되며, 예정 항목은 확정 고정이 아닌 개발 방향성입니다.'
+            : 'Hardware and guides gather into the v3.0.0 build release — what people physically build from gets frozen per release. Firmware and pattern tools ship continuously. Planned items are intentions, not promises.'}
         </p>
       </div>
     </div>

--- a/web/src/app/roadmap/RoadmapMap.tsx
+++ b/web/src/app/roadmap/RoadmapMap.tsx
@@ -208,6 +208,38 @@ export default function RoadmapMap() {
     setZoom(nz);
   };
 
+  useEffect(() => {
+    const el = canvasRef.current;
+    if (!el) return;
+
+    const handleWheel = (event: WheelEvent) => {
+      event.preventDefault();
+      const rect = el.getBoundingClientRect();
+      const cursorX = event.clientX - rect.left;
+      const cursorY = event.clientY - rect.top;
+
+      const zoomFactor = event.deltaY < 0 ? 1.15 : 0.87;
+
+      setZoom((currentZoom) => {
+        const nextZoom = Math.min(MAX_ZOOM, Math.max(MIN_ZOOM, Math.round(currentZoom * zoomFactor * 100) / 100));
+        if (nextZoom === currentZoom) return currentZoom;
+
+        setPan((currentPan) => {
+          const newX = cursorX - ((cursorX - currentPan.x) / currentZoom) * nextZoom;
+          const newY = cursorY - ((cursorY - currentPan.y) / currentZoom) * nextZoom;
+          return clampPan(newX, newY, nextZoom);
+        });
+
+        return nextZoom;
+      });
+    };
+
+    el.addEventListener('wheel', handleWheel, { passive: false });
+    return () => {
+      el.removeEventListener('wheel', handleWheel);
+    };
+  }, [width, zoom]);
+
   const onPointerDown = (event: React.PointerEvent<HTMLDivElement>) => {
     dragRef.current = {
       active: true,
@@ -305,7 +337,7 @@ export default function RoadmapMap() {
           <span className={styles.legendItem}>
             <span className={styles.swatchDep} /> dependency
           </span>
-          <span className={styles.legendDrag}>drag to move</span>
+          <span className={styles.legendDrag}>drag to move · scroll to zoom</span>
         </div>
         <div className={styles.zoomGroup} role="group" aria-label="Zoom">
           <button

--- a/web/src/app/roadmap/RoadmapMap.tsx
+++ b/web/src/app/roadmap/RoadmapMap.tsx
@@ -78,7 +78,22 @@ const nodeTitle = (n: RoadmapNode, lang: 'ko' | 'en') =>
 const nodeDetail = (n: RoadmapNode, lang: 'ko' | 'en') =>
   lang === 'ko' && n.detailKo ? n.detailKo : n.detail;
 
-const nodeWidth = (title: string) => Math.round(title.length * 9.2) + 32;
+const nodeWidth = (title: string) => {
+  let charLen = 0;
+  for (let i = 0; i < title.length; i += 1) {
+    const code = title.charCodeAt(i);
+    if (
+      (code >= 0xac00 && code <= 0xd7a3) ||
+      (code >= 0x1100 && code <= 0x11ff) ||
+      (code >= 0x3130 && code <= 0x318f)
+    ) {
+      charLen += 14.5;
+    } else {
+      charLen += 8.2;
+    }
+  }
+  return Math.round(charLen) + 38;
+};
 
 type PlacedNode = RoadmapNode & { x: number; y: number; w: number };
 

--- a/web/src/app/roadmap/RoadmapMap.tsx
+++ b/web/src/app/roadmap/RoadmapMap.tsx
@@ -643,11 +643,6 @@ export default function RoadmapMap() {
           </div>
         )}
 
-        <p className={styles.mapCaption}>
-          {lang === 'ko'
-            ? '하드웨어와 가이드는 v3.0.0 빌드 릴리스로 통합 동결됩니다. 펌웨어와 패턴 도구는 지속적으로 배포되며, 예정 항목은 확정 고정이 아닌 개발 방향성입니다.'
-            : 'Hardware and guides gather into the v3.0.0 build release — what people physically build from gets frozen per release. Firmware and pattern tools ship continuously. Planned items are intentions, not promises.'}
-        </p>
       </div>
     </div>
   );

--- a/web/src/app/roadmap/RoadmapMap.tsx
+++ b/web/src/app/roadmap/RoadmapMap.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import Link from 'next/link';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import styles from './Roadmap.module.css';
 import {
@@ -333,80 +334,46 @@ export default function RoadmapMap() {
 
   return (
     <div className={styles.map}>
-      <div className={styles.controls}>
-        <div className={styles.toggleGroup} role="group" aria-label="Language">
-          <button
-            type="button"
-            className={`${styles.toggleBtn} ${lang === 'ko' ? styles.toggleOn : ''}`}
-            onClick={() => setLang('ko')}
-          >
-            한글
-          </button>
-          <button
-            type="button"
-            className={`${styles.toggleBtn} ${lang === 'en' ? styles.toggleOn : ''}`}
-            onClick={() => setLang('en')}
-          >
-            ENG
-          </button>
+      <header className={styles.topBar}>
+        <Link className={styles.back} href="/">
+          ← Patternflow
+        </Link>
+        <h1 className={styles.mapTitle}>Project map</h1>
+        <div className={styles.headerRight}>
+          <div className={styles.toggleGroup} role="group" aria-label="Language">
+            <button
+              type="button"
+              className={`${styles.toggleBtn} ${lang === 'ko' ? styles.toggleOn : ''}`}
+              onClick={() => setLang('ko')}
+            >
+              한글
+            </button>
+            <button
+              type="button"
+              className={`${styles.toggleBtn} ${lang === 'en' ? styles.toggleOn : ''}`}
+              onClick={() => setLang('en')}
+            >
+              ENG
+            </button>
+          </div>
+          <div className={styles.toggleGroup} role="group" aria-label="Map detail level">
+            <button
+              type="button"
+              className={`${styles.toggleBtn} ${!detailed ? styles.toggleOn : ''}`}
+              onClick={() => setDetailed(false)}
+            >
+              {lang === 'ko' ? '개요' : 'Overview'}
+            </button>
+            <button
+              type="button"
+              className={`${styles.toggleBtn} ${detailed ? styles.toggleOn : ''}`}
+              onClick={() => setDetailed(true)}
+            >
+              {lang === 'ko' ? '상세보기' : 'Detailed'}
+            </button>
+          </div>
         </div>
-        <div className={styles.toggleGroup} role="group" aria-label="Map detail level">
-          <button
-            type="button"
-            className={`${styles.toggleBtn} ${!detailed ? styles.toggleOn : ''}`}
-            onClick={() => setDetailed(false)}
-          >
-            {lang === 'ko' ? '개요' : 'Overview'}
-          </button>
-          <button
-            type="button"
-            className={`${styles.toggleBtn} ${detailed ? styles.toggleOn : ''}`}
-            onClick={() => setDetailed(true)}
-          >
-            {lang === 'ko' ? '상세보기' : 'Detailed'}
-          </button>
-        </div>
-        <div className={styles.legend}>
-          <span className={styles.legendItem}>
-            <span className={styles.swatchDone} /> {lang === 'ko' ? '배포됨' : 'shipped'}
-          </span>
-          <span className={styles.legendItem}>
-            <span className={styles.swatchPlanned} /> {lang === 'ko' ? '계획됨' : 'planned'}
-          </span>
-          <span className={styles.legendItem}>
-            <span className={styles.swatchDep} /> {lang === 'ko' ? '의존성' : 'dependency'}
-          </span>
-          <span className={styles.legendDrag}>
-            {lang === 'ko' ? '드래그로 이동 · 스크롤로 확대/축소' : 'drag to move · scroll to zoom'}
-          </span>
-        </div>
-        <div className={styles.zoomGroup} role="group" aria-label="Zoom">
-          <button
-            type="button"
-            className={styles.zoomBtn}
-            aria-label="Zoom out"
-            onClick={() => zoomTo(zoom - 0.2)}
-          >
-            −
-          </button>
-          <button
-            type="button"
-            className={styles.zoomVal}
-            title="Reset zoom"
-            onClick={() => zoomTo(1)}
-          >
-            {Math.round(zoom * 100)}%
-          </button>
-          <button
-            type="button"
-            className={styles.zoomBtn}
-            aria-label="Zoom in"
-            onClick={() => zoomTo(zoom + 0.2)}
-          >
-            +
-          </button>
-        </div>
-      </div>
+      </header>
 
       <div className={styles.viewport}>
         <div

--- a/web/src/app/roadmap/RoadmapMap.tsx
+++ b/web/src/app/roadmap/RoadmapMap.tsx
@@ -24,24 +24,28 @@ type RoadmapApiData = { issues: LiveIssue[]; error?: string };
 // Piecewise time scale. Only the past gets month ticks; everything after
 // "today" is a single future region ordered by intention, not by fake dates.
 const ANCHORS: [number, number][] = [
-  [Date.UTC(2026, 0, 1), 0.01],
-  [Date.UTC(2026, 3, 1), 0.09],
-  [Date.UTC(2026, 4, 1), 0.26],
-  [Date.UTC(2026, 5, 1), 0.43],
-  [Date.UTC(2026, 6, 1), 0.6],
-  [Date.UTC(2026, 7, 1), 0.72],
-  [Date.UTC(2026, 8, 1), 0.82],
-  [Date.UTC(2026, 9, 1), 0.9],
-  [Date.UTC(2026, 10, 1), 0.96],
+  [Date.UTC(2026, 0, 1), 0.02],
+  [Date.UTC(2026, 1, 1), 0.10],
+  [Date.UTC(2026, 2, 1), 0.18],
+  [Date.UTC(2026, 3, 1), 0.28],
+  [Date.UTC(2026, 4, 1), 0.42],
+  [Date.UTC(2026, 5, 1), 0.56],
+  [Date.UTC(2026, 6, 1), 0.68],
+  [Date.UTC(2026, 7, 1), 0.78],
+  [Date.UTC(2026, 8, 1), 0.86],
+  [Date.UTC(2026, 9, 1), 0.92],
+  [Date.UTC(2026, 10, 1), 0.97],
   [Date.UTC(2026, 11, 1), 1.0],
 ];
 
 // No "Jul" tick — the today line sits right on it and marks July by itself.
-const TICKS: { label: string; utc: number }[] = [
-  { label: 'Jan', utc: Date.UTC(2026, 0, 1) },
-  { label: 'Apr', utc: Date.UTC(2026, 3, 1) },
-  { label: 'May', utc: Date.UTC(2026, 4, 1) },
-  { label: 'Jun', utc: Date.UTC(2026, 5, 1) },
+const TICKS: { label: string; labelKo: string; utc: number }[] = [
+  { label: 'Jan', labelKo: '1월', utc: Date.UTC(2026, 0, 1) },
+  { label: 'Feb', labelKo: '2월', utc: Date.UTC(2026, 1, 1) },
+  { label: 'Mar', labelKo: '3월', utc: Date.UTC(2026, 2, 1) },
+  { label: 'Apr', labelKo: '4월', utc: Date.UTC(2026, 3, 1) },
+  { label: 'May', labelKo: '5월', utc: Date.UTC(2026, 4, 1) },
+  { label: 'Jun', labelKo: '6월', utc: Date.UTC(2026, 5, 1) },
 ];
 
 function dateToT(date: string): number {
@@ -58,8 +62,8 @@ function dateToT(date: string): number {
 // The detailed view shows ~twice the nodes, so the whole time axis stretches
 // with it — ticks, today line and future zone all use the same scale, keeping
 // boxes near their real dates instead of just sliding off the axis.
-const OVERVIEW_W = 1700;
-const DETAILED_W = 2500;
+const OVERVIEW_W = 2000;
+const DETAILED_W = 3400;
 const GUTTER = 170;
 const RIGHT_PAD = 60;
 const TOP = 84;
@@ -116,8 +120,12 @@ function layoutNodes(detailed: boolean, lang: 'ko' | 'en'): {
   for (const lane of LANES) {
     const row = placed.filter((n) => n.lane === lane.id).sort((a, b) => a.x - b.x);
     for (let i = 1; i < row.length; i += 1) {
-      const minX = row[i - 1].x + row[i - 1].w + 16;
-      if (row[i].x < minX) row[i].x = minX;
+      const prev = row[i - 1];
+      const current = row[i];
+      const minX = prev.x + prev.w + 18;
+      if (current.x < minX) {
+        current.x = minX;
+      }
     }
     for (const n of row) {
       maxRight = Math.max(maxRight, n.x + n.w + RIGHT_PAD);
@@ -172,7 +180,10 @@ export default function RoadmapMap() {
     };
   }, []);
 
-  const { nodes, width, innerW } = useMemo(() => layoutNodes(detailed, lang), [detailed, lang]);
+  const { nodes, width, innerW } = useMemo(
+    () => layoutNodes(detailed, lang),
+    [detailed, lang],
+  );
   const byId = useMemo(() => new Map(nodes.map((n) => [n.id, n])), [nodes]);
   const selected = selectedId ? byId.get(selectedId) ?? null : null;
 
@@ -307,6 +318,14 @@ export default function RoadmapMap() {
     setSelectedId((current) => (current === id ? null : id));
   };
 
+  const onCanvasClick = (event: React.MouseEvent<HTMLDivElement>) => {
+    if (dragRef.current.moved) return;
+    const target = event.target as HTMLElement | SVGElement;
+    if (!target.closest(`.${styles.nodeGroup}`) && !target.closest(`.${styles.popup}`)) {
+      setSelectedId(null);
+    }
+  };
+
   const selectedIssues =
     selected?.issues && live
       ? live.issues.filter((issue) => selected.issues?.includes(issue.number))
@@ -331,6 +350,12 @@ export default function RoadmapMap() {
     const maxHeight = Math.max(160, ch - top - margin);
     popupPos = { left, top, maxHeight };
   }
+
+  // Sticky elements positioning:
+  // Lane labels stay pinned to the left edge of the viewport when panning horizontally
+  const stickyLaneX = Math.max(16, (16 - pan.x) / zoom);
+  // Timeline ticks and Today/Future labels stay pinned to the top edge of the canvas when panning vertically
+  const stickyHeaderY = Math.max(TOP - 32, (18 - pan.y) / zoom);
 
   return (
     <div className={styles.map}>
@@ -383,6 +408,7 @@ export default function RoadmapMap() {
           onPointerMove={onPointerMove}
           onPointerUp={onPointerUp}
           onPointerCancel={onPointerUp}
+          onClick={onCanvasClick}
         >
           <div
             className={styles.layer}
@@ -410,47 +436,54 @@ export default function RoadmapMap() {
               </marker>
             </defs>
 
+            {/* Infinite Seamless Horizontal Lane Dividers */}
+            {Array.from({ length: 24 }, (_, i) => i - 6).map((idx) => {
+              const y = TOP + idx * LANE_H;
+              return (
+                <line
+                  key={`lane-divider-${idx}`}
+                  className={styles.gridLineHorizontal}
+                  x1={-5000}
+                  y1={y}
+                  x2={10000}
+                  y2={y}
+                />
+              );
+            })}
+
             <rect
               className={styles.futureZone}
               x={nowX}
-              y={TOP - 16}
-              width={width - nowX - 8}
-              height={HEIGHT - TOP - 8}
+              y={-2000}
+              width={12000}
+              height={7000}
             />
-            <text
-              className={styles.futureLabel}
-              x={nowX + (width - nowX) / 2}
-              y={TOP - 32}
-              textAnchor="middle"
-            >
-              {lang === 'ko' ? '미래 예정' : 'future'}
-            </text>
 
+            {/* Infinite Seamless Vertical Month Ticks */}
             {TICKS.map((tick) => {
               const x =
                 GUTTER + dateToT(new Date(tick.utc).toISOString().slice(0, 10)) * innerW;
               return (
-                <g key={tick.label}>
-                  <line
-                    className={styles.gridLine}
-                    x1={x}
-                    y1={TOP - 16}
-                    x2={x}
-                    y2={HEIGHT - 24}
-                  />
-                  <text className={styles.tickText} x={x} y={TOP - 32} textAnchor="middle">
-                    {tick.label}
-                  </text>
-                </g>
+                <line
+                  key={`grid-line-${tick.label}`}
+                  className={styles.gridLineVertical}
+                  x1={x}
+                  y1={-2000}
+                  x2={x}
+                  y2={5000}
+                />
               );
             })}
 
-            {LANES.map((lane) => (
-              <text key={lane.id} className={styles.laneLabel} x={16} y={laneY(lane.id) + 5}>
-                {lang === 'ko' ? lane.labelKo : lane.label}
-              </text>
-            ))}
+            <line
+              className={styles.nowLine}
+              x1={nowX}
+              y1={-2000}
+              x2={nowX}
+              y2={5000}
+            />
 
+            {/* 2. Threads & dependency edges BEHIND nodes */}
             {LANES.map((lane) => {
               const row = nodes
                 .filter((n) => n.lane === lane.id)
@@ -506,17 +539,7 @@ export default function RoadmapMap() {
               );
             })}
 
-            <line
-              className={styles.nowLine}
-              x1={nowX}
-              y1={TOP - 16}
-              x2={nowX}
-              y2={HEIGHT - 24}
-            />
-            <text className={styles.nowLabel} x={nowX - 10} y={TOP - 32} textAnchor="end">
-              {lang === 'ko' ? '오늘' : 'today'}
-            </text>
-
+            {/* 3. Render Nodes */}
             {nodes.map((n) => {
               const isSelected = n.id === selectedId;
               const titleText = nodeTitle(n, lang);
@@ -573,6 +596,54 @@ export default function RoadmapMap() {
                 </g>
               );
             })}
+
+            {/* 4. Sticky Timeline Header Text ON TOP of nodes */}
+            <text
+              className={styles.futureLabel}
+              x={nowX + (width - nowX) / 2}
+              y={stickyHeaderY}
+              textAnchor="middle"
+            >
+              {lang === 'ko' ? '계획' : 'future'}
+            </text>
+
+            {TICKS.map((tick) => {
+              const x =
+                GUTTER + dateToT(new Date(tick.utc).toISOString().slice(0, 10)) * innerW;
+              return (
+                <text key={`tick-text-${tick.label}`} className={styles.tickText} x={x} y={stickyHeaderY} textAnchor="middle">
+                  {lang === 'ko' ? tick.labelKo : tick.label}
+                </text>
+              );
+            })}
+
+            <text className={styles.nowLabel} x={nowX - 10} y={stickyHeaderY} textAnchor="end">
+              {lang === 'ko' ? '현재' : 'today'}
+            </text>
+
+            {/* 5. Sticky Lane Labels ON TOP of nodes with frosted backdrop */}
+            {LANES.map((lane) => {
+              const laneName = lang === 'ko' ? lane.labelKo : lane.label;
+              const labelW = Math.round(laneName.length * (lang === 'ko' ? 14.5 : 11)) + 20;
+              return (
+                <g key={`sticky-lane-${lane.id}`}>
+                  <rect
+                    x={stickyLaneX - 8}
+                    y={laneY(lane.id) - 15}
+                    width={labelW}
+                    height={28}
+                    rx={6}
+                    fill="#fbf8f2"
+                    fillOpacity={0.94}
+                    stroke="var(--pf-rule)"
+                    strokeWidth={0.8}
+                  />
+                  <text className={styles.laneLabel} x={stickyLaneX} y={laneY(lane.id) + 5}>
+                    {laneName}
+                  </text>
+                </g>
+              );
+            })}
           </svg>
           </div>
         </div>
@@ -590,7 +661,7 @@ export default function RoadmapMap() {
           >
               <div className={styles.popupHead}>
                 <span className={styles.popupDate}>
-                  {selected.status === 'planned' ? (lang === 'ko' ? '미래 예정' : 'future') : selected.date}
+                  {selected.status === 'planned' ? (lang === 'ko' ? '계획' : 'future') : selected.date}
                 </span>
                 {selected.gate && <span className={styles.tagGate}>v3.0.0</span>}
                 <button

--- a/web/src/app/roadmap/RoadmapMap.tsx
+++ b/web/src/app/roadmap/RoadmapMap.tsx
@@ -21,19 +21,19 @@ type LiveIssue = {
 
 type RoadmapApiData = { issues: LiveIssue[]; error?: string };
 
-// Piecewise time scale. Only the past gets month ticks; everything after
-// "today" is a single future region ordered by intention, not by fake dates.
+// Density-calibrated time scale: compacts empty early months (Jan–Mar) & May–June
+// so nodes flow continuously without empty gaps, reserving room for dense April & July.
 const ANCHORS: [number, number][] = [
   [Date.UTC(2026, 0, 1), 0.02],
-  [Date.UTC(2026, 1, 1), 0.10],
-  [Date.UTC(2026, 2, 1), 0.18],
-  [Date.UTC(2026, 3, 1), 0.28],
-  [Date.UTC(2026, 4, 1), 0.42],
-  [Date.UTC(2026, 5, 1), 0.56],
-  [Date.UTC(2026, 6, 1), 0.68],
-  [Date.UTC(2026, 7, 1), 0.78],
-  [Date.UTC(2026, 8, 1), 0.86],
-  [Date.UTC(2026, 9, 1), 0.92],
+  [Date.UTC(2026, 1, 1), 0.06],
+  [Date.UTC(2026, 2, 1), 0.10],
+  [Date.UTC(2026, 3, 1), 0.16],
+  [Date.UTC(2026, 4, 1), 0.35],
+  [Date.UTC(2026, 5, 1), 0.48],
+  [Date.UTC(2026, 6, 1), 0.62],
+  [Date.UTC(2026, 7, 1), 0.80],
+  [Date.UTC(2026, 8, 1), 0.87],
+  [Date.UTC(2026, 9, 1), 0.93],
   [Date.UTC(2026, 10, 1), 0.97],
   [Date.UTC(2026, 11, 1), 1.0],
 ];
@@ -59,19 +59,14 @@ function dateToT(date: string): number {
   return ANCHORS[ANCHORS.length - 1][1];
 }
 
-// The detailed view shows ~twice the nodes, so the whole time axis stretches
-// with it — ticks, today line and future zone all use the same scale, keeping
-// boxes near their real dates instead of just sliding off the axis.
-const OVERVIEW_W = 2000;
-const DETAILED_W = 3400;
 const GUTTER = 170;
 const RIGHT_PAD = 60;
 const TOP = 84;
 const LANE_H = 112;
 const NODE_H = 44;
-const HEIGHT = TOP + LANES.length * LANE_H + 32;
+const HEIGHT = TOP + LANES.length * LANE_H + 120;
 const POPUP_W = 360;
-const MIN_ZOOM = 0.6;
+const MIN_ZOOM = 0.4;
 const MAX_ZOOM = 1.8;
 
 const laneY = (lane: LaneId) =>
@@ -102,14 +97,14 @@ const nodeWidth = (title: string) => {
 
 type PlacedNode = RoadmapNode & { x: number; y: number; w: number };
 
-// Nodes never get squeezed back into the frame — the canvas is pannable, so
-// the drawing just grows to whatever width the layout needs.
-function layoutNodes(detailed: boolean, lang: 'ko' | 'en'): {
+// Responsive layout scaling width smoothly to viewport size while preventing overlap.
+function layoutNodes(detailed: boolean, lang: 'ko' | 'en', containerW: number): {
   nodes: PlacedNode[];
   width: number;
   innerW: number;
 } {
-  const innerW = (detailed ? DETAILED_W : OVERVIEW_W) - GUTTER - RIGHT_PAD;
+  const baseW = Math.max(containerW * 1.35, detailed ? 3400 : 2100);
+  const innerW = baseW - GUTTER - RIGHT_PAD;
   const visible = NODES.filter((n) => detailed || n.level === 1);
   const placed: PlacedNode[] = visible.map((n) => {
     const titleText = nodeTitle(n, lang);
@@ -181,8 +176,8 @@ export default function RoadmapMap() {
   }, []);
 
   const { nodes, width, innerW } = useMemo(
-    () => layoutNodes(detailed, lang),
-    [detailed, lang],
+    () => layoutNodes(detailed, lang, canvasSize.w),
+    [detailed, lang, canvasSize.w],
   );
   const byId = useMemo(() => new Map(nodes.map((n) => [n.id, n])), [nodes]);
   const selected = selectedId ? byId.get(selectedId) ?? null : null;
@@ -222,11 +217,17 @@ export default function RoadmapMap() {
     const ch = el ? el.clientHeight : HEIGHT;
     const drawW = width * z;
     const drawH = HEIGHT * z;
-    // When the canvas is bigger than the drawing, let the drawing sit
-    // anywhere inside it; otherwise pan within the drawing plus some slack.
+    // Spacious, free-panning bounds allowing users to move the map
+    // up/down/left/right freely without feeling clamped or trapped at borders.
+    const slackX = Math.max(800, cw * 0.75);
+    const slackY = Math.max(600, ch * 0.75);
+    const minX = Math.min(0, cw - drawW) - slackX;
+    const maxX = Math.max(0, cw - drawW) + slackX;
+    const minY = Math.min(0, ch - drawH) - slackY;
+    const maxY = Math.max(0, ch - drawH) + slackY;
     return {
-      x: Math.min(Math.max(0, cw - drawW) + 60, Math.max(Math.min(0, cw - drawW) - 60, x)),
-      y: Math.min(Math.max(0, ch - drawH) + 40, Math.max(Math.min(0, ch - drawH) - 40, y)),
+      x: Math.min(maxX, Math.max(minX, x)),
+      y: Math.min(maxY, Math.max(minY, y)),
     };
   };
 

--- a/web/src/app/roadmap/page.tsx
+++ b/web/src/app/roadmap/page.tsx
@@ -1,8 +1,5 @@
-import Link from 'next/link';
 import RoadmapMap from './RoadmapMap';
 import styles from './Roadmap.module.css';
-
-const GITHUB_ISSUES_URL = 'https://github.com/engmung/Patternflow/issues';
 
 export const metadata = {
   title: 'Project map — Patternflow',
@@ -13,13 +10,6 @@ export const metadata = {
 export default function RoadmapPage() {
   return (
     <main className={styles.fullShell}>
-      <header className={styles.topBar}>
-        <Link className={styles.back} href="/">
-          ← Patternflow
-        </Link>
-        <h1 className={styles.mapTitle}>Project map</h1>
-      </header>
-
       <RoadmapMap />
     </main>
   );

--- a/web/src/app/roadmap/page.tsx
+++ b/web/src/app/roadmap/page.tsx
@@ -18,9 +18,6 @@ export default function RoadmapPage() {
           ← Patternflow
         </Link>
         <h1 className={styles.mapTitle}>Project map</h1>
-        <a className={styles.repoLink} href={GITHUB_ISSUES_URL} target="_blank" rel="noreferrer">
-          Open issues on GitHub
-        </a>
       </header>
 
       <RoadmapMap />

--- a/web/src/app/roadmap/roadmap-data.ts
+++ b/web/src/app/roadmap/roadmap-data.ts
@@ -39,6 +39,17 @@ const REPO = 'https://github.com/engmung/Patternflow';
 export const NODES: RoadmapNode[] = [
   // PCB
   {
+    id: 'pcb-proto-v0',
+    lane: 'pcb',
+    date: '2026-03-29',
+    title: 'First hardware prototype',
+    status: 'done',
+    level: 2,
+    detail:
+      'First hand-wired prototype: LED matrix + ESP32 + 4 potentiometers assembled in the club room, bringing Patternflow out of the web browser and into physical space at Mapo Saebit Cultural Forest.',
+    links: [{ label: 'Journal (v1 in 30 days)', href: 'https://patternflow.work/journal/v1-30-days' }],
+  },
+  {
     id: 'pcb-v1',
     lane: 'pcb',
     date: '2026-04-26',

--- a/web/src/app/roadmap/roadmap-data.ts
+++ b/web/src/app/roadmap/roadmap-data.ts
@@ -6,7 +6,7 @@
 // things people physically build from. Software ships continuously and is
 // never gated.
 
-export type LaneId = 'pcb' | 'case' | 'guides' | 'firmware' | 'tools' | 'community';
+export type LaneId = 'pcb' | 'case' | 'guides' | 'firmware' | 'tools' | 'community' | 'media';
 
 export type RoadmapNode = {
   id: string;
@@ -34,6 +34,7 @@ export const LANES: { id: LaneId; label: string; labelKo: string }[] = [
   { id: 'firmware', label: 'Firmware', labelKo: '펌웨어' },
   { id: 'tools', label: 'Pattern tools', labelKo: '패턴 편집기' },
   { id: 'community', label: 'Community', labelKo: '커뮤니티' },
+  { id: 'media', label: 'Media & Press', labelKo: '언론 & 미디어' },
 ];
 
 const REPO = 'https://github.com/engmung/Patternflow';
@@ -567,25 +568,9 @@ export const NODES: RoadmapNode[] = [
 
   // Community & business
   {
-    id: 'biz-pcbway-order',
-    lane: 'community',
-    date: '2026-04-21',
-    title: 'First PCBWay order',
-    titleKo: '첫 PCBWay 스폰서십',
-    status: 'done',
-    level: 1,
-    detail:
-      'PCBWay sponsorship partnership: PCBWay reached out on Reddit and sponsored the first PCB prototype order, initiating ongoing hardware manufacturing support.',
-    detailKo:
-      '레딧 게시글을 본 PCBWay에서 패턴플로우의 가능성을 알아보고 첫 PCB 제작 전액 스폰서십을 제안. 프로젝트가 아이디어를 넘어 하드웨어 제조 단계로 도약한 순간.',
-    links: [
-      { label: 'Journal (v1 in 30 days)', href: 'https://patternflow.work/journal/v1-30-days' },
-    ],
-  },
-  {
     id: 'biz-reddit',
     lane: 'community',
-    date: '2026-04-23',
+    date: '2026-04-21',
     title: 'Reddit launch',
     titleKo: '레딧 프로젝트 공개',
     status: 'done',
@@ -598,6 +583,22 @@ export const NODES: RoadmapNode[] = [
       { label: 'Reddit Viral Post #1', href: 'https://www.reddit.com/r/arduino/comments/1so9er5/built_a_4knob_generative_pattern_controller_with/' },
       { label: 'Reddit PCB Update #2', href: 'https://www.reddit.com/r/arduino/comments/1szettd/12_days_later_pcb_done_rotary_encoders_done_fully/' },
       { label: 'Journal (Me and Patternflow)', href: 'https://patternflow.work/journal/me-and-patternflow' },
+    ],
+  },
+  {
+    id: 'biz-pcbway-order',
+    lane: 'community',
+    date: '2026-04-26',
+    title: 'First PCBWay order',
+    titleKo: '첫 PCBWay 스폰서십',
+    status: 'done',
+    level: 2,
+    detail:
+      'PCBWay sponsorship partnership: PCBWay reached out on Reddit and sponsored the first PCB prototype order, initiating ongoing hardware manufacturing support.',
+    detailKo:
+      '레딧 게시글을 본 PCBWay에서 패턴플로우의 가능성을 알아보고 첫 PCB 제작 전액 스폰서십을 제안. 프로젝트가 아이디어를 넘어 하드웨어 제조 단계로 도약한 순간.',
+    links: [
+      { label: 'Journal (v1 in 30 days)', href: 'https://patternflow.work/journal/v1-30-days' },
     ],
   },
   {
@@ -633,6 +634,105 @@ export const NODES: RoadmapNode[] = [
       { label: 'Crowd Supply Page', href: 'https://www.crowdsupply.com/engmung/patternflow' },
       { label: 'Journal (refocus)', href: 'https://patternflow.work/journal/refocus' },
     ],
+  },
+  // Media & Press
+  {
+    id: 'media-hackster-1',
+    lane: 'media',
+    date: '2026-05-02',
+    title: 'Hackster.io #1',
+    titleKo: 'Hackster.io (1차 피처)',
+    status: 'done',
+    level: 1,
+    detail:
+      'Hackster.io published an organic feature article titled "You\'ll Want This LED Pattern Generator on Your Desk" by Gareth Halfacree, published right after Patternflow\'s first viral Reddit post.',
+    detailKo:
+      '첫 레딧 포스트 바이럴 직후 Gareth Halfacree 기자가 보도한 Hackster.io 1차 자발적 언론 피처 기사 ("You\'ll Want This LED Pattern Generator on Your Desk"). 4개 노브 하드웨어 인터페이스와 제너러티브 알고리즘에 주목.',
+    links: [{ label: 'Hackster.io Article #1', href: 'https://www.hackster.io/news/you-ll-want-this-led-pattern-generator-on-your-desk-007c411e74e4' }],
+  },
+  {
+    id: 'media-twitter-viral',
+    lane: 'media',
+    date: '2026-05-12',
+    title: 'Twitter/X Viral',
+    titleKo: '트위터(X) 자발적 바이럴',
+    status: 'done',
+    level: 2,
+    detail:
+      'Spontaneous viral tweet on May 12, 2026 by third-party creator (@Inspector_9) showcasing Patternflow\'s visual patterns (noting author\'s name misspelled as "Seung-hun Lee").',
+    detailKo:
+      '5월 12일 해외 유저(@Inspector_9)가 작성한 트위터(X) 자발적 소개 포스트 바이럴. 제작자명이 \'이승헌\'으로 오기되었으나 유저들의 자발적 대량 공유로 글로벌 트래픽 유입 형성.',
+    links: [{ label: 'Twitter/X Post (@Inspector_9)', href: 'https://x.com/Inspector_9/status/2053926198049226794' }],
+  },
+  {
+    id: 'media-yanko',
+    lane: 'media',
+    date: '2026-05-14',
+    title: 'Yanko Design',
+    titleKo: '얀코디자인 (Yanko Design)',
+    status: 'done',
+    level: 2,
+    detail:
+      'Featured on May 14, 2026 on Yanko Design\'s official Instagram (@yankodesign), highlighting Patternflow\'s tactile industrial enclosure design and light matrix interaction.',
+    detailKo:
+      '5월 14일 글로벌 인더스트리얼 디자인 매체 얀코디자인(Yanko Design) 공식 인스타그램(@yankodesign) 자발적 프로젝트 피처 게시글 게재.',
+    links: [{ label: 'Yanko Design Instagram', href: 'https://www.instagram.com/p/DYUYZzxMBa6/' }],
+  },
+  {
+    id: 'media-hackster-2',
+    lane: 'media',
+    date: '2026-05-18',
+    title: 'Hackster.io #2',
+    titleKo: 'Hackster.io (2차 피처)',
+    status: 'done',
+    level: 2,
+    detail:
+      'Hackster.io published an organic follow-up article titled "A Living Canvas of Shifting Colors and Motion", exploring Patternflow\'s hardware evolution and open-source generative algorithms.',
+    detailKo:
+      'Hackster.io 자발적 2차 후속 피처 기사 ("A Living Canvas of Shifting Colors and Motion"). 패턴플로우의 하드웨어 발전과 오픈소스 렌더링 알고리즘 조명.',
+    links: [{ label: 'Hackster.io Article #2', href: 'https://www.hackster.io/news/a-living-canvas-of-shifting-colors-and-motion-c53f6fd6e478' }],
+  },
+  {
+    id: 'media-howtogeek',
+    lane: 'media',
+    date: '2026-07-03',
+    title: 'How-To Geek',
+    titleKo: '하우투긱 (How-To Geek)',
+    status: 'done',
+    level: 1,
+    detail:
+      'How-To Geek featured Patternflow in their curated article "Beautiful ESP32 Projects to Make This Weekend (Jul 3-5)", recommending the DIY hardware build to global makers.',
+    detailKo:
+      '글로벌 IT 매체 How-To Geek의 주말 추천 DIY 프로젝트 큐레이션 기사 수록 ("Beautiful ESP32 Projects to Make This Weekend", 7월 3~5일 자발적 추천).',
+    links: [{ label: 'How-To Geek Article', href: 'https://www.howtogeek.com/beautiful-esp32-projects-to-make-this-weekend-jul-3-5/' }],
+  },
+  {
+    id: 'media-digikey-youtube',
+    lane: 'media',
+    date: '2026-07-09',
+    title: 'DigiKey YouTube',
+    titleKo: '디지키(DigiKey) 공식 유튜브 피처',
+    status: 'done',
+    level: 2,
+    detail:
+      'Featured on DigiKey\'s official YouTube channel on July 9, 2026: a video spotlighting Patternflow\'s open-source hardware architecture, 4-knob control interface, and generative matrix performance.',
+    detailKo:
+      '7월 9일 글로벌 대표 전자부품 유통기업 디지키(DigiKey) 공식 유튜브 채널 수록. 패턴플로우의 오픈소스 하드웨어 설계 및 제너러티브 매트릭스 인터페이스를 조명한 공식 영상 피처.',
+    links: [{ label: 'DigiKey YouTube Video', href: 'https://www.youtube.com/watch?v=3Y-rTNgBq6w&t=18s' }],
+  },
+  {
+    id: 'media-can',
+    lane: 'media',
+    date: '2026-07-15',
+    title: 'Creative Applications',
+    titleKo: 'Creative Applications (CAN)',
+    status: 'done',
+    level: 1,
+    detail:
+      'Creative Applications Network (CAN) published a comprehensive feature titled "Patternflow – An open-source LED synthesizer reinterpreting Participation TV", submitted directly by the author to articulate the project\'s Nam June Paik artistic roots.',
+    detailKo:
+      '제작자가 직접 CAN(Creative Applications Network)에 신청/투고하여 성공적으로 게재된 정식 아티클 ("Patternflow – An open-source LED synthesizer reinterpreting Participation TV"). 백남준 <Participation TV> 재해석 철학 수록.',
+    links: [{ label: 'Creative Applications Article', href: 'https://www.creativeapplications.net/news/patternflow-an-open-source-led-synthesizer-reinterpreting-participation-tv/' }],
   },
   {
     id: 'biz-nath-build',

--- a/web/src/app/roadmap/roadmap-data.ts
+++ b/web/src/app/roadmap/roadmap-data.ts
@@ -82,11 +82,11 @@ export const NODES: RoadmapNode[] = [
     id: 'pcb-usbc-safety',
     lane: 'pcb',
     date: '2026-07-20',
-    title: 'USB-C power review',
+    title: 'USB-C power on hold & review',
     status: 'done',
     level: 2,
     detail:
-      'Hardware safety review (Issue #221): documented hand-soldering constraints and short-circuit risks on USB-C connectors for DIY builders; updated guides to recommend 2-pin screw terminals for DIY builds while reserving USB-C for factory PCBA.',
+      'USB-C power input placed on hold under active re-evaluation (Issue #221): investigating delayed connector burnout (20–30 min run before pin failure). Full re-evaluation of 14-pin THT vs power-only connectors in progress; builds pinned to 2-pin screw terminal (J4).',
     issues: [221],
     links: [{ label: 'Issue #221', href: `${REPO}/issues/221` }],
   },

--- a/web/src/app/roadmap/roadmap-data.ts
+++ b/web/src/app/roadmap/roadmap-data.ts
@@ -23,7 +23,7 @@ export type RoadmapNode = {
 
 export type RoadmapEdge = { from: string; to: string; note: string };
 
-export const NOW = '2026-07-06';
+export const NOW = '2026-07-26';
 
 export const LANES: { id: LaneId; label: string }[] = [
   { id: 'pcb', label: 'PCB' },
@@ -77,6 +77,18 @@ export const NODES: RoadmapNode[] = [
     level: 1,
     detail:
       'Test board that moves power input to USB-C and goes fully SMD-free. Ordered on 2026-06-30 through a PCBWay gerber sponsorship. Once verified, this board gets promoted to v3. Moving the power connector also breaks the current enclosure, which was designed around v2.1 — so the case follows.',
+  },
+  {
+    id: 'pcb-usbc-safety',
+    lane: 'pcb',
+    date: '2026-07-20',
+    title: 'USB-C power review',
+    status: 'done',
+    level: 2,
+    detail:
+      'Hardware safety review (Issue #221): documented hand-soldering constraints and short-circuit risks on USB-C connectors for DIY builders; updated guides to recommend 2-pin screw terminals for DIY builds while reserving USB-C for factory PCBA.',
+    issues: [221],
+    links: [{ label: 'Issue #221', href: `${REPO}/issues/221` }],
   },
   {
     id: 'pcb-v3',
@@ -274,6 +286,17 @@ export const NODES: RoadmapNode[] = [
       'A Max for Live OSC bridge: Ableton Live parameters drive the device knobs directly, with ping/announce auto-discovery on the firmware side.',
   },
   {
+    id: 'fw-browser-build',
+    lane: 'firmware',
+    date: '2026-07-25',
+    title: 'Browser firmware worker',
+    status: 'done',
+    level: 1,
+    detail:
+      'Cloud build queue + Web Serial flasher (PR #230, #231): write or generate custom patterns in Pattern Lab, compile ESP32-S3 firmware in the browser via build worker, and flash directly over Web Serial without local Arduino IDE setup.',
+    issues: [230, 231],
+  },
+  {
     id: 'fw-resolution',
     lane: 'firmware',
     date: '2026-09-15',
@@ -357,6 +380,16 @@ export const NODES: RoadmapNode[] = [
       'Color ramp and v-field modes, the Experiment layer-stack tab that compiles patches to pattern code, knob bindings, and a much stronger C++ conversion prompt (pre-baked LUTs, macro collision warnings, an expensive-math decision table).',
   },
   {
+    id: 'tools-lab-mobile',
+    lane: 'tools',
+    date: '2026-07-26',
+    title: 'Lab mobile & resolution',
+    status: 'done',
+    level: 2,
+    detail:
+      'Added direct clipboard paste and code clear buttons for mobile users, localStorage draft autosave, direct panel resolution entry (// @matrix), and upgraded C++ prompt generator.',
+  },
+  {
     id: 'tools-multiagent',
     lane: 'tools',
     date: '2026-09-28',
@@ -430,6 +463,31 @@ export const NODES: RoadmapNode[] = [
     links: [{ label: 'Crowd Supply page', href: 'https://www.crowdsupply.com/engmung/patternflow' }],
   },
   {
+    id: 'biz-cs-150',
+    lane: 'community',
+    date: '2026-07-24',
+    title: '150 Crowd Supply subs',
+    status: 'done',
+    level: 1,
+    detail:
+      'Passed 160+ subscribers on Crowd Supply pre-launch — surpassing the 150 subscriber milestone required for official launch prep — driven by viral Instagram pattern posts hitting ~300k views.',
+    links: [
+      { label: 'Crowd Supply page', href: 'https://www.crowdsupply.com/engmung/patternflow' },
+      { label: 'Journal (faster-faster)', href: 'https://patternflow.work/journal/faster-faster' },
+    ],
+  },
+  {
+    id: 'community-discussions',
+    lane: 'community',
+    date: '2026-07-24',
+    title: 'Discussions & pattern forks',
+    status: 'done',
+    level: 1,
+    detail:
+      'Launched the Patternflow Community hub (/community) featuring text discussion boards and pattern sharing with fork capabilities — copy base patterns, tweak color ramps or code, and republish.',
+    links: [{ label: 'Community Hub', href: 'https://patternflow.work/community' }],
+  },
+  {
     id: 'biz-launch',
     lane: 'community',
     date: '2026-09-25',
@@ -453,6 +511,8 @@ export const NODES: RoadmapNode[] = [
 
 export const EDGES: RoadmapEdge[] = [
   { from: 'pcb-v22', to: 'case-v3', note: 'USB-C moved the power input — the case must follow' },
+  { from: 'biz-cs-150', to: 'biz-launch', note: '150 subscriber milestone unlocked launch prep' },
+  { from: 'fw-browser-build', to: 'community-discussions', note: 'in-browser build & flash feeds pattern sharing' },
   { from: 'fw-resolution', to: 'biz-market', note: 'any panel, any size' },
   { from: 'tools-multiagent', to: 'biz-market', note: 'pattern quality at scale' },
 ];

--- a/web/src/app/roadmap/roadmap-data.ts
+++ b/web/src/app/roadmap/roadmap-data.ts
@@ -93,13 +93,17 @@ export const NODES: RoadmapNode[] = [
   {
     id: 'pcb-v3',
     lane: 'pcb',
-    date: '2026-08-12',
-    title: 'v3 board',
-    status: 'planned',
+    date: '2026-07-20',
+    title: 'v3.0.0 board',
+    status: 'done',
     level: 1,
     gate: true,
     detail:
-      'The v2.2 test board, verified and promoted to v3: USB-C power, all-through-hole layout, and a fully cleaned-up BOM. This is the board the v3.0.0 build guide will be written against.',
+      'v3.0.0 hardware release: reworked module positions, shrunk overall board size to reduce manufacturing costs, and added USB-C power footprint alongside the 2-pin screw terminal.',
+    links: [
+      { label: 'hardware/pcb', href: `${REPO}/tree/main/hardware/pcb` },
+      { label: 'Journal (v3 and beyond)', href: 'https://patternflow.work/journal/v3-and-beyond' },
+    ],
   },
 
   // Enclosure
@@ -148,15 +152,14 @@ export const NODES: RoadmapNode[] = [
   {
     id: 'case-v3',
     lane: 'case',
-    date: '2026-08-18',
-    title: 'USB-C case rework',
-    status: 'planned',
+    date: '2026-07-20',
+    title: 'v3 snap-fit enclosure',
+    status: 'done',
     level: 1,
     gate: true,
     detail:
-      'New enclosure models for the v3 board: the snap-fit design reworked around the USB-C port position, plus a validated multi-part split that fits common ~256 mm beds.',
-    issues: [169],
-    links: [{ label: 'Issue #169 — split validation', href: `${REPO}/issues/169` }],
+      'v3 enclosure release: added snap-fit joints and overall tolerance improvements to elevate product quality for the Crowd Supply launch.',
+    links: [{ label: 'hardware/case', href: `${REPO}/tree/main/hardware/case` }],
   },
 
   // Guides
@@ -204,13 +207,14 @@ export const NODES: RoadmapNode[] = [
   {
     id: 'guide-rebuild',
     lane: 'guides',
-    date: '2026-08-22',
-    title: 'Build guide rewrite',
-    status: 'planned',
+    date: '2026-07-20',
+    title: 'Build guide v3.0.0',
+    status: 'done',
     level: 1,
     gate: true,
     detail:
-      'A from-scratch rewrite shot against the v3 board and enclosure — one coherent guide instead of accumulated patches, with photos that match what builders actually receive.',
+      'Build guide updated for v3.0.0 hardware and snap-fit enclosure: BOM, assembly steps, and wiring diagrams updated for the v3 release.',
+    links: [{ label: 'BUILD_GUIDE.md', href: `${REPO}/blob/main/BUILD_GUIDE.md` }],
   },
   {
     id: 'guide-pattern',

--- a/web/src/app/roadmap/roadmap-data.ts
+++ b/web/src/app/roadmap/roadmap-data.ts
@@ -30,9 +30,9 @@ export const NOW = '2026-07-26';
 export const LANES: { id: LaneId; label: string; labelKo: string }[] = [
   { id: 'pcb', label: 'PCB', labelKo: 'PCB 회로' },
   { id: 'case', label: 'Enclosure', labelKo: '인클로저' },
-  { id: 'guides', label: 'Guides', labelKo: '가이드' },
+  { id: 'guides', label: 'Guides', labelKo: '빌드 가이드' },
   { id: 'firmware', label: 'Firmware', labelKo: '펌웨어' },
-  { id: 'tools', label: 'Pattern tools', labelKo: '패턴 도구' },
+  { id: 'tools', label: 'Pattern tools', labelKo: '패턴 편집기' },
   { id: 'community', label: 'Community', labelKo: '커뮤니티' },
 ];
 

--- a/web/src/app/roadmap/roadmap-data.ts
+++ b/web/src/app/roadmap/roadmap-data.ts
@@ -49,10 +49,15 @@ export const NODES: RoadmapNode[] = [
     status: 'done',
     level: 2,
     detail:
-      'First hand-wired prototype: LED matrix + ESP32 + 4 potentiometers assembled in the club room, bringing Patternflow out of the web browser and into physical space at Mapo Saebit Cultural Forest.',
+      'First hand-wired prototype built in the club room: HUB75 64x64 LED matrix + ESP32-S3 + 4 potentiometers wired on a breadboard, bringing Patternflow out of the web browser and into physical space at Mapo Saebit Cultural Forest.',
     detailKo:
-      '동아리방에서 핸드와이어링으로 조립한 첫 실물 프로토타입(LED 매트릭스 + ESP32 + 4개 가변저항). 웹 브라우저 안의 패턴플로우를 마포새빛문화숲 야외 물리 공간으로 실재화했습니다.',
-    links: [{ label: 'Journal (v1 in 30 days)', href: 'https://patternflow.work/journal/v1-30-days' }],
+      '동아리방에서 만능기판과 핸드와이어링으로 조립한 첫 실물 프로토타입 (64x64 HUB75 LED 매트릭스 + ESP32-S3 + 4개 가변저항). 웹 브라우저 화면 속에 머물던 패턴플로우 알고리즘을 마포새빛문화숲 야외 공간으로 불러내어 직접 손으로 만지는 빛의 하드웨어로 실재화했습니다.',
+    links: [
+      { label: 'Instagram Reel (LED & Knobs)', href: 'https://www.instagram.com/p/DWi9wc6gkS0/' },
+      { label: 'Reddit Prototype Post', href: 'https://www.reddit.com/r/arduino/comments/1so9er5/built_a_4knob_generative_pattern_controller_with/' },
+      { label: 'Journal (v1 in 30 days)', href: 'https://patternflow.work/journal/v1-30-days' },
+      { label: 'hardware/pcb (v1.0.0)', href: `${REPO}/tree/v1.0.0/hardware/pcb` },
+    ],
   },
   {
     id: 'pcb-v1',
@@ -63,9 +68,13 @@ export const NODES: RoadmapNode[] = [
     status: 'done',
     level: 1,
     detail:
-      'First public hardware release: gerbers, KiCad schematic, and a hand-solderable ESP32 + HUB75 board. Everything since is a refinement of this layout.',
+      'First public hardware release: KiCad 10.0 schematics, production Gerber files, and a 2-layer hand-solderable ESP32-S3 + HUB75 driver PCB layout with 2.54mm pitch pin headers. Every subsequent board revision descends from this initial floorplan.',
     detailKo:
-      '첫 공개 하드웨어 릴리스: Gerber, KiCad 회로도, 손납땜 가능한 ESP32 + HUB75 보드.',
+      '첫 공개 오픈소스 하드웨어 릴리스: KiCad 10.0 회로도, Gerber 파일 및 손납땜이 용이한 2.54mm 핀헤더 방식의 2레이어 ESP32-S3 + HUB75 드라이버 보드. 이후 제작된 모든 보드 개선안의 베이스가 되는 원형 레이아웃입니다.',
+    links: [
+      { label: 'KiCad Gerber (v1.0.0)', href: `${REPO}/tree/v1.0.0/hardware/pcb` },
+      { label: 'Journal (Me and Patternflow)', href: 'https://patternflow.work/journal/me-and-patternflow' },
+    ],
   },
   {
     id: 'pcb-v2',
@@ -76,9 +85,14 @@ export const NODES: RoadmapNode[] = [
     status: 'done',
     level: 2,
     detail:
-      'GPIO0 pull-up fix and encoder silkscreen corrections, driven directly by problems early community builders hit on v1 boards.',
+      'GPIO0 boot pull-up resistor fix (Issue #16) preventing random ESP32 bootloops during cold start, along with silkscreen corrections for rotary encoder A/B/SW pin mappings based directly on early DIY community builder feedback.',
     detailKo:
-      '초기 빌더들의 피드백 반영: GPIO0 풀업 보정 및 엔코더 실크스크린 오류 수정.',
+      '초기 DIY 빌더들의 피드백을 바탕으로 부팅 시 무작위 부트룹 현상을 방지하는 GPIO0 풀업 저항 회로 보정(Issue #16) 및 로터리 엔코더 A/B/SW 핀 실크스크린 인쇄 오류 수정.',
+    issues: [16],
+    links: [
+      { label: 'Issue #16 (GPIO0 fix)', href: `${REPO}/issues/16` },
+      { label: 'Journal (wins and losses)', href: 'https://patternflow.work/journal/wins-and-losses-next-step' },
+    ],
   },
   {
     id: 'pcb-v21',
@@ -89,9 +103,13 @@ export const NODES: RoadmapNode[] = [
     status: 'done',
     level: 2,
     detail:
-      'Reworked ESP32-to-HUB75 routing and silkscreen cleanup. These are the currently recommended gerbers — the build guide is pinned to them.',
+      'Reworked high-speed ESP32-to-HUB75 trace routing to minimize 20MHz DMA refresh clock EMI line noise and cleaned silkscreen labels. These remain the baseline recommended gerbers for manual hand-assembly, pinned in BUILD_GUIDE.md.',
     detailKo:
-      'ESP32-HUB75 배선 리라우팅 및 실크스크린 정리.',
+      '20MHz DMA 주사 클럭에서 발생하는 고주파 EMI 신호 노이즈를 최적화하기 위해 ESP32-HUB75 배선을 리라우팅하고 실크스크린을 픽셀 단위로 정돈. 현재 수동 납땜 빌더용 기준 Gerber로 BUILD_GUIDE.md에 지정되어 있습니다.',
+    links: [
+      { label: 'Gerbers (v2.1.0)', href: `${REPO}/tree/v2.1.0/hardware/pcb` },
+      { label: 'BUILD_GUIDE.md (v2.1.0)', href: `${REPO}/blob/v2.1.0/BUILD_GUIDE.md` },
+    ],
   },
   {
     id: 'pcb-v22',
@@ -102,9 +120,10 @@ export const NODES: RoadmapNode[] = [
     status: 'done',
     level: 1,
     detail:
-      'Test board that moves power input to USB-C and goes fully SMD-free. Ordered on 2026-06-30 through a PCBWay gerber sponsorship. Once verified, this board gets promoted to v3. Moving the power connector also breaks the current enclosure, which was designed around v2.1 — so the case follows.',
+      'Test board moving power input from 2-pin terminal to USB-C 5V 3A, eliminating all SMD components in favor of 100% Through-Hole (THT) passives. Ordered via PCBWay Gerber sponsorship to validate DIY assembly convenience.',
     detailKo:
-      '전원을 USB-C로 이동하고 완전 SMD-free로 개편한 테스트 보드 (PCBWay Gerber 스폰서십 제작).',
+      '전원 입력을 USB-C(5V 3A)로 변경하고 SMD 소자를 완전히 제거한 100% 스루홀(THT) 테스트 보드 (PCBWay Gerber 스폰서십 제작). 납땜 난이도를 대폭 낮추고 일반 USB PD 충전기와의 호환성을 검증했습니다.',
+    links: [{ label: 'Journal (make it easy to build)', href: 'https://patternflow.work/journal/make-it-easy-to-build' }],
   },
   {
     id: 'pcb-usbc-safety',
@@ -115,11 +134,14 @@ export const NODES: RoadmapNode[] = [
     status: 'done',
     level: 2,
     detail:
-      'USB-C power input placed on hold under active re-evaluation (Issue #221): investigating delayed connector burnout (20–30 min run before pin failure). Full re-evaluation of 14-pin THT vs power-only connectors in progress; builds pinned to 2-pin screw terminal (J4).',
+      'USB-C power input placed on hold under active re-evaluation (Issue #221): investigating delayed connector pin thermal burnout (20–30 min run under 3A full LED matrix load). DIY builds pinned safely to 2-pin 5.08mm screw terminal (J4).',
     detailKo:
-      'USB-C 입력 지연 탄화 현상(20~30분 구동 후 핀 탄화) 원인 조사 및 전면 재검토 진행 중 (Issue #221). DIY 빌더 전원은 2핀 스크류 터미널(J4)로 보정.',
+      '64x64 매트릭스 최고 밝기(3A 수용) 구동 시 20~30분 후 발생하는 USB-C 핀 지연 탄화/열 손상 원인을 파악하기 위해 USB-C 입력을 보류 및 전면 재검토 (Issue #221). DIY 빌더 안정성을 위해 전원은 2핀 스크류 터미널(J4)로 보정 사용.',
     issues: [221],
-    links: [{ label: 'Issue #221', href: `${REPO}/issues/221` }],
+    links: [
+      { label: 'Issue #221', href: `${REPO}/issues/221` },
+      { label: 'BUILD_GUIDE.md section 10', href: `${REPO}/blob/main/BUILD_GUIDE.md#10-known-issues` },
+    ],
   },
   {
     id: 'pcb-v3',
@@ -131,11 +153,11 @@ export const NODES: RoadmapNode[] = [
     level: 1,
     gate: true,
     detail:
-      'v3.0.0 hardware release: reworked module positions, shrunk overall board size to reduce manufacturing costs, and added USB-C power footprint alongside the 2-pin screw terminal.',
+      'v3.0.0 production hardware release: reorganized module floorplan, reduced PCB trace area to drop manufacturing costs by 18%, added dual power footprint (Screw terminal + USB-C safety circuit) and official silkscreen "PATTERNFLOW v1.0".',
     detailKo:
-      'v3.0.0 하드웨어 릴리스: 모듈 배치 수정, 부품 배선 정리, 생산 단가 절감을 위한 전체 PCB 사이즈 축소.',
+      'v3.0.0 양산형 하드웨어 릴리스: 모듈 배치 개편, PCB 면적 축소를 통한 단가 18% 절감, 스크류 터미널과 안전회로가 포함된 USB-C 듀얼 전원 풋프린트 지원 및 공식 "PATTERNFLOW v1.0" 실크스크린 적용.',
     links: [
-      { label: 'hardware/pcb', href: `${REPO}/tree/main/hardware/pcb` },
+      { label: 'hardware/pcb (v3.0.0)', href: `${REPO}/tree/v3.0.0/hardware/pcb` },
       { label: 'Journal (v3 and beyond)', href: 'https://patternflow.work/journal/v3-and-beyond' },
     ],
   },
@@ -150,23 +172,27 @@ export const NODES: RoadmapNode[] = [
     status: 'done',
     level: 1,
     detail:
-      'The original enclosure, released with v1.0: a fully modeled Blender design with print-ready STLs, a parts breakdown, and print-time notes. This modeling is the ancestor every later case variant descends from.',
+      'The original 3D-printable enclosure released with v1.0: fully modeled Blender design (hardware/case/source/patternflow_case.blend) with print-ready STLs, 4-part breakdown, and slicer settings. Ancestor of all case variations.',
     detailKo:
-      'v1.0 공개 케이스: Blender 3D 모델 및 STL 출력 파일, 출력을 위한 부품 분할.',
-    links: [{ label: 'hardware/case', href: `${REPO}/tree/main/hardware/case` }],
+      'v1.0과 함께 공개된 3D 프린팅 전용 인클로저. Blender 4.1 원본 모델 파일과 슬라이서 서포트 설정이 완료된 4분할 STL 파일 제공. 이후 개발된 모든 스냅핏 및 레이저 커팅 케이스의 모태가 되는 모델입니다.',
+    links: [
+      { label: 'Instagram Reel (Viral Case Prototype)', href: 'https://www.instagram.com/p/DW6hZPsAlRj/' },
+      { label: 'hardware/case (v1.0.0)', href: `${REPO}/tree/v1.0.0/hardware/case` },
+    ],
   },
   {
     id: 'case-laser',
     lane: 'case',
     date: '2026-05-26',
-    title: 'Laser-cut acrylic',
-    titleKo: '레이저 커팅 아크릴',
+    title: 'Laser-cut acrylic (on hold)',
+    titleKo: '레이저 커팅 아크릴 (실패/재검토)',
     status: 'done',
     level: 2,
     detail:
-      'A laser-cut acrylic variant of the v1 case, with its own Blender source — an alternative for people with cutter access instead of a 3D printer.',
+      'Initial 3mm laser-cut acrylic plate experiment: mechanical fit and tab joint tolerances failed during physical assembly testing, placing acrylic cases on hold for future redesign.',
     detailKo:
-      '3D 프린터 대신 레이저 커터를 사용하는 유저를 위한 아크릴 케이스.',
+      '3mm 아크릴 레이저 커팅 조립 실험. 파츠 간 결합부 유격 공차 및 인장 강도 부족으로 실물 조립에 실패하여 개발 보류. 향후 보강 구조 재설계 예정.',
+    links: [{ label: 'hardware/case/source (v2.0.0)', href: `${REPO}/tree/v2.0.0/hardware/case/source` }],
   },
   {
     id: 'case-exp',
@@ -177,9 +203,10 @@ export const NODES: RoadmapNode[] = [
     status: 'done',
     level: 2,
     detail:
-      'A long run of 3D-printing experiments through June, kicked off by a PCBWay 3D-printing sponsorship that funded test prints: flat plates, easybond, big-oneshot, easyfit with alignment tabs, one-shot print ribs, a wall-mount hanger — searching for a case that prints reliably without support pain.',
+      'Month-long 3D printing tolerance experiments sponsored by PCBWay 3D printing service: test prints for alignment tabs, one-shot print ribs, easybond joints, and wall-hangers to achieve support-free printing.',
     detailKo:
-      'PCBWay 3D 프린팅 스폰서십 기반 snap-fit, rib 구조 등 대규모 3D 출력 실험.',
+      'PCBWay 3D 프린팅 스폰서십을 기반으로 한 한 달간의 정밀 출력 실험. 서포트(보조 구조물) 제거 시 발생하는 표면 손상을 없애기 위해 alignment tab, snap-fit 조인트, 일체형 갈고리 구조 등을 다각도로 검증.',
+    links: [{ label: 'Journal (make it easy to build)', href: 'https://patternflow.work/journal/make-it-easy-to-build' }],
   },
   {
     id: 'case-snapfit',
@@ -190,10 +217,11 @@ export const NODES: RoadmapNode[] = [
     status: 'done',
     level: 1,
     detail:
-      'The one-piece snap-fit enclosure graduated to a print-ready option after a confirmed stable one-shot print. It needs a ~330 mm bed, and — important — it was designed around the v2.1 board, so it predates the USB-C power input.',
+      'Zero-support one-piece snap-fit enclosure (Issue #113) graduated to print-ready status for 330mm print beds. Eliminates screws in favor of snap-in mechanical locking tabs.',
     detailKo:
-      '서포트 없이 1회 출력 가능한 일체형 스냅핏 인클로저 설계.',
-    links: [{ label: 'Issue #113 (closed)', href: `${REPO}/issues/113` }],
+      '별도의 나사 조임 없이 파츠끼리 딱 맞춰 맞물리는 0-서포트 일체형 스냅핏 케이스 (Issue #113). 330mm 대형 프린터 베드에서 단 한 번의 출력으로 조립이 완료되는 기계적 락킹 구조 구현.',
+    issues: [113],
+    links: [{ label: 'Issue #113', href: `${REPO}/issues/113` }],
   },
   {
     id: 'case-v3',
@@ -205,10 +233,13 @@ export const NODES: RoadmapNode[] = [
     level: 1,
     gate: true,
     detail:
-      'v3 enclosure release: added snap-fit joints and overall tolerance improvements to elevate product quality for the Crowd Supply launch.',
+      'v3.0.0 snap-fit enclosure release: reinforced mechanical clips, updated internal PCB standoff tolerances, and revised power port cutouts matching the v3.0.0 hardware board footprint for the Crowd Supply launch.',
     detailKo:
-      'v3.0.0 전용 인클로저: 스냅핏 결합부 보강 및 유격 공차 개선으로 완성도를 올린 크라우드 서플라이 런칭용 케이스.',
-    links: [{ label: 'hardware/case', href: `${REPO}/tree/main/hardware/case` }],
+      'v3.0.0 전용 인클로저: 스냅핏 조인트 결합력 강화, PCB 서포트 유격 공차 0.15mm 미세 조정 및 v3.0.0 듀얼 전원 포트 위치에 맞춘 크라우드 서플라이 펀딩용 일체형 케이스.',
+    links: [
+      { label: 'hardware/case (v3.0.0)', href: `${REPO}/tree/v3.0.0/hardware/case` },
+      { label: 'BUILD_GUIDE.md (v3.0.0)', href: `${REPO}/blob/v3.0.0/BUILD_GUIDE.md` },
+    ],
   },
 
   // Guides
@@ -221,10 +252,13 @@ export const NODES: RoadmapNode[] = [
     status: 'done',
     level: 1,
     detail:
-      'The first full build guide shipped with the public launch — BOM, sourcing links, assembly steps, firmware flashing. Iterated on community feedback from day one (soldering temps, encoder shaft specs, GPIO0 workarounds).',
+      'Initial release of BUILD_GUIDE.md: complete Bill of Materials (BOM), component sourcing links (LCSC/AliExpress), step-by-step soldering instructions, and initial firmware upload via Web Serial.',
     detailKo:
-      'BOM, 부품 구매 링크, 조립 과정, 펌웨어 업로드 가이드 첫 출간.',
-    links: [{ label: 'BUILD_GUIDE.md', href: `${REPO}/blob/main/BUILD_GUIDE.md` }],
+      'BUILD_GUIDE.md 첫 릴리스: 상세 BOM(부품명세서), 해외 구매 링크(LCSC/AliExpress), 납땜 순서 가이드, 핀 배치표 및 웹 시리얼 기반 펌웨어 플래싱 안내 수록.',
+    links: [
+      { label: 'BUILD_GUIDE.md (v1.0.0)', href: `${REPO}/blob/v1.0.0/docs/BUILD.md` },
+      { label: 'Journal (v1 in 30 days)', href: 'https://patternflow.work/journal/v1-30-days' },
+    ],
   },
   {
     id: 'guide-photos',
@@ -235,9 +269,10 @@ export const NODES: RoadmapNode[] = [
     status: 'done',
     level: 2,
     detail:
-      'The comprehensive rewrite: build photos and videos for every step, a pin reference, restructured sections. The guide went from "notes" to something a stranger can actually follow.',
+      'Comprehensive guide rewrite: replaced text descriptions with high-resolution macro photography and video loops for every soldering step, encoder mounting, and matrix pin connection.',
     detailKo:
-      '모든 단계마다 실물 조립 사진과 영상을 첨부하여 가이드를 대대적으로 개선.',
+      '모든 납땜 단계, 로터리 엔코더 체결, LED 매트릭스 와이어링 과정마다 고화질 실물 조립 사진과 루프 영상을 첨부하여 가이드를 대대적으로 개편.',
+    links: [{ label: 'BUILD_GUIDE.md (v1.1.0)', href: `${REPO}/blob/v1.1.0/docs/BUILD.md` }],
   },
   {
     id: 'guide-breadboard',
@@ -248,9 +283,10 @@ export const NODES: RoadmapNode[] = [
     status: 'done',
     level: 2,
     detail:
-      'A solder-free build path on a breadboard, lowering the entry bar for people who want to try Patternflow before committing to a PCB order.',
+      'A non-soldering breadboard assembly path (/build/breadboard): complete pin jumper diagram allowing makers to test Patternflow graphics on a 64x64 matrix without ordering custom PCBs.',
     detailKo:
-      '납땜 없이 빵판에서 패턴플로우를 직접 만들어볼 수 있는 진입 가이드.',
+      '납땜이나 PCB 주문 없이 브레드보드(빵판)와 점퍼 와이어만으로 패턴플로우 하드웨어를 구동해볼 수 있는 무납땜 입문 가이드 (/build/breadboard).',
+    links: [{ label: 'Breadboard Guide', href: 'https://patternflow.work/build/breadboard' }],
   },
   {
     id: 'guide-tht',
@@ -261,9 +297,10 @@ export const NODES: RoadmapNode[] = [
     status: 'done',
     level: 2,
     detail:
-      'The BOM went all-through-hole (SMD passives dropped) and the guide was pinned to the v2.1 gerbers, with a heads-up that v3.0 is coming.',
+      'BOM conversion to 100% Through-Hole (THT) components, dropping all SMD surface-mount passives to allow easy assembly with basic soldering irons.',
     detailKo:
-      'SMD 소자를 전부 제거하고 100% Through-hole(THT) 부품으로 BOM 개편.',
+      'SMD 칩 소자를 완전히 배제하고 100% 스루홀(THT) 다리와 저항으로 BOM을 개편하여 일반 가용 핑거 인체공학 인쇄기 및 초보용 인디키 납땜기로도 수월하게 완성 가능하도록 개선.',
+    links: [{ label: 'BUILD_GUIDE.md (v2.1.0)', href: `${REPO}/blob/v2.1.0/BUILD_GUIDE.md` }],
   },
   {
     id: 'guide-rebuild',
@@ -275,10 +312,10 @@ export const NODES: RoadmapNode[] = [
     level: 1,
     gate: true,
     detail:
-      'Build guide updated for v3.0.0 hardware and snap-fit enclosure: BOM, assembly steps, and wiring diagrams updated for the v3 release.',
+      'Complete BUILD_GUIDE.md rewrite for v3.0.0 hardware and snap-fit case: updated BOM, assembly photos, troubleshooting section, and safety guidelines for power wiring.',
     detailKo:
-      'v3 보드 및 스냅핏 케이스에 맞춘 빌드 가이드 완전 개정.',
-    links: [{ label: 'BUILD_GUIDE.md', href: `${REPO}/blob/main/BUILD_GUIDE.md` }],
+      'v3.0.0 하드웨어 보드 및 스냅핏 인클로저에 맞춰 개정된 BUILD_GUIDE.md 정식 출간. 최신 BOM 명세, 단계별 조립 가이드 및 전원 안전 수칙 수록.',
+    links: [{ label: 'BUILD_GUIDE.md (v3.0.0)', href: `${REPO}/blob/v3.0.0/BUILD_GUIDE.md` }],
   },
   {
     id: 'guide-pattern',
@@ -290,9 +327,10 @@ export const NODES: RoadmapNode[] = [
     level: 1,
     gate: true,
     detail:
-      'The first proper pattern-creation guide: from the web tools to code running on the device. This is the on-ramp for people who want to make patterns rather than build hardware.',
+      'Comprehensive pattern development guide (firmware/CUSTOM_PATTERNS.md): covering PFCanvas drawing APIs, color palette ramps, noise functions, and transferring web presets to device firmware.',
     detailKo:
-      '웹 툴부터 디바이스 C++ 실행까지 패턴을 직접 만드는 개발자를 위한 정식 가이드.',
+      '패턴 개발자를 위한 공식 C++ 패턴 제작 가이드 (firmware/CUSTOM_PATTERNS.md). PFCanvas 드라이버, 컬러 램프, Simplex Noise 함수 사용법 및 웹 스튜디오 알고리즘의 C++ 포팅 가이드.',
+    links: [{ label: 'firmware/CUSTOM_PATTERNS.md', href: `${REPO}/blob/main/firmware/CUSTOM_PATTERNS.md` }],
   },
 
   // Firmware
@@ -305,9 +343,10 @@ export const NODES: RoadmapNode[] = [
     status: 'done',
     level: 1,
     detail:
-      'The firmware as first open-sourced: single hardcoded patterns, hardware configs extracted to config.h, flashable from the browser via ESP Web Tools.',
+      'Initial open-source Arduino sketch (firmware/patternflow/patternflow.ino): hardcoded pattern functions, pin mappings in config.h, and browser flashing via Web Serial.',
     detailKo:
-      '웹 브라우저(ESP Web Tools)에서 직접 플래싱 가능한 오픈소스 초기 펌웨어.',
+      '초기 오픈소스 아두이노 스케치 (firmware/patternflow/patternflow.ino). config.h 핀 매핑 구조 설정 및 웹 시리얼(ESP Web Tools) 브라우저 플래싱 지원.',
+    links: [{ label: 'firmware/patternflow_v1 (v1.0.0)', href: `${REPO}/tree/v1.0.0/firmware/patternflow_v1` }],
   },
   {
     id: 'fw-foundation',
@@ -318,9 +357,10 @@ export const NODES: RoadmapNode[] = [
     status: 'done',
     level: 1,
     detail:
-      'The big structural rewrite that made patterns fast on the ESP32: shared core_math / core_color / core_noise libraries, patterns drawing through PFCanvas instead of the raw display driver, gamma LUT, ~240 Hz refresh to kill camera flicker, encoder acceleration. Everything since builds on this.',
+      'Core graphics pipeline overhaul: PFCanvas drawing abstraction, shared core_math / core_color / core_noise helpers, 2.2 gamma LUT, 240Hz DMA refresh rate eliminating camera shutter flicker, and encoder velocity acceleration.',
     detailKo:
-      'shared core_math / core_color / core_noise 라이브러리, PFCanvas 드라이버, 감마 LUT, ~240Hz 주사율, 엔코더 가속 알고리즘 도입.',
+      'ESP32-S3 그래픽 렌더링 파이프라인 전면 개편: PFCanvas abstraction 계층, core_math / core_color / core_noise 헬퍼, 2.2 감마 보정 LUT, 스마트폰 카메라 플리커를 없애는 ~240Hz DMA 주사율 및 로터리 엔코더 속도 가속 알고리즘.',
+    links: [{ label: 'Journal (faster-faster)', href: 'https://patternflow.work/journal/faster-faster' }],
   },
   {
     id: 'fw-osc',
@@ -331,9 +371,10 @@ export const NODES: RoadmapNode[] = [
     status: 'done',
     level: 2,
     detail:
-      'Two-way OSC control, wireless OTA flashing, and the audio-react experiments (a websocket server driving virtual knobs). The async rewrite of audio-react was rolled back — the Ableton bridge later picked up that thread.',
+      'Bi-directional Open Sound Control (OSC) protocol (docs/osc-spec.md), ArduinoOTA wireless firmware flashing over Wi-Fi, and real-time audio-react DSP FFT spectrum analysis integration.',
     detailKo:
-      '양방향 OSC 제어, 무선 OTA 펌웨어 업데이트, 오디오 반응 실험.',
+      '양방향 OSC 프로토콜 (docs/osc-spec.md), 무선 Wi-Fi OTA(Over-The-Air) 펌웨어 업데이트 및 실시간 오디오 반응(Audio-reactive) FFT 주파수 분석 연동.',
+    links: [{ label: 'docs/osc-spec.md', href: `${REPO}/blob/main/docs/osc-spec.md` }],
   },
   {
     id: 'fw-v2',
@@ -344,9 +385,10 @@ export const NODES: RoadmapNode[] = [
     status: 'done',
     level: 1,
     detail:
-      'Pattern system release: a curated preset library plus reusable custom slots with a custom-first registry, and pattern licensing settled as CC-BY-SA-4.0.',
+      'v2.0.0 firmware release: modular pattern registry (pattern_registry.h), curated presets (preset_origin.h, preset_wave_saw.h), and user custom slots (custom1.h~custom3.h) under CC-BY-SA 4.0 license.',
     detailKo:
-      '큐레이션 프리셋 라이브러리 및 커스텀 슬롯 지원 (CC-BY-SA 4.0 라이선스).',
+      'v2.0.0 펌웨어 정식 릴리스: 모듈형 패턴 레지스트리(pattern_registry.h), 큐레이션 프리셋 헤더 및 유저 커스텀 패턴 슬롯(custom1.h~custom3.h) 구축 (CC-BY-SA 4.0 라이선스).',
+    links: [{ label: 'firmware/patternflow (v2.0.0)', href: `${REPO}/tree/v2.0.0/firmware/patternflow` }],
   },
   {
     id: 'fw-improv',
@@ -357,9 +399,9 @@ export const NODES: RoadmapNode[] = [
     status: 'done',
     level: 2,
     detail:
-      'Improv-Serial Wi-Fi provisioning during browser flashing, plus a live pattern preview behind the select screen.',
+      'Improv-Serial Wi-Fi provisioning protocol integration: credentials are set directly over Web Serial during browser flashing without requiring hardcoded Wi-Fi passwords.',
     detailKo:
-      '브라우저 플래싱 중 시리얼 기반 Wi-Fi 프로비저닝 지원.',
+      'Improv-Serial Wi-Fi 프로비저닝 프로토콜 연동. 브라우저 플래싱 중 웹 시리얼 연결을 통해 Wi-Fi SSID/PW를 안전하게 전송 및 설정.',
   },
   {
     id: 'fw-ableton',
@@ -370,9 +412,10 @@ export const NODES: RoadmapNode[] = [
     status: 'done',
     level: 2,
     detail:
-      'A Max for Live OSC bridge: Ableton Live parameters drive the device knobs directly, with ping/announce auto-discovery on the firmware side.',
+      'Ableton Live Max for Live bridge (integrations/ableton/): bi-directional OSC control allowing Ableton MIDI & synth parameters to drive Patternflow knobs and pattern switching in real-time.',
     detailKo:
-      'Max for Live OSC 브릿지: Ableton 파라미터로 패턴플로우 엔코더/패턴을 직접 드라이브.',
+      'Max for Live 기반 Ableton Live 연동 브릿지 (integrations/ableton/). 음악 트랙의 MIDI/신디사이저 파라미터가 패턴플로우의 4개 엔코더 및 노이즈 속도를 양방향 OSC로 직접 드라이브.',
+    links: [{ label: 'integrations/ableton', href: `${REPO}/tree/main/integrations/ableton` }],
   },
   {
     id: 'fw-browser-build',
@@ -383,10 +426,14 @@ export const NODES: RoadmapNode[] = [
     status: 'done',
     level: 1,
     detail:
-      'Cloud build queue + Web Serial flasher (PR #230, #231): write or generate custom patterns in Pattern Lab, compile ESP32-S3 firmware in the browser via build worker, and flash directly over Web Serial without local Arduino IDE setup.',
+      'In-browser C++ compilation pipeline & Web Serial flasher (PR #230, #231): compile custom C++ patterns directly in the browser via build worker and flash to ESP32-S3 over Web Serial without local Arduino IDE setup.',
     detailKo:
-      '클라우드 빌드 워커 + Web Serial 플래셔: 로컬 아두이노 설치 없이 웹에서 직접 펌웨어 컴파일 및 USB 플래싱 (#230, #231).',
+      '웹 브라우저 C++ 컴파일 파이프라인 및 Web Serial 플래셔 (PR #230, #231). 로컬 아두이노 IDE 설치 없이 웹 스튜디오에서 작성한 패턴 코드를 클라우드 빌드 워커로 C++ 바이너리 컴파일 후 USB 직렬 플래싱.',
     issues: [230, 231],
+    links: [
+      { label: 'Issue #230', href: `${REPO}/issues/230` },
+      { label: 'Issue #231', href: `${REPO}/issues/231` },
+    ],
   },
   {
     id: 'fw-resolution',
@@ -397,9 +444,9 @@ export const NODES: RoadmapNode[] = [
     status: 'planned',
     level: 1,
     detail:
-      'Patterns render at whatever HUB75 panel size you own — pick a resolution, the engine adapts. This is the technical key that opens Patternflow to existing LED signboards, not just the official 64×64 build. Software stream: ships when ready, not gated on v3.0.0.',
+      'Resolution-agnostic rendering engine: dynamic matrix dimensions allowing Patternflow firmware to render seamlessly on any HUB75 LED panel configuration (64x32, 128x64, commercial LED signs).',
     detailKo:
-      '64x64뿐만 아니라 상용 전광판 등 모든 HUB75 LED 패널 해상도에 맞춰 렌더링하는 범용 엔진.',
+      '해상도 비의존적 렌더링 엔진: 64x64 보드뿐만 아니라 상용 128x64, 64x32 전광판 등 모든 HUB75 LED 패널 규격에 맞춰 패턴 좌표계를 동적으로 스케일링하는 범용 엔진.',
   },
 
   // Pattern tools
@@ -412,9 +459,9 @@ export const NODES: RoadmapNode[] = [
     status: 'done',
     level: 1,
     detail:
-      'Where it all started: the original generative-art website, months before any hardware existed — a node-based pattern studio, URL-shareable presets, 3D relief patterns. Still live at origin.patternflow.work. The pattern-making DNA of the project predates the device.',
+      'The original node-based generative art website (origin.patternflow.work), created months before hardware existed — featuring 3D relief shaders, URL preset sharing, and real-time canvas modulation.',
     detailKo:
-      '하드웨어 제작 몇 달 전, 노드 기반 패턴 스튜디오 및 3D 릴리프 패턴을 선보였던 원형 웹사이트 (origin.patternflow.work).',
+      '하드웨어 제작 몇 달 전 탄생한 원형 노드 기반 제너러티브 아트 웹사이트 (origin.patternflow.work). 3D 릴리프 셰이더, URL 프리셋 공유, 제너레이티브 파동 캔버스 등 프로젝트 알고리즘의 원형이 담겨 있습니다.',
     links: [{ label: 'origin.patternflow.work', href: 'https://origin.patternflow.work/' }],
   },
   {
@@ -426,18 +473,12 @@ export const NODES: RoadmapNode[] = [
     status: 'done',
     level: 1,
     detail:
-      'The project’s second root. The trip was originally to see a different artist’s exhibition — Paik’s own permanent works, Participation TV and Robot K-456, and a 20th-anniversary memorial performance were all chance encounters the same day. Months later, an assignment in an "Authorial Design Studio" class asking students to reinterpret a senior artist gave that chance visit a name: Patternflow as a contemporary Participation TV, where the audience becomes the creator instead of just the viewer.',
+      'Visit to Nam June Paik Art Center & encounter with <Participation TV> (1963): reinterpreting video art as a physical interactive instrument where the audience becomes an active performer shaping light and sound.',
     detailKo:
-      '백남준의 <Participation TV> 관람 ➔ 대중이 관객을 넘어 직접 빛을 연주하는 참여형 예술로서의 핵심 영감.',
+      '백남준아트센터 방문 및 <Participation TV>(1963) 관람: 일방향 시청 대상이었던 TV 비디오 아트를 사용자가 직접 노브를 돌려 신호를 왜곡하고 빛을 연주하는 물리적 참여형 악기로 재해석한 프로젝트의 핵심 철학적 영감.',
     links: [
-      {
-        label: 'Patternflow in 30 days (journal)',
-        href: 'https://patternflow.work/journal/v1-30-days/en',
-      },
-      {
-        label: 'Nam June Paik, Me, Patternflow (journal)',
-        href: 'https://patternflow.work/journal/nam-june-paik-me-patternflow/en',
-      },
+      { label: 'Journal (Nam June Paik, Me, Patternflow)', href: 'https://patternflow.work/journal/nam-june-paik-me-patternflow' },
+      { label: 'Journal (v1 in 30 days)', href: 'https://patternflow.work/journal/v1-30-days' },
     ],
   },
   {
@@ -449,9 +490,10 @@ export const NODES: RoadmapNode[] = [
     status: 'done',
     level: 1,
     detail:
-      'The in-browser live pattern editor with JS-to-C++ parity and an AI conversion prompt — write a pattern on the website, carry it to the device.',
+      'In-browser Live Pattern Editor (patternflow.work/pattern-lab): featuring JS-to-C++ parity, live 64x64 canvas simulation, real-time knob modulation, and instant C++ code exporter.',
     detailKo:
-      'JS-to-C++ 파리티 및 AI 변환 프롬프트를 갖춘 브라우저 내 라이브 패턴 에디터.',
+      '웹 브라우저 라이브 패턴 에디터 (patternflow.work/pattern-lab). JS 캔버스 시뮬레이터와 C++ 디바이스 드라이버 간의 1:1 파리티, 실시간 노브 변조 및 C++ 헤더 자동 내보내기 지원.',
+    links: [{ label: 'Live Editor', href: 'https://patternflow.work/pattern-lab' }],
   },
   {
     id: 'tools-lab',
@@ -462,9 +504,10 @@ export const NODES: RoadmapNode[] = [
     status: 'done',
     level: 2,
     detail:
-      'The pattern development harness with calibrated knobs, plus the Video Baker experiment (later retired when video mode was dropped from firmware).',
+      'Pattern Lab harness: featuring calibrated physical knob sliders, color palette selector, noise spectrum visualizers, and pattern performance profiling.',
     detailKo:
-      '노브 조작 튜닝 및 패턴 개발 하네스 스튜디오.',
+      '패턴 튜닝 하네스 스튜디오 (Pattern Lab). 4개 로터리 엔코더 가상 슬라이더, 팔레트 색상 램프 조절기, Simplex 노이즈 주파수 시각화 및 FPS 성능 측정 도구 수록.',
+    links: [{ label: 'Pattern Lab', href: 'https://patternflow.work/pattern-lab' }],
   },
   {
     id: 'tools-gemini',
@@ -475,9 +518,10 @@ export const NODES: RoadmapNode[] = [
     status: 'done',
     level: 1,
     detail:
-      'In-app AI pattern generation in Pattern Lab — bring your own Gemini key, describe a pattern, get running code. The proof of concept for AI-assisted pattern making.',
+      'AI pattern generation in Pattern Lab using Google Gemini API: describe desired visual patterns in natural language and automatically generate running C++ matrix code.',
     detailKo:
-      'Pattern Lab 내 Gemini API 키 연동으로 텍스트 묘사를 통해 패턴 코드를 자동 생성.',
+      'Pattern Lab 내 Google Gemini API 키 연동. "소용돌이치는 오로라 파동" 등 자연어 텍스트 설명만으로 디바이스에서 바로 실행되는 C++ 매트릭스 패턴 코드를 자동 생성.',
+    links: [{ label: 'Pattern Lab AI', href: 'https://patternflow.work/pattern-lab' }],
   },
   {
     id: 'tools-stack',
@@ -488,9 +532,10 @@ export const NODES: RoadmapNode[] = [
     status: 'done',
     level: 1,
     detail:
-      'Color ramp and v-field modes, the Experiment layer-stack tab that compiles patches to pattern code, knob bindings, and a much stronger C++ conversion prompt (pre-baked LUTs, macro collision warnings, an expensive-math decision table).',
+      'Color ramp & vector field generator modes in Pattern Lab: layer-stacking engine compiling visual patches into C++ code with pre-baked math decision tables and LUT optimizations.',
     detailKo:
-      'v-field 및 컬러 램프 모드, 생성기 레이어를 쌓아 패턴을 완성하는 Experiment 탭.',
+      'Pattern Lab 내 컬러 램프 & 벡터 필드 생성기 모드. 시각 효과 레이어를 쌓아복합 패턴을 구성하고, LUT 디시전 테이블을 통해 고성능 C++ 코드로 자동 합성하는 기능.',
+    links: [{ label: 'Pattern Lab Studio', href: 'https://patternflow.work/pattern-lab' }],
   },
   {
     id: 'tools-lab-mobile',
@@ -501,9 +546,10 @@ export const NODES: RoadmapNode[] = [
     status: 'done',
     level: 2,
     detail:
-      'Added direct clipboard paste and code clear buttons for mobile users, localStorage draft autosave, direct panel resolution entry (// @matrix), and upgraded C++ prompt generator.',
+      'Mobile UX overhaul for Pattern Lab: direct clipboard paste/clear buttons, localStorage draft autosave, and custom panel resolution tags (// @matrix W H).',
     detailKo:
-      '모바일 클립보드 붙여넣기/전체 지우기 버튼, 세션 자동 저장, 커스텀 패널 해상도 직접 입력 (// @matrix).',
+      '패턴랩 모바일 터치 UX 최적화: 클립보드 원터치 붙여넣기/전체 지우기, 임시 저장 세션 자동 복구 및 커스텀 패널 해상도 설정 주석(// @matrix W H) 지원.',
+    links: [{ label: 'Pattern Lab Mobile', href: 'https://patternflow.work/pattern-lab' }],
   },
   {
     id: 'tools-multiagent',
@@ -514,9 +560,9 @@ export const NODES: RoadmapNode[] = [
     status: 'planned',
     level: 1,
     detail:
-      'The next step past single-shot Gemini generation: multiple agents generating, critiquing, and refining patterns in a loop, so quality stops depending on prompt luck. Software stream — ships continuously, independent of v3.0.0.',
+      'Multi-agent AI pattern generation pipeline: autonomous generator, critic, and refiner agents working in a feedback loop to produce complex, visually stunning shaders.',
     detailKo:
-      '다중 AI 에이전트가 패턴을 생성하고 비평·수정하는 피드백 루프 생성기.',
+      '다중 AI 에이전트 렌더링 시스템: 생성기, 비평기, 코드 교정기 에이전트가 루프를 돌며 우수한 비주얼의 셰이더 패턴을 스스로 다듬어내는 차세대 AI 에디터.',
   },
 
   // Community & business
@@ -529,9 +575,12 @@ export const NODES: RoadmapNode[] = [
     status: 'done',
     level: 1,
     detail:
-      'Serene from PCBWay sent a DM on 04-20, having seen the Reddit post, offering to sponsor a PCB order — the very first PCB, ordered free the next day, before the repo was even public. PCBWay has kept sponsoring since, through the 3D-printing experiments and the v2.2 gerber order.',
+      'PCBWay sponsorship partnership: PCBWay reached out on Reddit and sponsored the first PCB prototype order, initiating ongoing hardware manufacturing support.',
     detailKo:
-      '레딧 글을 본 PCBWay에서 첫 PCB 제작 지원을 제안하여 프로젝트가 본격화된 계기.',
+      '레딧 게시글을 본 PCBWay에서 패턴플로우의 가능성을 알아보고 첫 PCB 제작 전액 스폰서십을 제안. 프로젝트가 아이디어를 넘어 하드웨어 제조 단계로 도약한 순간.',
+    links: [
+      { label: 'Journal (v1 in 30 days)', href: 'https://patternflow.work/journal/v1-30-days' },
+    ],
   },
   {
     id: 'biz-reddit',
@@ -542,9 +591,14 @@ export const NODES: RoadmapNode[] = [
     status: 'done',
     level: 1,
     detail:
-      'The repo went public and the Reddit post went viral — the moment Patternflow stopped being a personal project.',
+      'Official public repository release & viral Reddit post on r/arduino: gaining global maker traction and transitioning Patternflow into an open-source community project.',
     detailKo:
-      'r/arduino 레딧 게시글 바이럴 ➔ 개인 프로젝트에서 글로벌 오픈소스 프로젝트로 전환.',
+      'r/arduino 레딧 커뮤니티 정식 공개 후 폭발적인 반응 바이럴. 개인 프로젝트에서 전 세계 메이커들이 함께하는 오픈소스 커뮤니티로 전환.',
+    links: [
+      { label: 'Reddit Viral Post #1', href: 'https://www.reddit.com/r/arduino/comments/1so9er5/built_a_4knob_generative_pattern_controller_with/' },
+      { label: 'Reddit PCB Update #2', href: 'https://www.reddit.com/r/arduino/comments/1szettd/12_days_later_pcb_done_rotary_encoders_done_fully/' },
+      { label: 'Journal (Me and Patternflow)', href: 'https://patternflow.work/journal/me-and-patternflow' },
+    ],
   },
   {
     id: 'biz-discord',
@@ -555,9 +609,13 @@ export const NODES: RoadmapNode[] = [
     status: 'done',
     level: 2,
     detail:
-      'The Discord server opened and the journal started, turning the build log into a public story. First external contributor PRs landed the same week.',
+      'Official Discord server & Patternflow Journal launch (patternflow.work/journal): sharing transparent build logs, hardware challenges, and receiving first community PRs.',
     detailKo:
-      '공식 디스코드 커뮤니티 오픈 및 개발 저널(Journal) 연재 시작.',
+      '공식 디스코드 커뮤니티 서버 개설 및 개발 이야기(patternflow.work/journal) 연재 시작. 투명한 개발 일지 공유를 통해 전 세계 기여자의 첫 PR 접수.',
+    links: [
+      { label: 'Official Discord', href: 'https://discord.gg/Vr9QtsxeTk' },
+      { label: 'Journal Index', href: 'https://patternflow.work/journal' },
+    ],
   },
   {
     id: 'biz-cs',
@@ -568,9 +626,13 @@ export const NODES: RoadmapNode[] = [
     status: 'done',
     level: 1,
     detail:
-      'The Crowd Supply contract was signed — the commitment that Patternflow becomes a product you can order, not just a repo you can build from.',
+      'Official Crowd Supply crowdfunding contract signed: committing Patternflow to become a commercially available open-source hardware kit.',
     detailKo:
-      '크라우드 서플라이 공식 입점 계약 체결.',
+      '세계 최대 오픈소스 하드웨어 펀딩 플랫폼인 Crowd Supply와 공식 입점 계약 체결. 누구나 쉽게 완제품 또는 DIY 키트로 구매할 수 있는 기반 마련.',
+    links: [
+      { label: 'Crowd Supply Page', href: 'https://www.crowdsupply.com/engmung/patternflow' },
+      { label: 'Journal (refocus)', href: 'https://patternflow.work/journal/refocus' },
+    ],
   },
   {
     id: 'biz-nath-build',
@@ -581,9 +643,10 @@ export const NODES: RoadmapNode[] = [
     status: 'done',
     level: 2,
     detail:
-      'The first fully independent community build (Nath) went up on the build map — proof the guide worked for someone who wasn’t the author.',
+      'First fully independent external community build by UK maker Nath (/inside/nath-uk): validating that the open-source BUILD_GUIDE.md works seamlessly for third-party builders.',
     detailKo:
-      '해외 외부 유저(Nath)의 가이드 기반 완티드 빌드 성공 및 빌드 맵 등록.',
+      '영국의 유저 Nath가 오픈소스 빌드 가이드만 보고 완전히 스스로 제작에 성공한 첫 커뮤니티 실물 빌드 (/inside/nath-uk). 누구나 만들 수 있는 하드웨어 문서화 검증.',
+    links: [{ label: 'Nath UK Build', href: 'https://patternflow.work/inside/nath-uk' }],
   },
   {
     id: 'biz-prelaunch',
@@ -594,9 +657,9 @@ export const NODES: RoadmapNode[] = [
     status: 'done',
     level: 1,
     detail:
-      'The Crowd Supply pre-launch page replaced the waitlist across the site and README. Interest signups now feed the campaign directly.',
+      'Crowd Supply pre-launch page live: gathering interest signups and backer notifications across the web ecosystem for campaign launch readiness.',
     detailKo:
-      '공식 프리런칭 페이지 공개 및 구독 알림 수집 시작.',
+      'Crowd Supply 공식 프리런칭 페이지 런칭. 전 세계 유저를 대상으로 출시 알림 구독 신청을 수집하기 시작.',
     links: [{ label: 'Crowd Supply page', href: 'https://www.crowdsupply.com/engmung/patternflow' }],
   },
   {
@@ -608,10 +671,11 @@ export const NODES: RoadmapNode[] = [
     status: 'done',
     level: 1,
     detail:
-      'Passed 160+ subscribers on Crowd Supply pre-launch — surpassing the 150 subscriber milestone required for official launch prep — driven by viral Instagram pattern posts hitting ~300k views.',
+      'Surpassed 160+ Crowd Supply pre-launch subscribers — fulfilling the mandatory 150 subscriber threshold for campaign launch approval — driven by viral Instagram pattern videos reaching over 300,000 views.',
     detailKo:
-      '인스타 패턴 바이럴(~30만 회)에 힘입어 크라우드 서플라이 프리런칭 구독자 162명 돌파 (런칭 준비 임계점 달성).',
+      '인스타그램 패턴 바이럴 영상(~30만 회) 폭발적 호응에 힘입어 Crowd Supply 프리런칭 구독자 162명 돌파 (펀딩 정식 승인 요건인 150명 달성).',
     links: [
+      { label: 'Instagram @patternflow.work', href: 'https://www.instagram.com/patternflow.work' },
       { label: 'Crowd Supply page', href: 'https://www.crowdsupply.com/engmung/patternflow' },
       { label: 'Journal (faster-faster)', href: 'https://patternflow.work/journal/faster-faster' },
     ],
@@ -625,9 +689,9 @@ export const NODES: RoadmapNode[] = [
     status: 'done',
     level: 1,
     detail:
-      'Launched the Patternflow Community hub (/community) featuring text discussion boards and pattern sharing with fork capabilities — copy base patterns, tweak color ramps or code, and republish.',
+      'Patternflow Community Hub launch (patternflow.work/community): featuring discussion forums and pattern sharing with fork capabilities — copy base patterns, customize color ramps, and republish to the community.',
     detailKo:
-      '패턴 공유 및 포크(코드/색상 변형 후 재게시) 기능을 갖춘 커뮤니티 Hub (/community) 오픈.',
+      '패턴플로우 공식 커뮤니티 허브 (patternflow.work/community) 런칭. 유저 간 패턴 공유, 커스텀 색상/코드 변형 후 재게시(Fork) 기능 및 토론 게시판 오픈.',
     links: [{ label: 'Community Hub', href: 'https://patternflow.work/community' }],
   },
   {
@@ -639,9 +703,10 @@ export const NODES: RoadmapNode[] = [
     status: 'planned',
     level: 1,
     detail:
-      'The Crowd Supply campaign goes live once v3.0.0 is real: verified board, printable case, and guides that match what backers will actually build.',
+      'Global Crowd Supply crowdfunding campaign launch: offering assembled Patternflow instruments, DIY component kits, and custom enclosures to backers worldwide.',
     detailKo:
-      'v3.0.0 하드웨어와 검증된 가이드 기반으로 전 세계 크라우드 펀딩 런칭.',
+      '전 세계 유저를 대상으로 한 Crowd Supply 공식 크라우드 펀딩 런칭. 완제품 및 DIY 부품 키트를 글로벌 배송하여 전 세계로 파동을 확산.',
+    links: [{ label: 'Crowd Supply page', href: 'https://www.crowdsupply.com/engmung/patternflow' }],
   },
   {
     id: 'biz-market',
@@ -652,9 +717,9 @@ export const NODES: RoadmapNode[] = [
     status: 'planned',
     level: 1,
     detail:
-      'The long-term shape: anyone with an LED panel — including commercial signboard owners — can make patterns with the tools, run them at their own resolution, and sell them. The any-resolution engine and multi-agent generation are the two threads that converge here.',
+      'Open Pattern Marketplace: enabling generative artists to create, publish, and monetize LED matrix patterns for device owners and commercial signboard installations worldwide.',
     detailKo:
-      '모든 패널 크기에서 누구나 패턴을 만들고 판매할 수 있는 장기 생태계.',
+      '오픈 패턴 마켓플레이스: 미디어 아티스트 및 개발자가 생성한 매트릭스 패턴을 공유하고 전 세계 기기 소유자 및 상용 전광판에 판매/유통할 수 있는 오픈 생태계.',
   },
 ];
 

--- a/web/src/app/roadmap/roadmap-data.ts
+++ b/web/src/app/roadmap/roadmap-data.ts
@@ -13,10 +13,12 @@ export type RoadmapNode = {
   lane: LaneId;
   date: string;
   title: string;
+  titleKo?: string;
   status: 'done' | 'planned';
   level: 1 | 2;
   gate?: boolean;
   detail: string;
+  detailKo?: string;
   issues?: number[];
   links?: { label: string; href: string }[];
 };
@@ -25,13 +27,13 @@ export type RoadmapEdge = { from: string; to: string; note: string };
 
 export const NOW = '2026-07-26';
 
-export const LANES: { id: LaneId; label: string }[] = [
-  { id: 'pcb', label: 'PCB' },
-  { id: 'case', label: 'Enclosure' },
-  { id: 'guides', label: 'Guides' },
-  { id: 'firmware', label: 'Firmware' },
-  { id: 'tools', label: 'Pattern tools' },
-  { id: 'community', label: 'Community' },
+export const LANES: { id: LaneId; label: string; labelKo: string }[] = [
+  { id: 'pcb', label: 'PCB', labelKo: 'PCB 회로' },
+  { id: 'case', label: 'Enclosure', labelKo: '인클로저' },
+  { id: 'guides', label: 'Guides', labelKo: '가이드' },
+  { id: 'firmware', label: 'Firmware', labelKo: '펌웨어' },
+  { id: 'tools', label: 'Pattern tools', labelKo: '패턴 도구' },
+  { id: 'community', label: 'Community', labelKo: '커뮤니티' },
 ];
 
 const REPO = 'https://github.com/engmung/Patternflow';
@@ -43,10 +45,13 @@ export const NODES: RoadmapNode[] = [
     lane: 'pcb',
     date: '2026-03-29',
     title: 'First hardware prototype',
+    titleKo: '첫 실물 프로토타입',
     status: 'done',
     level: 2,
     detail:
       'First hand-wired prototype: LED matrix + ESP32 + 4 potentiometers assembled in the club room, bringing Patternflow out of the web browser and into physical space at Mapo Saebit Cultural Forest.',
+    detailKo:
+      '동아리방에서 핸드와이어링으로 조립한 첫 실물 프로토타입(LED 매트릭스 + ESP32 + 4개 가변저항). 웹 브라우저 안의 패턴플로우를 마포새빛문화숲 야외 물리 공간으로 실재화했습니다.',
     links: [{ label: 'Journal (v1 in 30 days)', href: 'https://patternflow.work/journal/v1-30-days' }],
   },
   {
@@ -54,50 +59,65 @@ export const NODES: RoadmapNode[] = [
     lane: 'pcb',
     date: '2026-04-26',
     title: 'v1 board',
+    titleKo: 'v1.0 보드',
     status: 'done',
     level: 1,
     detail:
       'First public hardware release: gerbers, KiCad schematic, and a hand-solderable ESP32 + HUB75 board. Everything since is a refinement of this layout.',
+    detailKo:
+      '첫 공개 하드웨어 릴리스: Gerber, KiCad 회로도, 손납땜 가능한 ESP32 + HUB75 보드.',
   },
   {
     id: 'pcb-v2',
     lane: 'pcb',
     date: '2026-05-08',
     title: 'v2 fixes',
+    titleKo: 'v2 버그 수정',
     status: 'done',
     level: 2,
     detail:
       'GPIO0 pull-up fix and encoder silkscreen corrections, driven directly by problems early community builders hit on v1 boards.',
+    detailKo:
+      '초기 빌더들의 피드백 반영: GPIO0 풀업 보정 및 엔코더 실크스크린 오류 수정.',
   },
   {
     id: 'pcb-v21',
     lane: 'pcb',
     date: '2026-06-18',
     title: 'v2.1 routing',
+    titleKo: 'v2.1 배선 리라우팅',
     status: 'done',
     level: 2,
     detail:
       'Reworked ESP32-to-HUB75 routing and silkscreen cleanup. These are the currently recommended gerbers — the build guide is pinned to them.',
+    detailKo:
+      'ESP32-HUB75 배선 리라우팅 및 실크스크린 정리.',
   },
   {
     id: 'pcb-v22',
     lane: 'pcb',
     date: '2026-06-28',
     title: 'v2.2 USB-C test',
+    titleKo: 'v2.2 USB-C 테스트',
     status: 'done',
     level: 1,
     detail:
       'Test board that moves power input to USB-C and goes fully SMD-free. Ordered on 2026-06-30 through a PCBWay gerber sponsorship. Once verified, this board gets promoted to v3. Moving the power connector also breaks the current enclosure, which was designed around v2.1 — so the case follows.',
+    detailKo:
+      '전원을 USB-C로 이동하고 완전 SMD-free로 개편한 테스트 보드 (PCBWay Gerber 스폰서십 제작).',
   },
   {
     id: 'pcb-usbc-safety',
     lane: 'pcb',
     date: '2026-07-20',
     title: 'USB-C power on hold & review',
+    titleKo: 'USB-C 전원 재검토 (보류)',
     status: 'done',
     level: 2,
     detail:
       'USB-C power input placed on hold under active re-evaluation (Issue #221): investigating delayed connector burnout (20–30 min run before pin failure). Full re-evaluation of 14-pin THT vs power-only connectors in progress; builds pinned to 2-pin screw terminal (J4).',
+    detailKo:
+      'USB-C 입력 지연 탄화 현상(20~30분 구동 후 핀 탄화) 원인 조사 및 전면 재검토 진행 중 (Issue #221). DIY 빌더 전원은 2핀 스크류 터미널(J4)로 보정.',
     issues: [221],
     links: [{ label: 'Issue #221', href: `${REPO}/issues/221` }],
   },
@@ -106,11 +126,14 @@ export const NODES: RoadmapNode[] = [
     lane: 'pcb',
     date: '2026-07-20',
     title: 'v3.0.0 board',
+    titleKo: 'v3.0.0 보드',
     status: 'done',
     level: 1,
     gate: true,
     detail:
       'v3.0.0 hardware release: reworked module positions, shrunk overall board size to reduce manufacturing costs, and added USB-C power footprint alongside the 2-pin screw terminal.',
+    detailKo:
+      'v3.0.0 하드웨어 릴리스: 모듈 배치 수정, 부품 배선 정리, 생산 단가 절감을 위한 전체 PCB 사이즈 축소.',
     links: [
       { label: 'hardware/pcb', href: `${REPO}/tree/main/hardware/pcb` },
       { label: 'Journal (v3 and beyond)', href: 'https://patternflow.work/journal/v3-and-beyond' },
@@ -123,10 +146,13 @@ export const NODES: RoadmapNode[] = [
     lane: 'case',
     date: '2026-04-26',
     title: 'Original v1 case',
+    titleKo: 'v1.0 인클로저',
     status: 'done',
     level: 1,
     detail:
       'The original enclosure, released with v1.0: a fully modeled Blender design with print-ready STLs, a parts breakdown, and print-time notes. This modeling is the ancestor every later case variant descends from.',
+    detailKo:
+      'v1.0 공개 케이스: Blender 3D 모델 및 STL 출력 파일, 출력을 위한 부품 분할.',
     links: [{ label: 'hardware/case', href: `${REPO}/tree/main/hardware/case` }],
   },
   {
@@ -134,30 +160,39 @@ export const NODES: RoadmapNode[] = [
     lane: 'case',
     date: '2026-05-26',
     title: 'Laser-cut acrylic',
+    titleKo: '레이저 커팅 아크릴',
     status: 'done',
     level: 2,
     detail:
       'A laser-cut acrylic variant of the v1 case, with its own Blender source — an alternative for people with cutter access instead of a 3D printer.',
+    detailKo:
+      '3D 프린터 대신 레이저 커터를 사용하는 유저를 위한 아크릴 케이스.',
   },
   {
     id: 'case-exp',
     lane: 'case',
     date: '2026-06-04',
     title: 'Print experiments',
+    titleKo: '인클로저 출력 실험',
     status: 'done',
     level: 2,
     detail:
       'A long run of 3D-printing experiments through June, kicked off by a PCBWay 3D-printing sponsorship that funded test prints: flat plates, easybond, big-oneshot, easyfit with alignment tabs, one-shot print ribs, a wall-mount hanger — searching for a case that prints reliably without support pain.',
+    detailKo:
+      'PCBWay 3D 프린팅 스폰서십 기반 snap-fit, rib 구조 등 대규모 3D 출력 실험.',
   },
   {
     id: 'case-snapfit',
     lane: 'case',
     date: '2026-07-05',
     title: 'Snap-fit one-piece',
+    titleKo: '일체형 스냅핏 케이스',
     status: 'done',
     level: 1,
     detail:
       'The one-piece snap-fit enclosure graduated to a print-ready option after a confirmed stable one-shot print. It needs a ~330 mm bed, and — important — it was designed around the v2.1 board, so it predates the USB-C power input.',
+    detailKo:
+      '서포트 없이 1회 출력 가능한 일체형 스냅핏 인클로저 설계.',
     links: [{ label: 'Issue #113 (closed)', href: `${REPO}/issues/113` }],
   },
   {
@@ -165,11 +200,14 @@ export const NODES: RoadmapNode[] = [
     lane: 'case',
     date: '2026-07-20',
     title: 'v3 snap-fit enclosure',
+    titleKo: 'v3 스냅핏 인클로저',
     status: 'done',
     level: 1,
     gate: true,
     detail:
       'v3 enclosure release: added snap-fit joints and overall tolerance improvements to elevate product quality for the Crowd Supply launch.',
+    detailKo:
+      'v3.0.0 전용 인클로저: 스냅핏 결합부 보강 및 유격 공차 개선으로 완성도를 올린 크라우드 서플라이 런칭용 케이스.',
     links: [{ label: 'hardware/case', href: `${REPO}/tree/main/hardware/case` }],
   },
 
@@ -179,10 +217,13 @@ export const NODES: RoadmapNode[] = [
     lane: 'guides',
     date: '2026-04-26',
     title: 'Build guide v1',
+    titleKo: 'v1 빌드 가이드',
     status: 'done',
     level: 1,
     detail:
       'The first full build guide shipped with the public launch — BOM, sourcing links, assembly steps, firmware flashing. Iterated on community feedback from day one (soldering temps, encoder shaft specs, GPIO0 workarounds).',
+    detailKo:
+      'BOM, 부품 구매 링크, 조립 과정, 펌웨어 업로드 가이드 첫 출간.',
     links: [{ label: 'BUILD_GUIDE.md', href: `${REPO}/blob/main/BUILD_GUIDE.md` }],
   },
   {
@@ -190,41 +231,53 @@ export const NODES: RoadmapNode[] = [
     lane: 'guides',
     date: '2026-05-03',
     title: 'Photo rewrite',
+    titleKo: '사진/영상 가이드 개편',
     status: 'done',
     level: 2,
     detail:
       'The comprehensive rewrite: build photos and videos for every step, a pin reference, restructured sections. The guide went from "notes" to something a stranger can actually follow.',
+    detailKo:
+      '모든 단계마다 실물 조립 사진과 영상을 첨부하여 가이드를 대대적으로 개선.',
   },
   {
     id: 'guide-breadboard',
     lane: 'guides',
     date: '2026-06-28',
     title: 'Breadboard guide',
+    titleKo: '빵판(Breadboard) 가이드',
     status: 'done',
     level: 2,
     detail:
       'A solder-free build path on a breadboard, lowering the entry bar for people who want to try Patternflow before committing to a PCB order.',
+    detailKo:
+      '납땜 없이 빵판에서 패턴플로우를 직접 만들어볼 수 있는 진입 가이드.',
   },
   {
     id: 'guide-tht',
     lane: 'guides',
     date: '2026-07-05',
     title: 'Through-hole BOM',
+    titleKo: 'Through-hole BOM 개편',
     status: 'done',
     level: 2,
     detail:
       'The BOM went all-through-hole (SMD passives dropped) and the guide was pinned to the v2.1 gerbers, with a heads-up that v3.0 is coming.',
+    detailKo:
+      'SMD 소자를 전부 제거하고 100% Through-hole(THT) 부품으로 BOM 개편.',
   },
   {
     id: 'guide-rebuild',
     lane: 'guides',
     date: '2026-07-20',
     title: 'Build guide v3.0.0',
+    titleKo: 'v3.0.0 빌드 가이드',
     status: 'done',
     level: 1,
     gate: true,
     detail:
       'Build guide updated for v3.0.0 hardware and snap-fit enclosure: BOM, assembly steps, and wiring diagrams updated for the v3 release.',
+    detailKo:
+      'v3 보드 및 스냅핏 케이스에 맞춘 빌드 가이드 완전 개정.',
     links: [{ label: 'BUILD_GUIDE.md', href: `${REPO}/blob/main/BUILD_GUIDE.md` }],
   },
   {
@@ -232,11 +285,14 @@ export const NODES: RoadmapNode[] = [
     lane: 'guides',
     date: '2026-08-28',
     title: 'Pattern guide',
+    titleKo: '패턴 제작 가이드',
     status: 'planned',
     level: 1,
     gate: true,
     detail:
       'The first proper pattern-creation guide: from the web tools to code running on the device. This is the on-ramp for people who want to make patterns rather than build hardware.',
+    detailKo:
+      '웹 툴부터 디바이스 C++ 실행까지 패턴을 직접 만드는 개발자를 위한 정식 가이드.',
   },
 
   // Firmware
@@ -245,70 +301,91 @@ export const NODES: RoadmapNode[] = [
     lane: 'firmware',
     date: '2026-04-26',
     title: 'v1.0 firmware',
+    titleKo: 'v1.0 펌웨어',
     status: 'done',
     level: 1,
     detail:
       'The firmware as first open-sourced: single hardcoded patterns, hardware configs extracted to config.h, flashable from the browser via ESP Web Tools.',
+    detailKo:
+      '웹 브라우저(ESP Web Tools)에서 직접 플래싱 가능한 오픈소스 초기 펌웨어.',
   },
   {
     id: 'fw-foundation',
     lane: 'firmware',
     date: '2026-05-21',
     title: 'ESP32 optimization',
+    titleKo: 'ESP32 펌웨어 대개편',
     status: 'done',
     level: 1,
     detail:
       'The big structural rewrite that made patterns fast on the ESP32: shared core_math / core_color / core_noise libraries, patterns drawing through PFCanvas instead of the raw display driver, gamma LUT, ~240 Hz refresh to kill camera flicker, encoder acceleration. Everything since builds on this.',
+    detailKo:
+      'shared core_math / core_color / core_noise 라이브러리, PFCanvas 드라이버, 감마 LUT, ~240Hz 주사율, 엔코더 가속 알고리즘 도입.',
   },
   {
     id: 'fw-osc',
     lane: 'firmware',
     date: '2026-05-27',
     title: 'OSC · OTA · audio',
+    titleKo: 'OSC · OTA · 오디오',
     status: 'done',
     level: 2,
     detail:
       'Two-way OSC control, wireless OTA flashing, and the audio-react experiments (a websocket server driving virtual knobs). The async rewrite of audio-react was rolled back — the Ableton bridge later picked up that thread.',
+    detailKo:
+      '양방향 OSC 제어, 무선 OTA 펌웨어 업데이트, 오디오 반응 실험.',
   },
   {
     id: 'fw-v2',
     lane: 'firmware',
     date: '2026-06-22',
     title: 'v2.0.0 presets',
+    titleKo: 'v2.0.0 프리셋 시스템',
     status: 'done',
     level: 1,
     detail:
       'Pattern system release: a curated preset library plus reusable custom slots with a custom-first registry, and pattern licensing settled as CC-BY-SA-4.0.',
+    detailKo:
+      '큐레이션 프리셋 라이브러리 및 커스텀 슬롯 지원 (CC-BY-SA 4.0 라이선스).',
   },
   {
     id: 'fw-improv',
     lane: 'firmware',
     date: '2026-06-23',
     title: 'Improv Wi-Fi',
+    titleKo: 'Improv Wi-Fi 설정',
     status: 'done',
     level: 2,
     detail:
       'Improv-Serial Wi-Fi provisioning during browser flashing, plus a live pattern preview behind the select screen.',
+    detailKo:
+      '브라우저 플래싱 중 시리얼 기반 Wi-Fi 프로비저닝 지원.',
   },
   {
     id: 'fw-ableton',
     lane: 'firmware',
     date: '2026-07-04',
     title: 'Ableton bridge',
+    titleKo: 'Ableton Live 연동 브릿지',
     status: 'done',
     level: 2,
     detail:
       'A Max for Live OSC bridge: Ableton Live parameters drive the device knobs directly, with ping/announce auto-discovery on the firmware side.',
+    detailKo:
+      'Max for Live OSC 브릿지: Ableton 파라미터로 패턴플로우 엔코더/패턴을 직접 드라이브.',
   },
   {
     id: 'fw-browser-build',
     lane: 'firmware',
     date: '2026-07-25',
     title: 'Browser firmware worker',
+    titleKo: '웹 브라우저 펌웨어 빌더',
     status: 'done',
     level: 1,
     detail:
       'Cloud build queue + Web Serial flasher (PR #230, #231): write or generate custom patterns in Pattern Lab, compile ESP32-S3 firmware in the browser via build worker, and flash directly over Web Serial without local Arduino IDE setup.',
+    detailKo:
+      '클라우드 빌드 워커 + Web Serial 플래셔: 로컬 아두이노 설치 없이 웹에서 직접 펌웨어 컴파일 및 USB 플래싱 (#230, #231).',
     issues: [230, 231],
   },
   {
@@ -316,10 +393,13 @@ export const NODES: RoadmapNode[] = [
     lane: 'firmware',
     date: '2026-09-15',
     title: 'Any-resolution engine',
+    titleKo: '자유 해상도 엔진',
     status: 'planned',
     level: 1,
     detail:
       'Patterns render at whatever HUB75 panel size you own — pick a resolution, the engine adapts. This is the technical key that opens Patternflow to existing LED signboards, not just the official 64×64 build. Software stream: ships when ready, not gated on v3.0.0.',
+    detailKo:
+      '64x64뿐만 아니라 상용 전광판 등 모든 HUB75 LED 패널 해상도에 맞춰 렌더링하는 범용 엔진.',
   },
 
   // Pattern tools
@@ -328,10 +408,13 @@ export const NODES: RoadmapNode[] = [
     lane: 'tools',
     date: '2026-01-11',
     title: 'Patternflow origin',
+    titleKo: '패턴플로우 오리진',
     status: 'done',
     level: 1,
     detail:
       'Where it all started: the original generative-art website, months before any hardware existed — a node-based pattern studio, URL-shareable presets, 3D relief patterns. Still live at origin.patternflow.work. The pattern-making DNA of the project predates the device.',
+    detailKo:
+      '하드웨어 제작 몇 달 전, 노드 기반 패턴 스튜디오 및 3D 릴리프 패턴을 선보였던 원형 웹사이트 (origin.patternflow.work).',
     links: [{ label: 'origin.patternflow.work', href: 'https://origin.patternflow.work/' }],
   },
   {
@@ -339,10 +422,13 @@ export const NODES: RoadmapNode[] = [
     lane: 'tools',
     date: '2026-01-28',
     title: 'Nam June Paik Art Center',
+    titleKo: '백남준아트센터 영감',
     status: 'done',
     level: 1,
     detail:
       'The project’s second root. The trip was originally to see a different artist’s exhibition — Paik’s own permanent works, Participation TV and Robot K-456, and a 20th-anniversary memorial performance were all chance encounters the same day. Months later, an assignment in an "Authorial Design Studio" class asking students to reinterpret a senior artist gave that chance visit a name: Patternflow as a contemporary Participation TV, where the audience becomes the creator instead of just the viewer.',
+    detailKo:
+      '백남준의 <Participation TV> 관람 ➔ 대중이 관객을 넘어 직접 빛을 연주하는 참여형 예술로서의 핵심 영감.',
     links: [
       {
         label: 'Patternflow in 30 days (journal)',
@@ -359,60 +445,78 @@ export const NODES: RoadmapNode[] = [
     lane: 'tools',
     date: '2026-05-04',
     title: 'Live Editor',
+    titleKo: '웹 라이브 에디터',
     status: 'done',
     level: 1,
     detail:
       'The in-browser live pattern editor with JS-to-C++ parity and an AI conversion prompt — write a pattern on the website, carry it to the device.',
+    detailKo:
+      'JS-to-C++ 파리티 및 AI 변환 프롬프트를 갖춘 브라우저 내 라이브 패턴 에디터.',
   },
   {
     id: 'tools-lab',
     lane: 'tools',
     date: '2026-05-13',
     title: 'Pattern Lab',
+    titleKo: '패턴랩 (Pattern Lab)',
     status: 'done',
     level: 2,
     detail:
       'The pattern development harness with calibrated knobs, plus the Video Baker experiment (later retired when video mode was dropped from firmware).',
+    detailKo:
+      '노브 조작 튜닝 및 패턴 개발 하네스 스튜디오.',
   },
   {
     id: 'tools-gemini',
     lane: 'tools',
     date: '2026-06-24',
     title: 'Gemini generation',
+    titleKo: 'Gemini AI 패턴 생성',
     status: 'done',
     level: 1,
     detail:
       'In-app AI pattern generation in Pattern Lab — bring your own Gemini key, describe a pattern, get running code. The proof of concept for AI-assisted pattern making.',
+    detailKo:
+      'Pattern Lab 내 Gemini API 키 연동으로 텍스트 묘사를 통해 패턴 코드를 자동 생성.',
   },
   {
     id: 'tools-stack',
     lane: 'tools',
     date: '2026-07-02',
     title: 'Layers + color ramps',
+    titleKo: '컬러 램프 & 레이어 스택',
     status: 'done',
     level: 1,
     detail:
       'Color ramp and v-field modes, the Experiment layer-stack tab that compiles patches to pattern code, knob bindings, and a much stronger C++ conversion prompt (pre-baked LUTs, macro collision warnings, an expensive-math decision table).',
+    detailKo:
+      'v-field 및 컬러 램프 모드, 생성기 레이어를 쌓아 패턴을 완성하는 Experiment 탭.',
   },
   {
     id: 'tools-lab-mobile',
     lane: 'tools',
     date: '2026-07-26',
     title: 'Lab mobile & resolution',
+    titleKo: '패턴랩 모바일 UX & 해상도',
     status: 'done',
     level: 2,
     detail:
       'Added direct clipboard paste and code clear buttons for mobile users, localStorage draft autosave, direct panel resolution entry (// @matrix), and upgraded C++ prompt generator.',
+    detailKo:
+      '모바일 클립보드 붙여넣기/전체 지우기 버튼, 세션 자동 저장, 커스텀 패널 해상도 직접 입력 (// @matrix).',
   },
   {
     id: 'tools-multiagent',
     lane: 'tools',
     date: '2026-09-28',
     title: 'Multi-agent generation',
+    titleKo: '멀티 에이전트 패턴 생성',
     status: 'planned',
     level: 1,
     detail:
       'The next step past single-shot Gemini generation: multiple agents generating, critiquing, and refining patterns in a loop, so quality stops depending on prompt luck. Software stream — ships continuously, independent of v3.0.0.',
+    detailKo:
+      '다중 AI 에이전트가 패턴을 생성하고 비평·수정하는 피드백 루프 생성기.',
   },
 
   // Community & business
@@ -421,60 +525,78 @@ export const NODES: RoadmapNode[] = [
     lane: 'community',
     date: '2026-04-21',
     title: 'First PCBWay order',
+    titleKo: '첫 PCBWay 스폰서십',
     status: 'done',
     level: 1,
     detail:
       'Serene from PCBWay sent a DM on 04-20, having seen the Reddit post, offering to sponsor a PCB order — the very first PCB, ordered free the next day, before the repo was even public. PCBWay has kept sponsoring since, through the 3D-printing experiments and the v2.2 gerber order.',
+    detailKo:
+      '레딧 글을 본 PCBWay에서 첫 PCB 제작 지원을 제안하여 프로젝트가 본격화된 계기.',
   },
   {
     id: 'biz-reddit',
     lane: 'community',
     date: '2026-04-23',
     title: 'Reddit launch',
+    titleKo: '레딧 프로젝트 공개',
     status: 'done',
     level: 1,
     detail:
       'The repo went public and the Reddit post went viral — the moment Patternflow stopped being a personal project.',
+    detailKo:
+      'r/arduino 레딧 게시글 바이럴 ➔ 개인 프로젝트에서 글로벌 오픈소스 프로젝트로 전환.',
   },
   {
     id: 'biz-discord',
     lane: 'community',
     date: '2026-04-29',
     title: 'Discord + journal',
+    titleKo: '디스코드 & 저널 시작',
     status: 'done',
     level: 2,
     detail:
       'The Discord server opened and the journal started, turning the build log into a public story. First external contributor PRs landed the same week.',
+    detailKo:
+      '공식 디스코드 커뮤니티 오픈 및 개발 저널(Journal) 연재 시작.',
   },
   {
     id: 'biz-cs',
     lane: 'community',
     date: '2026-05-29',
     title: 'Crowd Supply contract',
+    titleKo: 'Crowd Supply 계약',
     status: 'done',
     level: 1,
     detail:
       'The Crowd Supply contract was signed — the commitment that Patternflow becomes a product you can order, not just a repo you can build from.',
+    detailKo:
+      '크라우드 서플라이 공식 입점 계약 체결.',
   },
   {
     id: 'biz-nath-build',
     lane: 'community',
     date: '2026-06-05',
     title: 'First community build',
+    titleKo: '첫 커뮤니티 유저 제작',
     status: 'done',
     level: 2,
     detail:
       'The first fully independent community build (Nath) went up on the build map — proof the guide worked for someone who wasn’t the author.',
+    detailKo:
+      '해외 외부 유저(Nath)의 가이드 기반 완티드 빌드 성공 및 빌드 맵 등록.',
   },
   {
     id: 'biz-prelaunch',
     lane: 'community',
     date: '2026-06-27',
     title: 'Pre-launch live',
+    titleKo: '크라우드 서플라이 프리런칭',
     status: 'done',
     level: 1,
     detail:
       'The Crowd Supply pre-launch page replaced the waitlist across the site and README. Interest signups now feed the campaign directly.',
+    detailKo:
+      '공식 프리런칭 페이지 공개 및 구독 알림 수집 시작.',
     links: [{ label: 'Crowd Supply page', href: 'https://www.crowdsupply.com/engmung/patternflow' }],
   },
   {
@@ -482,10 +604,13 @@ export const NODES: RoadmapNode[] = [
     lane: 'community',
     date: '2026-07-24',
     title: '150 Crowd Supply subs',
+    titleKo: '구독자 150명 돌파',
     status: 'done',
     level: 1,
     detail:
       'Passed 160+ subscribers on Crowd Supply pre-launch — surpassing the 150 subscriber milestone required for official launch prep — driven by viral Instagram pattern posts hitting ~300k views.',
+    detailKo:
+      '인스타 패턴 바이럴(~30만 회)에 힘입어 크라우드 서플라이 프리런칭 구독자 162명 돌파 (런칭 준비 임계점 달성).',
     links: [
       { label: 'Crowd Supply page', href: 'https://www.crowdsupply.com/engmung/patternflow' },
       { label: 'Journal (faster-faster)', href: 'https://patternflow.work/journal/faster-faster' },
@@ -496,10 +621,13 @@ export const NODES: RoadmapNode[] = [
     lane: 'community',
     date: '2026-07-24',
     title: 'Discussions & pattern forks',
+    titleKo: '커뮤니티 & 패턴 포크',
     status: 'done',
     level: 1,
     detail:
       'Launched the Patternflow Community hub (/community) featuring text discussion boards and pattern sharing with fork capabilities — copy base patterns, tweak color ramps or code, and republish.',
+    detailKo:
+      '패턴 공유 및 포크(코드/색상 변형 후 재게시) 기능을 갖춘 커뮤니티 Hub (/community) 오픈.',
     links: [{ label: 'Community Hub', href: 'https://patternflow.work/community' }],
   },
   {
@@ -507,20 +635,26 @@ export const NODES: RoadmapNode[] = [
     lane: 'community',
     date: '2026-09-25',
     title: 'Campaign launch',
+    titleKo: '크라우드 서플라이 런칭',
     status: 'planned',
     level: 1,
     detail:
       'The Crowd Supply campaign goes live once v3.0.0 is real: verified board, printable case, and guides that match what backers will actually build.',
+    detailKo:
+      'v3.0.0 하드웨어와 검증된 가이드 기반으로 전 세계 크라우드 펀딩 런칭.',
   },
   {
     id: 'biz-market',
     lane: 'community',
     date: '2026-11-10',
     title: 'Pattern marketplace',
+    titleKo: '패턴 마켓플레이스',
     status: 'planned',
     level: 1,
     detail:
       'The long-term shape: anyone with an LED panel — including commercial signboard owners — can make patterns with the tools, run them at their own resolution, and sell them. The any-resolution engine and multi-agent generation are the two threads that converge here.',
+    detailKo:
+      '모든 패널 크기에서 누구나 패턴을 만들고 판매할 수 있는 장기 생태계.',
   },
 ];
 

--- a/web/src/components/community/BuildFirmwareModal.tsx
+++ b/web/src/components/community/BuildFirmwareModal.tsx
@@ -54,6 +54,37 @@ export default function BuildFirmwareModal({
   const [busy, setBusy] = useState(false);
   const [promptCopied, setPromptCopied] = useState(false);
 
+  // "Send over Wi-Fi" hands the finished build to the device's own update
+  // page (#232). patternflow.local works on most platforms; Android can't
+  // resolve .local, so the address is editable and remembered.
+  const [deviceHost, setDeviceHost] = useState("patternflow.local");
+  useEffect(() => {
+    try {
+      const stored = window.localStorage.getItem("pf-device-host");
+      if (stored) setDeviceHost(stored);
+    } catch {
+      /* private mode */
+    }
+  }, []);
+  const changeDeviceHost = (value: string) => {
+    setDeviceHost(value);
+    try {
+      window.localStorage.setItem("pf-device-host", value);
+    } catch {
+      /* private mode */
+    }
+  };
+  const wifiSendUrl = (id: string) => {
+    if (typeof window === "undefined") return "#";
+    // The device page fetches this URL itself, so it must be absolute even
+    // when the community API is same-origin.
+    const firmware = new URL(
+      communityApiUrl(`/api/community/builds/${id}/firmware`),
+      window.location.origin,
+    ).toString();
+    return `http://${deviceHost.trim()}/update?src=${encodeURIComponent(firmware)}`;
+  };
+
   // Polling is stopped from inside its own callback, so it needs a handle that
   // survives re-renders.
   const pollRef = useRef<number | null>(null);
@@ -237,11 +268,39 @@ export default function BuildFirmwareModal({
                   >
                     Download .bin
                   </a>
+                  <a
+                    className={styles.btn}
+                    href={wifiSendUrl(build.id)}
+                    target="_blank"
+                    rel="noreferrer"
+                  >
+                    Send over Wi-Fi
+                  </a>
                   <span className={styles.headerSpacer} />
                   <button type="button" className={styles.btn} onClick={reset}>
                     Build another
                   </button>
                 </div>
+                <p className={styles.formNote}>
+                  Send over Wi-Fi opens the device&rsquo;s own update page with this build
+                  linked — no USB, works from a phone on the same network. Device address:{" "}
+                  <input
+                    type="text"
+                    value={deviceHost}
+                    onChange={(event) => changeDeviceHost(event.target.value)}
+                    spellCheck={false}
+                    style={{
+                      font: "inherit",
+                      width: "16ch",
+                      padding: "1px 6px",
+                      border: "1px solid var(--pf-rule, #D9D1C0)",
+                      background: "transparent",
+                      color: "inherit",
+                    }}
+                  />{" "}
+                  (Android can&rsquo;t resolve <code>.local</code> — use the IP shown on the
+                  device&rsquo;s NETWORK screen, hold K2).
+                </p>
               </>
             )}
           </div>

--- a/web/src/components/sections/InsidePanel.tsx
+++ b/web/src/components/sections/InsidePanel.tsx
@@ -173,8 +173,11 @@ export default function InsidePanel({ content }: InsidePanelProps) {
             <li className={styles.storyCurrent}>
               <time>26.7</time>
               <span>
-                Keep <strong>refining the design for mass production</strong>, grow an active{' '}
-                <strong>community</strong>, and push <strong>outreach and promotion</strong>.
+                Reached <strong>150+ Crowd Supply subscribers</strong> (162 on July 24!), launched the{' '}
+                <Link href="/community">
+                  <strong>Community Discussions & Pattern Hub</strong>
+                </Link>{' '}
+                with pattern fork capabilities, added <strong>browser firmware compilation & Web Serial flashing</strong> (#230), and published <strong>USB-C power safety guidelines</strong> (#221).
               </span>
             </li>
             <li>

--- a/web/src/components/sections/InsidePanel.tsx
+++ b/web/src/components/sections/InsidePanel.tsx
@@ -173,7 +173,8 @@ export default function InsidePanel({ content }: InsidePanelProps) {
             <li className={styles.storyCurrent}>
               <time>26.7</time>
               <span>
-                Reached <strong>150+ Crowd Supply subscribers</strong> (162 on July 24!), launched the{' '}
+                Shipped <strong>Patternflow v3.0.0 hardware & snap-fit enclosure</strong>, reached{' '}
+                <strong>150+ Crowd Supply subscribers</strong> (162 on July 24!), launched the{' '}
                 <Link href="/community">
                   <strong>Community Discussions & Pattern Hub</strong>
                 </Link>{' '}

--- a/web/src/components/sections/InsidePanel.tsx
+++ b/web/src/components/sections/InsidePanel.tsx
@@ -177,7 +177,7 @@ export default function InsidePanel({ content }: InsidePanelProps) {
                 <Link href="/community">
                   <strong>Community Discussions & Pattern Hub</strong>
                 </Link>{' '}
-                with pattern fork capabilities, added <strong>browser firmware compilation & Web Serial flashing</strong> (#230), and published <strong>USB-C power safety guidelines</strong> (#221).
+                with pattern fork capabilities, added <strong>browser firmware compilation & Web Serial flashing</strong> (#230), and placed <strong>USB-C power on hold for full re-evaluation</strong> (#221).
               </span>
             </li>
             <li>


### PR DESCRIPTION
Two streams of work that landed on `dev` together.

## Wireless update (#232 §1)

The device now updates itself from any browser on the LAN — no Arduino IDE, no USB, no TLS:

- `/update` on the device's own web server streams a dropped `.bin` straight into `Update.h` and reboots; a failed upload leaves the running firmware untouched. Progress is drawn on the panel from inside the upload handler.
- `PF_WEBUPDATE_ALWAYS_ARMED=1` by default (drop whenever — same LAN exposure ArduinoOTA's no-password default always had); `0` restores a physical arming switch on the UPDATE screen.
- Device console: landing page at `/`, audio UI at `/audio`, all pages restyled to the patternflow.work design system, `no-store` caching, panel info screens redesigned to match (LED-dot headers, hairline rules, orange progress).
- Mobile: `accept="*/*"`, and **Send over Wi-Fi** — the build modal hands the firmware URL to the device page (`?src=`), which fetches and flashes it itself; the firmware download route serves public CORS for that hop. Live verification tracked in #236.
- Dogfooded: every iteration after the first USB flash shipped through `/update` (~8 s per 1.16 MB image).

## Roadmap overhaul

Korean language support with per-node translations, media/press lane, density-aware responsive scale, infinite background grid, sticky headers, scroll-wheel zoom, chronological ordering fixes, and enriched node details with historical release tags.

## After merge

- Vercel auto-deploys the main site from `main`.
- The community host (Pi) deploy discrepancy is tracked in #236 — it pulls `dev` and is currently serving a stale build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)