### PR TITLE
fix(lab): style the hardware flow's paste boxes

### DIFF
--- a/web/src/app/pattern-lab/HardwareModal.tsx
+++ b/web/src/app/pattern-lab/HardwareModal.tsx
@@ -81,6 +81,13 @@ export default function HardwareModal({
 
   const headerLooksReal = /^\s*#pragma\s+once\b/m.test(assembled);
 
+  /** null = nothing pasted yet, true/false = parsed or not. */
+  const unitState = (index: number): boolean | null => {
+    const pasted = (pastes[index] ?? "").trim();
+    if (pasted.length === 0) return null;
+    return cleanPastedUnit(pasted, index) !== null;
+  };
+
   const flashCopied = (key: string) => {
     setCopiedKey(key);
     window.setTimeout(() => setCopiedKey((current) => (current === key ? null : current)), 1200);
@@ -136,11 +143,12 @@ export default function HardwareModal({
 
               {stacked ? (
                 <>
-                  <label className={styles.modalNote}>
-                    <span>Composition name</span>
+                  <label className={styles.hwField}>
+                    <span>Name</span>
                     <input
                       type="text"
                       value={name}
+                      maxLength={24}
                       onChange={(event) => setName(event.target.value)}
                       spellCheck={false}
                     />
@@ -151,9 +159,16 @@ export default function HardwareModal({
                     partial port still builds.
                   </p>
                   {exportData.units.map((unit) => (
-                    <div key={unit.index} className={styles.modalNote}>
-                      <div className={styles.variantActions}>
-                        <span>L{unit.index} - {unit.name}{unit.isMask ? " (mask)" : ""}</span>
+                    <div key={unit.index} className={styles.hwUnit}>
+                      <div className={styles.hwUnitHead}>
+                        <span className={styles.hwUnitName}>
+                          L{unit.index} · {unit.name}
+                          {unit.isMask ? " · mask" : ""}
+                        </span>
+                        {unitState(unit.index) === true && <span className={styles.hwOk}>parsed ✓</span>}
+                        {unitState(unit.index) === false && (
+                          <span className={styles.hwBad}>not a namespace L{unit.index} block</span>
+                        )}
                         <button
                           type="button"
                           onClick={() => void copyText(`u${unit.index}`, unit.prompt)}
@@ -162,13 +177,14 @@ export default function HardwareModal({
                         </button>
                       </div>
                       <textarea
+                        className={styles.hwPaste}
                         value={pastes[unit.index] ?? ""}
                         onChange={(event) =>
                           setPastes((current) => ({ ...current, [unit.index]: event.target.value }))
                         }
-                        placeholder="Paste this layer's C++ here"
+                        placeholder={`Paste the namespace L${unit.index} { … } block here`}
                         spellCheck={false}
-                        rows={4}
+                        rows={5}
                       />
                     </div>
                   ))}
@@ -181,12 +197,20 @@ export default function HardwareModal({
                     </button>
                   </div>
                   <textarea
+                    className={styles.hwPaste}
                     value={single}
                     onChange={(event) => setSingle(event.target.value)}
                     placeholder="Paste the .h the model gives you — it starts with #pragma once"
                     spellCheck={false}
-                    rows={10}
+                    rows={12}
                   />
+                  {single.trim().length > 0 && (
+                    <p className={headerLooksReal ? styles.hwOk : styles.hwBad}>
+                      {headerLooksReal
+                        ? "Looks like a header ✓"
+                        : "A Patternflow header starts with #pragma once"}
+                    </p>
+                  )}
                 </>
               )}
 

--- a/web/src/app/pattern-lab/PatternLab.module.css
+++ b/web/src/app/pattern-lab/PatternLab.module.css
@@ -1418,3 +1418,107 @@
   line-height: 1;
   cursor: pointer;
 }
+
+/* ── Hardware flow (HardwareModal) ─────────────────────────────────────
+   The paste boxes are where the actual work lands, so they read as code:
+   monospace, a real field border, and the cream the rest of the lab uses.
+   Left unstyled they render as bare text on the modal background, which
+   looks like a layout bug rather than an input. */
+.hwPaste {
+  display: block;
+  width: 100%;
+  padding: 8px 10px;
+  border: 1px solid rgba(23, 21, 18, 0.3);
+  background: #fffdf8;
+  color: #171512;
+  font-family: var(--font-jetbrains), monospace;
+  font-size: 12px;
+  line-height: 1.55;
+  resize: vertical;
+}
+
+.hwPaste:focus {
+  outline: none;
+  border-color: #171512;
+}
+
+.hwPaste::placeholder {
+  color: rgba(23, 21, 18, 0.42);
+}
+
+.hwField {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 0 0 12px;
+  font-size: 12px;
+}
+
+.hwField input {
+  flex: 1;
+  min-height: 30px;
+  padding: 4px 8px;
+  border: 1px solid rgba(23, 21, 18, 0.3);
+  background: #fffdf8;
+  color: #171512;
+  font: inherit;
+  font-size: 13px;
+}
+
+.hwField input:focus {
+  outline: none;
+  border-color: #171512;
+}
+
+/* One layer of a stack: its prompt, its paste box, and whether it parsed. */
+.hwUnit {
+  margin: 0 0 10px;
+  padding: 10px;
+  border: 1px solid rgba(23, 21, 18, 0.2);
+  background: #fbf7ee;
+}
+
+.hwUnitHead {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-bottom: 8px;
+}
+
+.hwUnitName {
+  flex: 1;
+  font-family: var(--font-jetbrains), monospace;
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.hwUnitHead button {
+  min-height: 26px;
+  padding: 0 10px;
+  border: 1px solid rgba(23, 21, 18, 0.22);
+  background: #ffffff;
+  color: #171512;
+  font: inherit;
+  font-family: var(--font-jetbrains), monospace;
+  font-size: var(--pf-fs-mono);
+  text-transform: uppercase;
+  cursor: pointer;
+}
+
+.hwUnitHead button:hover {
+  border-color: #171512;
+}
+
+/* Reads at a glance: did this layer's paste actually parse? */
+.hwOk {
+  color: #2e7d4f;
+  font-family: var(--font-jetbrains), monospace;
+  font-size: 11px;
+}
+
+.hwBad {
+  color: #c2410c;
+  font-family: var(--font-jetbrains), monospace;
+  font-size: 11px;
+}


### PR DESCRIPTION
Follow-up to #248.

The old export wizard styled everything with inline styles. Moving its contents into `HardwareModal` left the inputs with nothing, so the paste box rendered as bare placeholder text floating on the modal background with a lone resize grabber underneath — it read as a half-finished layout rather than a field.

Proper classes in `PatternLab.module.css` now, using the tokens the rest of the modal uses. The paste boxes are where the actual work lands, so they read as code: monospace, a real field border, the lab's cream.

Added along the way, since the boxes are legible enough to report into: pasting a header says whether it looks like one, and each layer of a stack says whether its block parsed — the same check that decides whether the assembled header is complete, which was previously only visible as a count.

Verified in the browser: a non-header shows the red hint and leaves Next disabled; adding `#pragma once` flips it to "Looks like a header ✓" and enables Next. No console errors, `tsc` and the production build clean.