### PR TITLE
fix(web): point custom-build flash parts at v3.2.0

### DIFF
--- a/web/src/lib/firmware/paths.ts
+++ b/web/src/lib/firmware/paths.ts
@@ -18,11 +18,17 @@ export function registryPath(): string {
  * The bootloader and partition table do not depend on the sketch, so every
  * build shares the ones already committed for the stock firmware and only the
  * ~1.1 MB application image differs.
+ *
+ * Keep this pointing at the current stock release. The three files have been
+ * byte-identical across releases so far — a custom build flashed with the
+ * previous version's copies would still boot — but they are version-pinned
+ * paths, and pruning an old release directory would break every custom build
+ * silently rather than loudly.
  */
 export const STATIC_FLASH_PARTS = [
-  { path: "/flash/bin/v3.1.0/patternflow.ino.bootloader.bin", offset: 0 },
-  { path: "/flash/bin/v3.1.0/patternflow.ino.partitions.bin", offset: 0x8000 },
-  { path: "/flash/bin/v3.1.0/boot_app0.bin", offset: 0xe000 },
+  { path: "/flash/bin/v3.2.0/patternflow.ino.bootloader.bin", offset: 0 },
+  { path: "/flash/bin/v3.2.0/patternflow.ino.partitions.bin", offset: 0x8000 },
+  { path: "/flash/bin/v3.2.0/boot_app0.bin", offset: 0xe000 },
 ] as const;
 
 /** Offset the application image is written to (app0 in the partition table). */


### PR DESCRIPTION
Follow-up to #245. Custom pattern builds assemble their image from `STATIC_FLASH_PARTS` (bootloader, partition table, boot_app0) plus the freshly compiled app; those paths were still pinned at v3.1.0.

Harmless today — verified the three files are byte-identical across v3.1.0 and v3.2.0, and both partition tables carry `ffat` — so a custom build flashed with the older copies boots fine. Pinning them to a directory that could be pruned is the problem, not the bytes.