### PR TITLE
fix: raw-PUT module uploads, worker sketch sync, honest progress UI

### DIFF
--- a/firmware/patternflow/src/core_patterns_http.h
+++ b/firmware/patternflow/src/core_patterns_http.h
@@ -330,13 +330,94 @@ inline void handleUpload() {
   }
 }
 
+// Raw PUT body: same file lifecycle as the multipart handler, none of the
+// multipart parsing. Chunks arrive straight off the socket.
+inline void handlePutBody() {
+  HTTPRaw& raw = server().raw();
+  lastUploadActivityMs = millis();
+
+  if (raw.status == RAW_START) {
+    uploadFailed = false;
+    uploadError[0] = ' ';
+    uploadBytes = 0;
+    uploadPath[0] = ' ';
+    uploadSlug[0] = ' ';
+    if (uploadFile) uploadFile.close();
+
+    String name = server().header("X-PF-Name");
+    String lowered = name;
+    lowered.toLowerCase();
+    bool isJson = lowered.endsWith(".json");
+    if (!isJson && !lowered.endsWith(".pfm")) {
+      uploadFailed = true;
+      snprintf(uploadError, sizeof(uploadError), "only .pfm or .json accepted");
+      return;
+    }
+    if (!slugFromFilename(name, uploadSlug, sizeof(uploadSlug))) {
+      uploadFailed = true;
+      snprintf(uploadError, sizeof(uploadError), "invalid X-PF-Name");
+      return;
+    }
+    if (!mountModuleStorage()) {
+      uploadFailed = true;
+      snprintf(uploadError, sizeof(uploadError), "filesystem not mounted");
+      return;
+    }
+    if (!FFat.exists(MODULE_DIR) && !FFat.mkdir(MODULE_DIR)) {
+      uploadFailed = true;
+      snprintf(uploadError, sizeof(uploadError), "cannot create %s", MODULE_DIR);
+      return;
+    }
+    snprintf(uploadPath, sizeof(uploadPath), "%s/%s.%s", MODULE_DIR, uploadSlug,
+             isJson ? "json" : "pfm");
+
+    captureSelectionOnce();
+
+    uploadFile = FFat.open(uploadPath, FILE_WRITE);
+    if (!uploadFile) {
+      uploadFailed = true;
+      snprintf(uploadError, sizeof(uploadError), "cannot open destination (heap %u)",
+               (unsigned)heap_caps_get_free_size(MALLOC_CAP_INTERNAL));
+      return;
+    }
+    Serial.printf("[PATTERNS-HTTP] put start %s\n", uploadPath);
+    return;
+  }
+
+  if (uploadFailed) return;
+
+  if (raw.status == RAW_WRITE) {
+    if (!uploadFile) return;
+    if (uploadFile.write(raw.buf, raw.currentSize) != raw.currentSize) {
+      uploadFailed = true;
+      snprintf(uploadError, sizeof(uploadError), "write failed (heap %u)",
+               (unsigned)heap_caps_get_free_size(MALLOC_CAP_INTERNAL));
+      uploadFile.close();
+      return;
+    }
+    uploadBytes += raw.currentSize;
+    return;
+  }
+
+  if (raw.status == RAW_END || raw.status == RAW_ABORTED) {
+    if (uploadFile) uploadFile.close();
+    if (raw.status == RAW_ABORTED) {
+      uploadFailed = true;
+      snprintf(uploadError, sizeof(uploadError), "upload aborted");
+    }
+  }
+}
+
 // Runs once the whole body has been consumed.
 inline void handleUploadDone() {
   // Batched install (the /patterns page, or its ?src= one-click flow) marks
-  // every file but the final one with last=0, so the rescan-and-reload runs
-  // once per batch instead of once per file. Anything not sending the flag
-  // (curl, scripts) is treated as a batch of one.
-  bool lastInBatch = !server().hasArg("last") || server().arg("last") != "0";
+  // every file but the final one as last=0, so the rescan-and-reload runs
+  // once per batch instead of once per file. Multipart carries it as a form
+  // field, raw PUT as the X-PF-Last header. Anything sending neither (curl,
+  // scripts) is treated as a batch of one.
+  bool lastInBatch = true;
+  if (server().hasArg("last")) lastInBatch = server().arg("last") != "0";
+  else if (server().hasHeader("X-PF-Last")) lastInBatch = server().header("X-PF-Last") != "0";
 
   if (uploadFailed) {
     if (uploadPath[0] && FFat.exists(uploadPath)) FFat.remove(uploadPath);
@@ -373,9 +454,20 @@ inline void begin() {
   if (initialized) return;
   if (WiFi.status() != WL_CONNECTED) return;
 
+  // Custom headers are only readable when collected up front. Nothing else on
+  // the shared server collects any, so this list is the whole set.
+  static const char* headerKeys[] = {"X-PF-Name", "X-PF-Last"};
+  server().collectHeaders(headerKeys, 2);
+
   server().on("/patterns", HTTP_GET, handleIndex);
   server().on("/api/patterns", HTTP_GET, handleList);
   server().on("/api/patterns", HTTP_POST, handleUploadDone, handleUpload);
+  // Raw-body PUT is what the page actually uses: the WebServer's multipart
+  // parser is the flakiest part of this stack (query-string quirk, dead
+  // replies on multi-chunk bodies), and a raw octet stream sidesteps ALL of
+  // its boundary handling. Filename travels in X-PF-Name. The multipart POST
+  // above stays for curl and older pages.
+  server().on("/api/patterns", HTTP_PUT, handleUploadDone, handlePutBody);
   server().on("/api/patterns", HTTP_DELETE, handleDelete);
   server().on("/api/patterns/format", HTTP_POST, handleFormat);
 

--- a/firmware/patternflow/src/patterns_index.h
+++ b/firmware/patternflow/src/patterns_index.h
@@ -212,7 +212,7 @@ function del(slug,name){
 var items=[];
 
 var STATE_LABEL={get:'fetching…',wait:'waiting',up:'uploading',del:'deleting…',
-                 retry:'retrying…',ok:'✓ done',fail:'✗ failed'};
+                 ver:'verifying…',retry:'retrying…',ok:'✓ done',fail:'✗ failed'};
 
 function renderQ(){
   qEl.style.display=items.length?'block':'none';
@@ -221,7 +221,8 @@ function renderQ(){
     var li=document.createElement('li');
     var row=document.createElement('div');row.className='qrow';
     var nm=document.createElement('span');nm.className='qn';nm.textContent=it.name;
-    var st=document.createElement('span');st.className='qs '+it.st;
+    var st=document.createElement('span');
+    st.className='qs '+(it.st==='ver'?'up':it.st);
     st.textContent=it.st==='up'?('uploading '+(it.pct||0)+'%'):STATE_LABEL[it.st];
     row.appendChild(nm);row.appendChild(st);li.appendChild(row);
     if(it.st==='up'){
@@ -260,32 +261,40 @@ function runQ(i){
     if(items[j].st==='wait'||items[j].st==='retry')isLast=false;
   it.st='up';it.pct=0;renderQ();
 
-  var fd=new FormData();
-  // Form field, NOT a URL query: this WebServer answers multipart POSTs that
-  // carry a query string with an empty reply. last=1 triggers the device's
-  // single end-of-batch rescan.
-  fd.append('last',isLast?'1':'0');
-  fd.append('module',it.f);
   var xhr=new XMLHttpRequest();
-  xhr.open('POST','/api/patterns');
+  // Raw PUT, not multipart: the device WebServer's multipart parser is its
+  // flakiest path (multi-chunk bodies died with no reply often enough to make
+  // installs feel broken). A raw body sidesteps boundary parsing entirely.
+  // Filename and the batch flag travel as headers; last=1 triggers the
+  // device's single end-of-batch rescan.
+  xhr.open('PUT','/api/patterns');
+  xhr.setRequestHeader('X-PF-Name',it.name);
+  xhr.setRequestHeader('X-PF-Last',isLast?'1':'0');
+  // Transfer shows 0-90%. "100% handed to the network" is not "installed" —
+  // a bar parked on 100 while the device was still writing (or failing) read
+  // as success. The last 10% is the device's own confirmation.
   xhr.upload.onprogress=function(e){
-    if(e.lengthComputable){it.pct=Math.round(e.loaded/e.total*100);renderQ()}
+    if(!e.lengthComputable)return;
+    it.pct=Math.round(e.loaded/e.total*90);
+    if(e.loaded===e.total)it.st='ver';
+    renderQ();
   };
   var next=function(){setTimeout(function(){runQ(i+1)},350)};
   var deadReply=function(){
     it.tries=(it.tries||0)+1;
+    it.pct=0;
     if(it.tries<=2){it.st='retry';renderQ();
       setTimeout(function(){runQ(i)},700);return}
     it.st='fail';it.err='no reply from device';renderQ();next();
   };
   xhr.onload=function(){
     var d=null;try{d=JSON.parse(xhr.responseText)}catch(e){}
-    if(d&&d.ok){it.st='ok';renderQ();next()}
+    if(d&&d.ok){it.st='ok';it.pct=100;renderQ();next()}
     else if(d&&d.error){it.st='fail';it.err=d.error;renderQ();next()}
     else deadReply();
   };
   xhr.onerror=deadReply;
-  xhr.send(fd);
+  xhr.send(it.f);
 }
 
 function startBatch(fileList){

--- a/web/src/lib/firmware/buildRunner.ts
+++ b/web/src/lib/firmware/buildRunner.ts
@@ -118,26 +118,60 @@ async function pathExists(target: string): Promise<boolean> {
   }
 }
 
+/** Directories under the sketch that must never reach the worker's copy. */
+const SYNC_SKIP = new Set(["build", "data"]);
+
+async function syncTree(sourceDir: string, destinationDir: string): Promise<void> {
+  await fs.mkdir(destinationDir, { recursive: true });
+  for (const entry of await fs.readdir(sourceDir, { withFileTypes: true })) {
+    if (SYNC_SKIP.has(entry.name)) continue;
+    const source = path.join(sourceDir, entry.name);
+    const destination = path.join(destinationDir, entry.name);
+    if (entry.isDirectory()) {
+      await syncTree(source, destination);
+      continue;
+    }
+    if (!entry.isFile()) continue;
+
+    // Copy only what is new or changed, preserving everything else's mtime —
+    // arduino-cli rebuilds exactly the translation units the change touches
+    // and the warm cache stays warm.
+    const sourceStat = await fs.stat(source);
+    let same = false;
+    try {
+      const destinationStat = await fs.stat(destination);
+      same =
+        destinationStat.size === sourceStat.size &&
+        destinationStat.mtimeMs === sourceStat.mtimeMs;
+    } catch {
+      same = false;
+    }
+    if (!same) {
+      await fs.copyFile(source, destination);
+      await fs.utimes(destination, sourceStat.atime, sourceStat.mtime);
+    }
+  }
+}
+
 /**
- * Copy the firmware sources into the runner's working directory, once.
+ * Bring the runner's working copy of the firmware up to date with the repo.
  *
- * Re-copied on every build only for the files a build can change, so the
- * remaining sources keep their timestamps and arduino-cli does not decide the
- * world has moved and rebuild the lot.
+ * This used to full-copy once and then refresh only the generated files
+ * (custom slots, registry, secrets) — which meant a firmware source ADDED
+ * later never reached a long-lived worker: after the loadable-modules change,
+ * every deployed worker got the new pattern_registry.h (generated) but not
+ * the new src/core_module_loader.h it includes, and every "Flash to my board"
+ * died with a fatal include error. Now the whole tree is synced incrementally
+ * by size+mtime, so new and edited sources propagate while untouched files
+ * keep their timestamps (and the build cache its warmth).
  */
 export async function syncSketchDir(firmwareSrcDir: string, sketchDir: string): Promise<void> {
-  if (!(await pathExists(sketchDir))) {
-    await fs.mkdir(path.dirname(sketchDir), { recursive: true });
-    await fs.cp(firmwareSrcDir, sketchDir, {
-      recursive: true,
-      // The repo's own build output would be copied as a stale cache.
-      filter: (source) => !source.split(path.sep).includes("build"),
-    });
-    return;
-  }
+  await syncTree(firmwareSrcDir, sketchDir);
 
   // Restore the generated files to their pristine state so a previous build's
-  // custom slots cannot leak into this one.
+  // custom slots cannot leak into this one. (syncTree above only fixes them
+  // when the REPO side changed; this guards against the WORKER side having
+  // been rewritten by the previous job.)
   for (const entry of await fs.readdir(firmwareSrcDir)) {
     if (!GENERATED.test(entry)) continue;
     await fs.copyFile(path.join(firmwareSrcDir, entry), path.join(sketchDir, entry));


### PR DESCRIPTION
Three user-facing failures from the first real day of module installs, each run to ground on hardware.

1. **"Flash to my board" died on every deployed worker** with a fatal include error. syncSketchDir full-copied the firmware once and then refreshed only the generated files — so a source file ADDED later (core_module_loader.h and friends) never reached a long-lived worker's sketch copy, while the regenerated pattern_registry.h that includes it did. The sync is now a real incremental tree sync (size+mtime): new and changed sources propagate, untouched files keep their timestamps and the warm cache.

2. **.pfm uploads failed most of the time from real browsers** (json fine, pfm dead after ~5 s at "100%"). The Arduino WebServer's multipart parser is the flakiest thing in this stack — this session alone it produced the query-string kill, the dead replies on multi-chunk bodies, and the sustained-upload degradation. The page now uploads with a **raw PUT** (filename and batch flag in X-PF-Name / X-PF-Last headers, explicit octet-stream body) and skips boundary parsing entirely. Measured on device: 58 consecutive PUT uploads across rapid back-to-back batches, zero failures, no pacing needed — straight through the volume of traffic that used to degrade the whole network stack. Multipart POST stays for curl and older pages.

3. **A bar parked at 100 % while the reply then failed read as success.** Transfer now shows 0-90 %; the state flips to "verifying…" once the bytes are handed off, and only the device's own JSON confirmation completes the row. Dead-reply retries reset the bar instead of replaying 100 %.

Also learned, expensively, while verifying: a FAT volume corrupted by the (since-fixed) mid-handler crash can reach a state where FFat.exists() finds files but directory enumeration returns nothing — every module "disappears" while uploads keep succeeding. The explicit /api/patterns/format endpoint cleared it; worth remembering the signature.

<!-- Keep it short. Delete any line that doesn't apply. -->

## What
<!-- One or two sentences: what does this change do? -->

## Why
<!-- The reason / the issue it fixes. Link issues like: Fixes #123 -->

## Tested
<!-- How did you check it works? (built locally, flashed the board, ran the site…) -->

---
- [ ] Touches `web/` → it builds (`npm run build`)
- [ ] Sharing a pattern? It's CC-BY-SA 4.0 with an `// Author:` header (see CONTRIBUTING)
