### PR TITLE
fix: upload diagnostics on /update/status, honest build-time estimate

### DIFF
--- a/firmware/patternflow/src/core_web_update.h
+++ b/firmware/patternflow/src/core_web_update.h
@@ -81,6 +81,10 @@ inline bool bootMarkedValid = false;
 inline unsigned progressPct = 0;
 inline size_t expectedBytes = 0;
 inline size_t receivedBytes = 0;
+// Counts POSTs the upload handler actually saw. Distinguishes "the device
+// never received the request" from "it received it and got nowhere", which
+// look identical from the browser.
+inline unsigned uploadAttempts = 0;
 inline uint32_t rebootAtMs = 0;   // nonzero = flash landed, reboot scheduled
 inline String lastError;
 
@@ -120,6 +124,7 @@ inline void handleUpload() {
   HTTPUpload& up = server().upload();
   switch (up.status) {
     case UPLOAD_FILE_START: {
+      uploadAttempts++;
       rejected = !isArmed() || uploading || rebootAtMs != 0;
       if (rejected) {
         Serial.println("[UPDATE] upload refused (not armed)");
@@ -204,12 +209,28 @@ inline void handleUploadDone() {
                 "{\"error\":\"" + lastError + "\"}");
 }
 
+// Reports what the LAST upload attempt actually did, not just whether one is
+// running. "Connection lost during upload" is what the browser says for every
+// network-level failure, and without these fields there is no way to tell a
+// device that never saw a byte from one that took 900 KB and then had the
+// client vanish from one that failed the flash write. The counters are only
+// cleared when the next upload starts, so they can be read after the fact —
+// the same reason /api/status carries loadError.
 inline void handleStatus() {
-  char buf[96];
-  snprintf(buf, sizeof(buf), "{\"armed\":%s,\"busy\":%s,\"version\":\"%s\"}",
+  char buf[224];
+  String error = lastError;
+  error.replace("\"", "'");
+  snprintf(buf, sizeof(buf),
+           "{\"armed\":%s,\"busy\":%s,\"version\":\"%s\","
+           "\"lastError\":\"%s\",\"lastRejected\":%s,\"lastOk\":%s,"
+           "\"received\":%u,\"expected\":%u,\"attempts\":%u}",
            isArmed() ? "true" : "false",
            (uploading || rebootAtMs != 0) ? "true" : "false",
-           PF_IMPROV_FW_VERSION);
+           PF_IMPROV_FW_VERSION,
+           error.c_str(),
+           rejected ? "true" : "false",
+           completedOk ? "true" : "false",
+           (unsigned)receivedBytes, (unsigned)expectedBytes, uploadAttempts);
   server().send(200, "application/json", buf);
 }
 

--- a/firmware/patternflow/src/web_update_index.h
+++ b/firmware/patternflow/src/web_update_index.h
@@ -139,16 +139,24 @@ var armed=false,busy=false,uploading=false;
 function setPill(t,c){pill.textContent=t;pill.className=c||''}
 function setMsg(t,c){msg.textContent=t;msg.className=c||''}
 
+// The device serves one client at a time. Skipping polls while uploading is
+// not enough on its own: a poll issued a moment BEFORE the upload starts is
+// still in flight, and that one request is enough to wedge a 1.2 MB POST into
+// "Connection lost during upload". So the poll is abortable and the upload
+// cancels it before opening its own connection.
+var pollAbort=null;
 function poll(){
   if(uploading)return;
-  fetch('/update/status',{cache:'no-store'}).then(function(r){return r.json()}).then(function(s){
+  pollAbort=new AbortController();
+  fetch('/update/status',{cache:'no-store',signal:pollAbort.signal})
+  .then(function(r){return r.json()}).then(function(s){
     armed=s.armed;busy=s.busy;
     if(busy)setPill('BUSY','warn');
     else if(armed)setPill('READY','ok');
     else setPill('LOCKED','bad');
     armHint.style.display=(!armed&&!busy)?'block':'none';
     drop.classList.toggle('disabled',!armed||busy);
-  }).catch(function(){setPill('OFFLINE','bad')});
+  }).catch(function(e){if(!e||e.name!=='AbortError')setPill('OFFLINE','bad')});
 }
 setInterval(poll,2000);poll();
 
@@ -165,6 +173,7 @@ function upload(f){
   if(f.size<200*1024){setMsg('Suspiciously small for Patternflow firmware. Wrong file?','bad');return}
   if(!armed){setMsg('Device is locked - see the arming note above.','bad');return}
   uploading=true;
+  if(pollAbort)pollAbort.abort();
   setPill('FLASHING','warn');
   bar.style.display='block';fill.style.width='0%';
   setMsg('Uploading '+f.name+' ('+(f.size/1048576).toFixed(2)+' MB). Keep this tab open and the device powered.');

--- a/web/src/components/community/BuildFirmwareModal.tsx
+++ b/web/src/components/community/BuildFirmwareModal.tsx
@@ -217,8 +217,9 @@ export default function BuildFirmwareModal({
                     : `Compiling${seconds ? ` — ${seconds}s` : "…"}`}
                 </p>
                 <p className={styles.formNote}>
-                  A build takes about 30 seconds. The whole preset library is compiled
-                  alongside your pattern, so this produces a complete firmware image.
+                  A build takes 30 seconds to a minute. The whole preset library is
+                  compiled alongside your pattern, so this produces a complete firmware
+                  image.
                 </p>
               </>
             )}


### PR DESCRIPTION
Three small changes, going to main so the real server can be tested against.

### `/update/status` now says what an upload actually did

"Connection lost during upload" is what the browser prints for every network-level failure, and the device had no way to distinguish one that never saw the POST from one that took 900 KB and lost the client from one that failed the flash write — the same blind spot that made "this pattern is broken" unfixable until `/api/status` grew `loadError`.

It now also reports `lastError`, `lastRejected`, `lastOk`, `received`, `expected`, and an `attempts` counter incremented the moment the upload handler sees a POST. Cleared when the next upload starts, so a failed attempt is readable after the fact.

This immediately paid for itself on a live failure:

```
lastError: upload aborted
received:  379104
expected:  1295136     → 29.3%, matching what the progress bar showed
attempts:  3
```

### Status poll is cancelled before an upload starts

The update page skipped polls while uploading, but a poll issued a moment *before* the upload started was still in flight, and the device serves one client at a time. Found by reading the path.

Honest note: this did **not** fix the reported failure, and a deliberate test disproved the premise — an upload run with a competing client polling every 2 s completed normally (1,292,688 / 1,292,688). Keeping it because cancelling a request nobody will read is still correct, not because it is the fix. The intermittent failure is undiagnosed; the instrumentation above is how the next one gets read.

### Build time estimate

"About 30 seconds" was the floor, not the range. Now "30 seconds to a minute".