### PR TITLE
fix(web): CI lint error in the Send-over-Wi-Fi device-host state

### DIFF
--- a/web/src/components/community/BuildFirmwareModal.tsx
+++ b/web/src/components/community/BuildFirmwareModal.tsx
@@ -56,16 +56,17 @@ export default function BuildFirmwareModal({
 
   // "Send over Wi-Fi" hands the finished build to the device's own update
   // page (#232). patternflow.local works on most platforms; Android can't
-  // resolve .local, so the address is editable and remembered.
-  const [deviceHost, setDeviceHost] = useState("patternflow.local");
-  useEffect(() => {
+  // resolve .local, so the address is editable and remembered. Lazy init:
+  // the modal only mounts client-side, so localStorage is readable here and
+  // no effect (hence no synchronous setState-in-effect) is needed.
+  const [deviceHost, setDeviceHost] = useState(() => {
+    if (typeof window === "undefined") return "patternflow.local";
     try {
-      const stored = window.localStorage.getItem("pf-device-host");
-      if (stored) setDeviceHost(stored);
+      return window.localStorage.getItem("pf-device-host") ?? "patternflow.local";
     } catch {
-      /* private mode */
+      return "patternflow.local"; /* private mode */
     }
-  }, []);
+  });
   const changeDeviceHost = (value: string) => {
     setDeviceHost(value);
     try {


### PR DESCRIPTION
Web CI on main went red with #237: the effect restoring the remembered device address called setState synchronously (react-hooks rule). Replaced with a lazy useState initializer — the modal only mounts client-side, so localStorage is readable at init and the effect is gone.

`npm run lint`: 0 errors, 10 pre-existing warnings (same as the last green run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)