### PR TITLE
Licence rules that hold, and a way to take things down

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,13 @@ This file is intentionally a starting point. The contribution process will becom
 
 Custom patterns are welcome as community work, but official bundled firmware patterns will be curated for now. If you make something interesting, share it in the Discord **patterns** channel (follow the post guidelines there) or open an issue with the source.
 
-**Licensing — inbound = outbound.** By sharing a pattern (Discord, issue, or PR) you agree to license it under **CC-BY-SA 4.0** — the same commons as the rest of Patternflow — with attribution kept in the code header (`// Author:` and `// SPDX-License-Identifier: CC-BY-SA-4.0`). There is no copyright assignment (no CLA): you keep authorship, and the project just gets the right to bundle and redistribute it. You may set a different license in the header as long as it still lets the project bundle and redistribute the pattern.
+**Licensing — inbound = outbound.** By sending a pattern *to this repository* (Discord, issue, or PR) you agree to license it under **CC-BY-SA 4.0** — the same commons as the rest of Patternflow — with attribution kept in the code header (`// Author:` and `// SPDX-License-Identifier: CC-BY-SA-4.0`). There is no copyright assignment (no CLA): you keep authorship, and the project just gets the right to bundle and redistribute it. You may set a different license in the header as long as it still lets the project bundle and redistribute the pattern.
+
+**Publishing to the Community is a different thing.** Patterns posted to the
+[Community site](https://patternflow.work/community) are not repository
+contributions — you pick their license yourself when you publish (CC-BY-SA 4.0
+by default, or CC-BY 4.0), and nothing here applies to them. See the
+[License Summary](docs/LICENSE-SUMMARY.md).
 
 ## Commit messages
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@
 | **Flashing** | Everything from the browser (Chrome/Edge) — stock firmware, and custom patterns compiled by the build server; after the first USB flash, new builds can go over Wi-Fi. Arduino IDE only for firmware development or other matrix resolutions |
 | **Connectivity** | Wi-Fi — bidirectional OSC (Ableton/Max/TouchDesigner) and audio-react WebSocket · USB |
 | **Build** | ~1 h hands-on (≈30 min soldering + ≈30 min assembly — first-build friendly) + ~10 h 3D printing · around US$100 in parts ([BOM](BUILD_GUIDE.md#1-bill-of-materials-bom)) |
-| **License** | MIT (firmware & web) · CC-BY-SA 4.0 (hardware & patterns) |
+| **License** | MIT (firmware & web code) · CC-BY-SA 4.0 (hardware, docs, bundled patterns) · community patterns are licensed by their authors ([summary](docs/LICENSE-SUMMARY.md)) |
 
 ### Power & runtime
 
@@ -180,9 +180,13 @@ Patternflow's PCB fabrication and 3D-printed enclosure are sponsored by **[PCBWa
 
 ## License
 
-- Firmware & web — **MIT** ([LICENSE-MIT](./LICENSE-MIT))
-- Hardware & designs — **CC-BY-SA 4.0** ([LICENSE-CC-BY-SA](./LICENSE-CC-BY-SA))
-- Patterns — **CC-BY-SA 4.0**. Community submissions are inbound = outbound: by sharing a pattern you license it under CC-BY-SA 4.0 with attribution kept in the code header (no CLA). See [CONTRIBUTING.md](CONTRIBUTING.md).
+The SPDX header inside a file is the authority — folders are not license boundaries. Full breakdown in the **[License Summary](docs/LICENSE-SUMMARY.md)**.
+
+- Firmware & web code — **MIT** ([LICENSE-MIT](./LICENSE-MIT))
+- Hardware, designs & docs — **CC-BY-SA 4.0** ([LICENSE-CC-BY-SA](./LICENSE-CC-BY-SA))
+- Bundled patterns (the presets shipped in the firmware and the editor) — **CC-BY-SA 4.0**, per-file SPDX headers.
+- Patterns contributed *to the repository* — inbound = outbound: by sending a pattern as a PR, issue or Discord post you license it under CC-BY-SA 4.0, attribution kept in the code header (no CLA). See [CONTRIBUTING.md](CONTRIBUTING.md).
+- Patterns published *to the Community* — **licensed by their author**, either **CC-BY-SA 4.0** (default) or **CC-BY-4.0**. Both permit commercial use with credit; CC-BY-SA additionally requires adaptations to stay under the same license. A fork can never be looser than what it came from, and carries a `Based on:` credit to the original author in its source.
 
 "Patternflow" is a trademark of SeungHun Lee.
 

--- a/docs/LICENSE-SUMMARY.md
+++ b/docs/LICENSE-SUMMARY.md
@@ -1,14 +1,58 @@
 # License Summary
 
-| Folder | License | What you can do |
+**The SPDX header inside a file is the authority.** Folders are not license
+boundaries — the pattern presets live under `web/` and `firmware/`, which are
+otherwise MIT, and each preset file carries its own `SPDX-License-Identifier:
+CC-BY-SA-4.0`. That header wins. This page describes the layout; it does not
+override it.
+
+| Asset | License | What you can do |
 |---|---|---|
-| `firmware/` | MIT | Use, modify, distribute freely. Keep the copyright notice. |
-| `web/` | MIT | Same as above. |
-| `hardware/` | CC-BY-SA 4.0 | Modify and share — derivatives must use the same license and credit the author. |
-| `docs/` | CC-BY-SA 4.0 | Same as above. |
+| Firmware code (`firmware/`) | MIT | Use, modify, distribute freely. Keep the copyright notice. |
+| Web code (`web/`) | MIT | Same as above. |
+| Hardware designs (`hardware/`) | CC BY-SA 4.0 | Modify and share — derivatives use the same license, and credit the author. |
+| Docs & build guides (`docs/`, `BUILD_GUIDE*.md`) | CC BY-SA 4.0 | Same as above. |
+| Journal (`web/content/journal/`) | CC BY-SA 4.0 | Same as above. |
+| **Bundled patterns** (`web/src/lib/presets/`, `firmware/patternflow/presets/`) | CC BY-SA 4.0 | Per-file SPDX headers. They sit in code folders but they are artwork, not code. |
+| **Community patterns** | **Chosen by their author** — see below | Read the header in the pattern itself. |
+
+## Community patterns
+
+Patterns published to the [Community](https://patternflow.work/community) are
+**not repository contributions**. Each one is licensed by the person who made
+it, from two options:
+
+| SPDX | What it means |
+|---|---|
+| **`CC-BY-SA-4.0`** (default) | Free to use and adapt, including commercially, with credit. **Adaptations must carry the same license.** |
+| `CC-BY-4.0` | Free to use and adapt, including commercially, with credit. Adaptations may use any license. |
+
+Both allow commercial use. Putting a community pattern on a club wall, a shop
+display or a signboard is permitted, as long as the author is credited.
+
+A few older patterns are under **MIT** or **CC0-1.0**. Those options have been
+retired from the picker, but a license grant cannot be withdrawn — those
+patterns keep the terms they were published under. Always read the header in
+the pattern itself.
+
+**Forks** cannot loosen what they came from: a fork of a CC BY-SA 4.0 pattern
+must also be CC BY-SA 4.0, and every fork keeps a `Based on:` line crediting
+the original author in its source.
+
+## Contributing vs publishing
+
+These are different things and are governed by different documents.
+
+| | Repository contribution | Community publishing |
+|---|---|---|
+| Where | GitHub PR / issue / Discord | The community site |
+| License | Inbound = outbound (CC BY-SA 4.0) | The author's choice, above |
+| Governed by | [CONTRIBUTING.md](../CONTRIBUTING.md) | Terms of use *(not yet written)* |
 
 ## Trademark
 
 "Patternflow" and the Patternflow logo are trademarks of Seunghun Lee.
 
-The open-source licenses grant you rights to use the code and designs, but do not grant permission to use the name or branding for your own commercial products.
+The open-source licenses grant you rights to use the code and designs, but do
+not grant permission to use the name or branding for your own commercial
+products.

--- a/web/.env.example
+++ b/web/.env.example
@@ -56,3 +56,8 @@ COMMUNITY_ALLOWED_ORIGINS=https://patternflow.work
 # firmware that boots but is not the firmware we release.
 # To inspect the available options: arduino-cli board details --fqbn esp32:esp32:esp32s3
 #BUILD_FQBN=esp32:esp32:esp32s3:PSRAM=opi,FlashSize=16M,PartitionScheme=app3M_fat9M_16MB,CDCOnBoot=cdc,USBMode=hwcdc
+
+# Moderators — comma-separated USERNAMES (not ids) who may remove other
+# people's patterns, posts and comments. Unset means nobody can, which is the
+# right default for any deployment that is not the official community.
+#COMMUNITY_ADMIN_USERNAMES=engmung

--- a/web/drizzle/0006_add-reports.sql
+++ b/web/drizzle/0006_add-reports.sql
@@ -1,0 +1,17 @@
+CREATE TABLE `reports` (
+	`id` text PRIMARY KEY NOT NULL,
+	`target_type` text NOT NULL,
+	`target_id` text NOT NULL,
+	`target_title` text,
+	`target_user_id` text,
+	`reporter_id` text NOT NULL,
+	`reason` text NOT NULL,
+	`detail` text,
+	`status` text DEFAULT 'open' NOT NULL,
+	`created_at` integer NOT NULL,
+	`resolved_at` integer,
+	FOREIGN KEY (`reporter_id`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `reports_status_created_idx` ON `reports` (`status`,`created_at`);--> statement-breakpoint
+CREATE INDEX `reports_target_user_idx` ON `reports` (`target_user_id`);

--- a/web/drizzle/meta/0006_snapshot.json
+++ b/web/drizzle/meta/0006_snapshot.json
@@ -1,0 +1,1058 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "26915723-b674-4b79-8fd7-4db957a34a77",
+  "prevId": "a0852310-a766-4e10-b6d6-514a536b36b2",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "builds": {
+      "name": "builds",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'queued'"
+        },
+        "format": {
+          "name": "format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'bin'"
+        },
+        "patterns": {
+          "name": "patterns",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "namespaces": {
+          "name": "namespaces",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "artifact": {
+          "name": "artifact",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "artifact_bytes": {
+          "name": "artifact_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "worker": {
+          "name": "worker",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "builds_status_created_idx": {
+          "name": "builds_status_created_idx",
+          "columns": [
+            "status",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "builds_user_id_idx": {
+          "name": "builds_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "builds_user_id_user_id_fk": {
+          "name": "builds_user_id_user_id_fk",
+          "tableFrom": "builds",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "comments": {
+      "name": "comments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pattern_id": {
+          "name": "pattern_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "comments_pattern_id_idx": {
+          "name": "comments_pattern_id_idx",
+          "columns": [
+            "pattern_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "comments_pattern_id_patterns_id_fk": {
+          "name": "comments_pattern_id_patterns_id_fk",
+          "tableFrom": "comments",
+          "tableTo": "patterns",
+          "columnsFrom": [
+            "pattern_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "comments_user_id_user_id_fk": {
+          "name": "comments_user_id_user_id_fk",
+          "tableFrom": "comments",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "likes": {
+      "name": "likes",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pattern_id": {
+          "name": "pattern_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "likes_pattern_id_idx": {
+          "name": "likes_pattern_id_idx",
+          "columns": [
+            "pattern_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "likes_user_id_user_id_fk": {
+          "name": "likes_user_id_user_id_fk",
+          "tableFrom": "likes",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "likes_pattern_id_patterns_id_fk": {
+          "name": "likes_pattern_id_patterns_id_fk",
+          "tableFrom": "likes",
+          "tableTo": "patterns",
+          "columnsFrom": [
+            "pattern_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "likes_user_id_pattern_id_pk": {
+          "columns": [
+            "user_id",
+            "pattern_id"
+          ],
+          "name": "likes_user_id_pattern_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "patterns": {
+      "name": "patterns",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code_cpp": {
+          "name": "code_cpp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "license": {
+          "name": "license",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'CC-BY-SA-4.0'"
+        },
+        "made_on": {
+          "name": "made_on",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "patterns_created_at_idx": {
+          "name": "patterns_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "patterns_user_id_idx": {
+          "name": "patterns_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "patterns_user_id_user_id_fk": {
+          "name": "patterns_user_id_user_id_fk",
+          "tableFrom": "patterns",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "patterns_parent_id_patterns_id_fk": {
+          "name": "patterns_parent_id_patterns_id_fk",
+          "tableFrom": "patterns",
+          "tableTo": "patterns",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "post_comments": {
+      "name": "post_comments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "post_comments_post_id_idx": {
+          "name": "post_comments_post_id_idx",
+          "columns": [
+            "post_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "post_comments_post_id_posts_id_fk": {
+          "name": "post_comments_post_id_posts_id_fk",
+          "tableFrom": "post_comments",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_comments_user_id_user_id_fk": {
+          "name": "post_comments_user_id_user_id_fk",
+          "tableFrom": "post_comments",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "posts": {
+      "name": "posts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "posts_created_at_idx": {
+          "name": "posts_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "posts_user_id_idx": {
+          "name": "posts_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "posts_user_id_user_id_fk": {
+          "name": "posts_user_id_user_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "reports": {
+      "name": "reports",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_title": {
+          "name": "target_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "target_user_id": {
+          "name": "target_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reporter_id": {
+          "name": "reporter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'open'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "reports_status_created_idx": {
+          "name": "reports_status_created_idx",
+          "columns": [
+            "status",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "reports_target_user_idx": {
+          "name": "reports_target_user_idx",
+          "columns": [
+            "target_user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "reports_reporter_id_user_id_fk": {
+          "name": "reports_reporter_id_user_id_fk",
+          "tableFrom": "reports",
+          "tableTo": "user",
+          "columnsFrom": [
+            "reporter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "display_username": {
+          "name": "display_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        },
+        "user_username_unique": {
+          "name": "user_username_unique",
+          "columns": [
+            "username"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/web/drizzle/meta/_journal.json
+++ b/web/drizzle/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1785135019087,
       "tag": "0005_add-build-format",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "6",
+      "when": 1785317646720,
+      "tag": "0006_add-reports",
+      "breakpoints": true
     }
   ]
 }

--- a/web/package.json
+++ b/web/package.json
@@ -11,7 +11,9 @@
     "build:enqueue": "tsx scripts/enqueue-test-build.ts",
     "build:status": "tsx scripts/build-status.ts",
     "check:assemble": "tsx scripts/assemble-registry-smoke.ts",
-    "check:module": "tsx scripts/module-build-smoke.ts"
+    "check:module": "tsx scripts/module-build-smoke.ts",
+    "check:license": "tsx scripts/license-smoke.ts",
+    "check:moderation": "tsx scripts/moderation-smoke.ts"
   },
   "dependencies": {
     "@chenglou/pretext": "^0.0.6",

--- a/web/scripts/license-smoke.ts
+++ b/web/scripts/license-smoke.ts
@@ -1,0 +1,136 @@
+/**
+ * Licence machinery smoke test — `npm run check:license`.
+ *
+ * Covers the two rules a pattern community has to get right, because both are
+ * silent when they break: a fork must credit what it came from, and a fork must
+ * not be published under looser terms than its parent.
+ */
+import {
+  LICENSE_OPTIONS,
+  buildSharedPatternFile,
+  forkLicenseAllowed,
+  forkLicenseOptions,
+  licenseById,
+  licenseBySpdx,
+  stripShareWrapping,
+  type ShareLineage,
+  type ShareMeta,
+} from "../src/lib/sharePattern";
+import { licensedJsText } from "../src/lib/community/download";
+
+let failures = 0;
+
+function check(label: string, actual: unknown, expected: unknown) {
+  const ok = JSON.stringify(actual) === JSON.stringify(expected);
+  if (!ok) failures += 1;
+  console.log(`${ok ? "  ok  " : "FAIL  "}${label}${ok ? "" : `\n        got ${JSON.stringify(actual)}\n        want ${JSON.stringify(expected)}`}`);
+}
+
+const BODY = "const x = 1;";
+const PARENT: ShareLineage = {
+  title: "Origin",
+  handle: "engmung",
+  url: "https://patternflow.work/community/p/abc123",
+};
+
+function meta(basedOn: ShareLineage | null = null): ShareMeta {
+  return {
+    title: "Ripple Study",
+    author: "@minsu",
+    license: licenseBySpdx("CC-BY-SA-4.0"),
+    date: "2026-07-29",
+    source: "community",
+    basedOn,
+  };
+}
+
+console.log("\n── header ──");
+const original = buildSharedPatternFile(BODY, meta());
+const fork = buildSharedPatternFile(BODY, meta(PARENT));
+console.log(fork.split("\n").slice(0, 8).join("\n"));
+
+check("an original carries no credit line", original.includes("Based on:"), false);
+check("a fork credits the upstream author", fork.includes('Based on: "Origin" by @engmung'), true);
+check("a fork links the upstream pattern", fork.includes(PARENT.url!), true);
+
+console.log("\n── re-baking is idempotent ──");
+// Editing a pattern re-runs the whole build over the stored source. Doing that
+// must not stack headers or leave a second credit behind.
+const rebaked = buildSharedPatternFile(fork, meta(PARENT));
+check("one header after re-bake", (rebaked.match(/===== Patternflow pattern =====/g) ?? []).length, 1);
+check("one credit after re-bake", (rebaked.match(/Based on:/g) ?? []).length, 1);
+check("wrapping strips back to the body", stripShareWrapping(fork), BODY);
+// The credit is always rebuilt from the parent row, so it cannot survive as a
+// stale line when the pattern is no longer a fork.
+check("credit drops when lineage is gone", buildSharedPatternFile(fork, meta()).includes("Based on:"), false);
+
+console.log("\n── fork compatibility ──");
+check("BY-SA fork stays BY-SA", forkLicenseAllowed("CC-BY-SA-4.0", "CC-BY-SA-4.0"), true);
+check("BY-SA cannot become BY", forkLicenseAllowed("CC-BY-SA-4.0", "CC-BY-4.0"), false);
+check("BY-SA cannot become CC0", forkLicenseAllowed("CC-BY-SA-4.0", "CC0-1.0"), false);
+check("BY may stay BY", forkLicenseAllowed("CC-BY-4.0", "CC-BY-4.0"), true);
+check("BY may tighten to BY-SA", forkLicenseAllowed("CC-BY-4.0", "CC-BY-SA-4.0"), true);
+check("retired MIT parent is permissive", forkLicenseAllowed("MIT", "CC-BY-4.0"), true);
+check("BY-SA picker offers one option", forkLicenseOptions("CC-BY-SA-4.0").map((o) => o.spdx), ["CC-BY-SA-4.0"]);
+check("BY picker offers both", forkLicenseOptions("CC-BY-4.0").map((o) => o.spdx), ["CC-BY-SA-4.0", "CC-BY-4.0"]);
+
+console.log("\n── retired licences stay readable ──");
+check("only two are selectable", LICENSE_OPTIONS.map((o) => o.spdx), ["CC-BY-SA-4.0", "CC-BY-4.0"]);
+check("MIT still resolves", licenseBySpdx("MIT").spdx, "MIT");
+check("CC0 still resolves", licenseBySpdx("CC0-1.0").spdx, "CC0-1.0");
+// An unknown id must pass through, never silently become the default — that
+// would be us relicensing someone else's pattern.
+check("unknown SPDX passes through", licenseBySpdx("GPL-3.0-only").spdx, "GPL-3.0-only");
+check("licenseById finds retired ids", licenseById("mit").spdx, "MIT");
+
+console.log("\n── downloads carry the same credit as the stored source ──");
+// The download re-derives the header from the pattern row rather than trusting
+// the stored text, so this is a separate path that can drift from the one above.
+check(
+  "a fork's .js download credits upstream",
+  licensedJsText(
+    {
+      title: "Ripple Study",
+      license: "CC-BY-SA-4.0",
+      createdAt: "2026-07-29T00:00:00.000Z",
+      username: "minsu",
+      displayUsername: "minsu",
+      basedOn: PARENT,
+    },
+    BODY,
+  ).includes('Based on: "Origin" by @engmung'),
+  true,
+);
+check(
+  "a non-fork .js download has no credit line",
+  licensedJsText(
+    {
+      title: "Ripple Study",
+      license: "CC-BY-SA-4.0",
+      createdAt: "2026-07-29T00:00:00.000Z",
+      username: "minsu",
+      displayUsername: "minsu",
+    },
+    BODY,
+  ).includes("Based on:"),
+  false,
+);
+// A pattern published under a licence that has since been retired must keep it
+// in the file — not silently download as the current default.
+check(
+  "a retired licence survives into the download",
+  licensedJsText(
+    {
+      title: "Old One",
+      license: "MIT",
+      createdAt: "2026-05-01T00:00:00.000Z",
+      username: "someone",
+      displayUsername: "someone",
+    },
+    BODY,
+  ).includes("SPDX-License-Identifier: MIT"),
+  true,
+);
+
+console.log(failures === 0 ? "\nAll licence checks passed.\n" : `\n${failures} check(s) FAILED.\n`);
+process.exit(failures === 0 ? 0 : 1);

--- a/web/scripts/moderation-smoke.ts
+++ b/web/scripts/moderation-smoke.ts
@@ -1,0 +1,81 @@
+/**
+ * Moderation smoke test — `npm run check:moderation`.
+ *
+ * The admin check is a security boundary built out of environment-variable
+ * string parsing, which is exactly where a silent mistake lives: get it wrong
+ * one way and nobody can moderate, get it wrong the other and everybody can.
+ */
+import { adminUsernames, isAdminUsername } from "../src/lib/community/admin";
+import {
+  REPORT_REASONS,
+  cleanReportDetail,
+  isReportTargetType,
+} from "../src/lib/community/validate";
+
+let failures = 0;
+
+function check(label: string, actual: unknown, expected: unknown) {
+  const ok = JSON.stringify(actual) === JSON.stringify(expected);
+  if (!ok) failures += 1;
+  console.log(
+    `${ok ? "  ok  " : "FAIL  "}${label}${ok ? "" : `\n        got ${JSON.stringify(actual)}\n        want ${JSON.stringify(expected)}`}`,
+  );
+}
+
+function withEnv(value: string | undefined, run: () => void) {
+  const previous = process.env.COMMUNITY_ADMIN_USERNAMES;
+  if (value === undefined) delete process.env.COMMUNITY_ADMIN_USERNAMES;
+  else process.env.COMMUNITY_ADMIN_USERNAMES = value;
+  try {
+    run();
+  } finally {
+    if (previous === undefined) delete process.env.COMMUNITY_ADMIN_USERNAMES;
+    else process.env.COMMUNITY_ADMIN_USERNAMES = previous;
+  }
+}
+
+console.log("\n── nobody is a moderator by default ──");
+// This is the state every clone of this repo runs in. If it ever flips open,
+// any deployment of the community hands out removal rights to whoever asks.
+withEnv(undefined, () => {
+  check("unset env grants nobody", adminUsernames(), []);
+  check("unset env rejects a real handle", isAdminUsername("engmung"), false);
+});
+withEnv("", () => check("empty env grants nobody", isAdminUsername("engmung"), false));
+withEnv("   ", () => check("whitespace env grants nobody", isAdminUsername("engmung"), false));
+withEnv(",,,", () => check("commas-only env grants nobody", isAdminUsername("engmung"), false));
+
+console.log("\n── who is a moderator ──");
+withEnv("engmung", () => {
+  check("the listed handle is admin", isAdminUsername("engmung"), true);
+  check("someone else is not", isAdminUsername("someone"), false);
+  // Better Auth stores `username` lowercased, but nothing forces the env var to
+  // match that casing — a capitalised entry must still work.
+  check("comparison ignores case", isAdminUsername("ENGMUNG"), true);
+  check("null handle is not admin", isAdminUsername(null), false);
+  check("empty handle is not admin", isAdminUsername(""), false);
+  // A near-miss must not pass: no prefix or substring matching anywhere.
+  check("a longer handle does not match", isAdminUsername("engmung2"), false);
+  check("a shorter handle does not match", isAdminUsername("engmun"), false);
+});
+withEnv(" engmung , Second-Mod ", () => {
+  check("entries are trimmed", isAdminUsername("engmung"), true);
+  check("second entry works", isAdminUsername("second-mod"), true);
+  check("list is exactly two", adminUsernames(), ["engmung", "second-mod"]);
+});
+
+console.log("\n── report input ──");
+check("pattern is a valid target", isReportTargetType("pattern"), true);
+check("post is a valid target", isReportTargetType("post"), true);
+check("comment is a valid target", isReportTargetType("comment"), true);
+check("user is not a target", isReportTargetType("user"), false);
+check("non-string is not a target", isReportTargetType(42), false);
+check("reasons are the five expected", REPORT_REASONS.length, 5);
+check("blank detail becomes null", cleanReportDetail("   "), null);
+check("missing detail becomes null", cleanReportDetail(undefined), null);
+check("over-long detail is rejected", cleanReportDetail("x".repeat(2001)), undefined);
+check("non-string detail is rejected", cleanReportDetail(123), undefined);
+check("normal detail is trimmed", cleanReportDetail("  stolen from X  "), "stolen from X");
+
+console.log(failures === 0 ? "\nAll moderation checks passed.\n" : `\n${failures} check(s) FAILED.\n`);
+process.exit(failures === 0 ? 0 : 1);

--- a/web/src/app/api/community/comments/[id]/route.ts
+++ b/web/src/app/api/community/comments/[id]/route.ts
@@ -1,0 +1,55 @@
+import { eq } from "drizzle-orm";
+import { isAdminSession } from "@/lib/community/admin";
+import { getAuth } from "@/lib/community/auth";
+import { originBlocked, preflight, withCors } from "@/lib/community/cors";
+import { communityEnabled, getDb } from "@/lib/community/db";
+import { getCommentStub } from "@/lib/community/queries";
+import { comments, postComments } from "@/lib/community/schema";
+
+// DELETE /api/community/comments/[id]?on=pattern|post
+//
+// Comments previously had no removal path at all — not for their author, not
+// for anyone. That left "report this comment" with no remedy behind it, so the
+// report button and this route ship together.
+//
+// `on` says which thread the comment belongs to. Pattern comments and post
+// comments live in separate tables (see schema.ts), and guessing by trying both
+// would make the route's behaviour depend on id collisions.
+
+export async function DELETE(request: Request, context: { params: Promise<{ id: string }> }) {
+  const blocked = originBlocked(request);
+  if (blocked) return blocked;
+  return withCors(request, await handleDelete(request, context));
+}
+
+export const OPTIONS = preflight;
+
+async function handleDelete(request: Request, context: { params: Promise<{ id: string }> }) {
+  if (!communityEnabled()) {
+    return Response.json({ error: "Community is not enabled on this deployment." }, { status: 503 });
+  }
+
+  const session = await getAuth().api.getSession({ headers: request.headers });
+  if (!session) {
+    return Response.json({ error: "Sign in to delete a comment." }, { status: 401 });
+  }
+
+  const on = new URL(request.url).searchParams.get("on");
+  if (on !== "pattern" && on !== "post") {
+    return Response.json({ error: "Unknown comment thread." }, { status: 400 });
+  }
+
+  const { id } = await context.params;
+  const comment = await getCommentStub(on, id);
+  if (!comment) {
+    return Response.json({ error: "Comment not found." }, { status: 404 });
+  }
+  if (comment.userId !== session.user.id && !isAdminSession(session)) {
+    // 403, not 404 — the comment is public, it just isn't theirs to remove.
+    return Response.json({ error: "You can only delete your own comments." }, { status: 403 });
+  }
+
+  const table = on === "pattern" ? comments : postComments;
+  await getDb().delete(table).where(eq(table.id, id));
+  return Response.json({ ok: true });
+}

--- a/web/src/app/api/community/patterns/[id]/route.ts
+++ b/web/src/app/api/community/patterns/[id]/route.ts
@@ -1,11 +1,12 @@
 import { eq } from "drizzle-orm";
+import { isAdminSession } from "@/lib/community/admin";
 import { getAuth } from "@/lib/community/auth";
 import { originBlocked, preflight, withCors } from "@/lib/community/cors";
 import { communityEnabled, getDb } from "@/lib/community/db";
-import { getPattern } from "@/lib/community/queries";
+import { getPattern, getPatternStub } from "@/lib/community/queries";
 import { rateLimit } from "@/lib/community/ratelimit";
 import { patterns } from "@/lib/community/schema";
-import { buildStoredPatternCode } from "@/lib/community/license";
+import { buildStoredPatternCode, lineageFrom } from "@/lib/community/license";
 import {
   cleanCode,
   cleanCpp,
@@ -13,7 +14,7 @@ import {
   cleanMadeOn,
   cleanTitle,
 } from "@/lib/community/validate";
-import { LICENSE_OPTIONS, stripShareWrapping } from "@/lib/sharePattern";
+import { KNOWN_LICENSES, forkLicenseAllowed, stripShareWrapping } from "@/lib/sharePattern";
 
 // PATCH /api/community/patterns/[id] — the author edits their own pattern.
 //
@@ -55,7 +56,9 @@ async function handleDelete(request: Request, context: { params: Promise<{ id: s
   if (!pattern) {
     return Response.json({ error: "Pattern not found." }, { status: 404 });
   }
-  if (pattern.userId !== session.user.id) {
+  // Moderators can take anything down. Editing stays owner-only: removing
+  // someone's pattern is a moderation act, rewriting it in their name is not.
+  if (pattern.userId !== session.user.id && !isAdminSession(session)) {
     return Response.json({ error: "You can only delete your own patterns." }, { status: 403 });
   }
 
@@ -112,10 +115,25 @@ async function handlePatch(request: Request, context: { params: Promise<{ id: st
     description = next;
   }
 
+  // The parent is needed twice below: to keep a fork's licence compatible, and
+  // to re-bake the upstream credit into the source.
+  const parent = pattern.parentId ? await getPatternStub(pattern.parentId) : null;
+
   let license = pattern.license;
   if (raw.license !== undefined) {
-    const match = LICENSE_OPTIONS.find((option) => option.spdx === raw.license);
+    // KNOWN_LICENSES, not LICENSE_OPTIONS: a pattern published under a licence
+    // that has since been retired must stay editable by its author. Keeping the
+    // stored value is always allowed; only *changing* it is restricted.
+    const match = KNOWN_LICENSES.find((option) => option.spdx === raw.license);
     if (!match) return Response.json({ error: "Unknown licence." }, { status: 400 });
+    if (match.spdx !== pattern.license && parent && !forkLicenseAllowed(parent.license, match.spdx)) {
+      return Response.json(
+        {
+          error: `This pattern is a fork of a ${parent.license} pattern, so it cannot be relicensed as ${match.spdx}.`,
+        },
+        { status: 400 },
+      );
+    }
     license = match.spdx;
   }
 
@@ -183,6 +201,10 @@ async function handlePatch(request: Request, context: { params: Promise<{ id: st
         license,
         handle,
         date: madeOn ?? pattern.createdAt,
+        // Rebuilt from the parent row every time, never carried over from the
+        // submitted code — an author editing their fork cannot drop the credit
+        // by deleting the line from the editor.
+        basedOn: lineageFrom(parent),
       }),
       codeCpp,
       updatedAt: new Date(),

--- a/web/src/app/api/community/patterns/route.ts
+++ b/web/src/app/api/community/patterns/route.ts
@@ -5,8 +5,8 @@ import { getPatternStub, newId } from "@/lib/community/queries";
 import { rateLimit } from "@/lib/community/ratelimit";
 import { patterns } from "@/lib/community/schema";
 import { cleanCode, cleanCpp, cleanDescription, cleanTitle } from "@/lib/community/validate";
-import { buildStoredPatternCode } from "@/lib/community/license";
-import { LICENSE_OPTIONS, stripShareWrapping } from "@/lib/sharePattern";
+import { buildStoredPatternCode, lineageFrom } from "@/lib/community/license";
+import { LICENSE_OPTIONS, forkLicenseAllowed, stripShareWrapping } from "@/lib/sharePattern";
 
 // POST /api/community/patterns — publish (or fork-publish) a pattern.
 // Reads happen in server components; only mutations go through the API.
@@ -73,15 +73,30 @@ async function handlePost(request: Request) {
     );
   }
 
+  // New work can only take a currently-offered licence (the retired ones stay
+  // readable but are not selectable — see LICENSE_OPTIONS).
   const license =
     LICENSE_OPTIONS.find((option) => option.spdx === raw.license)?.spdx ?? "CC-BY-SA-4.0";
 
   // Fork lineage: only record parents that actually exist; a dangling or
   // malformed parentId silently degrades to an original post.
   let parentId: string | null = null;
+  let parent: Awaited<ReturnType<typeof getPatternStub>> | null = null;
   if (typeof raw.parentId === "string" && raw.parentId.length > 0) {
-    const parent = await getPatternStub(raw.parentId);
+    parent = await getPatternStub(raw.parentId);
     parentId = parent?.id ?? null;
+  }
+
+  // A fork is a derivative: it cannot be published under looser terms than the
+  // pattern it came from. Without this a CC BY-SA pattern could be forked and
+  // re-published as something permissive, with the platform doing the laundering.
+  if (parent && !forkLicenseAllowed(parent.license, license)) {
+    return Response.json(
+      {
+        error: `A fork of a ${parent.license} pattern cannot be published as ${license}. Publish it under ${parent.license}.`,
+      },
+      { status: 400 },
+    );
   }
 
   const now = new Date();
@@ -98,8 +113,15 @@ async function handlePost(request: Request) {
     description,
     // Licence header + attribution are baked into the stored source, so anyone
     // who copies the code out of the page takes the terms and the credit with
-    // it — not just people who download the file.
-    code: buildStoredPatternCode(code, { title, license, handle, date: now }),
+    // it — not just people who download the file. On a fork that includes the
+    // upstream credit, which both CC licences require a derivative to keep.
+    code: buildStoredPatternCode(code, {
+      title,
+      license,
+      handle,
+      date: now,
+      basedOn: lineageFrom(parent),
+    }),
     codeCpp,
     license,
     parentId,

--- a/web/src/app/api/community/posts/[id]/route.ts
+++ b/web/src/app/api/community/posts/[id]/route.ts
@@ -1,4 +1,5 @@
 import { eq } from "drizzle-orm";
+import { isAdminSession } from "@/lib/community/admin";
 import { getAuth } from "@/lib/community/auth";
 import { originBlocked, preflight, withCors } from "@/lib/community/cors";
 import { communityEnabled, getDb } from "@/lib/community/db";
@@ -44,7 +45,11 @@ async function authorize(request: Request, id: string, verb: string) {
   if (!post) {
     return { error: Response.json({ error: "Post not found." }, { status: 404 }) };
   }
-  if (post.userId !== session.user.id) {
+  // Moderators can take a post down, but not rewrite it: removing someone's
+  // post is a moderation act, editing it in their name is not.
+  const allowed =
+    post.userId === session.user.id || (verb === "delete" && isAdminSession(session));
+  if (!allowed) {
     // 403, not 404 — the post is public, it just isn't theirs to change.
     return {
       error: Response.json({ error: `You can only ${verb} your own posts.` }, { status: 403 }),

--- a/web/src/app/api/community/reports/route.ts
+++ b/web/src/app/api/community/reports/route.ts
@@ -1,0 +1,82 @@
+import { getAuth } from "@/lib/community/auth";
+import { originBlocked, preflight, withCors } from "@/lib/community/cors";
+import { communityEnabled, getDb } from "@/lib/community/db";
+import { newId, reportTarget } from "@/lib/community/queries";
+import { rateLimit } from "@/lib/community/ratelimit";
+import { reports } from "@/lib/community/schema";
+import { REPORT_REASONS, cleanReportDetail, isReportTargetType } from "@/lib/community/validate";
+
+// POST /api/community/reports — flag a pattern, post or comment for review.
+//
+// Signing in is required, which is the whole anti-spam design: reports are
+// cheap to file and expensive to read, so they have to cost an account. People
+// who are not members — a rights holder sending a takedown, say — use the
+// address published in the terms instead.
+
+export async function POST(request: Request) {
+  const blocked = originBlocked(request);
+  if (blocked) return blocked;
+  return withCors(request, await handlePost(request));
+}
+
+export const OPTIONS = preflight;
+
+async function handlePost(request: Request) {
+  if (!communityEnabled()) {
+    return Response.json({ error: "Community is not enabled on this deployment." }, { status: 503 });
+  }
+
+  const session = await getAuth().api.getSession({ headers: request.headers });
+  if (!session) {
+    return Response.json({ error: "Sign in to report something." }, { status: 401 });
+  }
+
+  if (!rateLimit(`report:${session.user.id}`, 5, 60_000)) {
+    return Response.json({ error: "Too many reports — wait a minute and try again." }, { status: 429 });
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return Response.json({ error: "Invalid JSON body." }, { status: 400 });
+  }
+  const raw = body as Record<string, unknown>;
+
+  if (!isReportTargetType(raw.targetType)) {
+    return Response.json({ error: "Unknown report target." }, { status: 400 });
+  }
+  if (typeof raw.targetId !== "string" || raw.targetId.length === 0) {
+    return Response.json({ error: "Missing report target." }, { status: 400 });
+  }
+  if (typeof raw.reason !== "string" || !REPORT_REASONS.includes(raw.reason as never)) {
+    return Response.json({ error: "Pick a reason." }, { status: 400 });
+  }
+
+  const detail = cleanReportDetail(raw.detail);
+  if (detail === undefined) {
+    return Response.json({ error: "Details are too long (max 2000 chars)." }, { status: 400 });
+  }
+
+  // Resolve the target now so the report keeps a readable snapshot of what was
+  // flagged even after the content is removed.
+  const target = await reportTarget(raw.targetType, raw.targetId);
+  if (!target) {
+    return Response.json({ error: "That content no longer exists." }, { status: 404 });
+  }
+
+  await getDb().insert(reports).values({
+    id: newId(),
+    targetType: raw.targetType,
+    targetId: raw.targetId,
+    targetTitle: target.title,
+    targetUserId: target.userId,
+    reporterId: session.user.id,
+    reason: raw.reason,
+    detail,
+    status: "open",
+    createdAt: new Date(),
+  });
+
+  return Response.json({ ok: true }, { status: 201 });
+}

--- a/web/src/app/community/layout.tsx
+++ b/web/src/app/community/layout.tsx
@@ -70,6 +70,11 @@ export default async function CommunityLayout({ children }: { children: React.Re
           </nav>
         </header>
         {children}
+        <footer className={styles.pageFooter}>
+          <Link href="/terms">Terms &amp; Privacy</Link>
+          <span>·</span>
+          <a href="mailto:contact@patternflow.work">Report something</a>
+        </footer>
       </div>
     </main>
   );

--- a/web/src/app/community/p/[id]/PatternDetailClient.tsx
+++ b/web/src/app/community/p/[id]/PatternDetailClient.tsx
@@ -11,6 +11,7 @@ import { formatDate } from "@/components/community/PatternCard";
 import LikeButton from "@/components/community/LikeButton";
 import AddHeaderModal from "@/components/community/AddHeaderModal";
 import EditDetailsModal from "@/components/community/EditDetailsModal";
+import ReportModal from "@/components/community/ReportModal";
 import DeletePatternButton from "@/components/community/DeletePatternButton";
 import BuildFirmwareModal from "@/components/community/BuildFirmwareModal";
 import SendModuleModal from "@/components/community/SendModuleModal";
@@ -20,6 +21,7 @@ import { knobSetupFromCode } from "@/lib/community/knobs";
 import { describeMatrixShape, matrixFromCode } from "@/lib/patternMatrix";
 import { writeLabHandoff } from "@/lib/community/handoff";
 import { downloadPatternHeader, downloadPatternJs } from "@/lib/community/download";
+import { communityPatternUrl } from "@/lib/community/license";
 import { COMMUNITY_FETCH_INIT, communityApiUrl } from "@/lib/community/apiBase";
 import { captureEvent } from "@/lib/posthogEvents";
 import styles from "@/components/community/Community.module.css";
@@ -41,7 +43,7 @@ export type PatternView = {
   createdAt: string; // ISO
   username: string | null;
   displayUsername: string | null;
-  parent: { id: string; title: string } | null;
+  parent: { id: string; title: string; handle: string | null; license: string } | null;
   likeCount: number;
   forkCount: number;
 };
@@ -66,6 +68,7 @@ export default function PatternDetailClient({
   const [codeTab, setCodeTab] = useState<"js" | "h">("js");
   const [headerModalOpen, setHeaderModalOpen] = useState(false);
   const [detailsModalOpen, setDetailsModalOpen] = useState(false);
+  const [reportOpen, setReportOpen] = useState(false);
   const [buildOpen, setBuildOpen] = useState(false);
   const [sendOpen, setSendOpen] = useState(false);
   const [savingCode, setSavingCode] = useState(false);
@@ -116,6 +119,7 @@ export default function PatternDetailClient({
       code,
       parentId: pattern.id,
       parentTitle: pattern.title,
+      parentLicense: pattern.license,
     });
     captureEvent("community_open_in_lab", { pattern_id: pattern.id, edited });
     router.push("/pattern-lab?from=community");
@@ -124,14 +128,27 @@ export default function PatternDetailClient({
   // Downloads always carry the PUBLISHED source, never in-page edits: the
   // licence header credits this pattern's author, which is only true of what
   // they actually published. Edits belong in a fork, via Open in Pattern Lab.
+  //
+  // A fork's file also carries its upstream credit, matching the stored source.
+  const downloadable = {
+    ...pattern,
+    basedOn: pattern.parent
+      ? {
+          title: pattern.parent.title,
+          handle: pattern.parent.handle,
+          url: communityPatternUrl(pattern.parent.id),
+        }
+      : null,
+  };
+
   const downloadJs = () => {
-    downloadPatternJs(pattern, pattern.code);
+    downloadPatternJs(downloadable, pattern.code);
     captureEvent("community_download", { pattern_id: pattern.id, kind: "js" });
   };
 
   const downloadHeader = () => {
     if (!pattern.codeCpp) return;
-    downloadPatternHeader(pattern, pattern.codeCpp);
+    downloadPatternHeader(downloadable, pattern.codeCpp);
     captureEvent("community_download", { pattern_id: pattern.id, kind: "h" });
   };
 
@@ -430,6 +447,12 @@ export default function PatternDetailClient({
               <Link href={`/community/p/${pattern.parent.id}`}>{pattern.parent.title}</Link>
             </span>
           )}
+          {/* Last in the row on purpose: available, never the thing you notice. */}
+          {!isOwner && (
+            <button type="button" className={styles.reportLink} onClick={() => setReportOpen(true)}>
+              Report
+            </button>
+          )}
         </div>
 
         {pattern.description && (
@@ -494,7 +517,17 @@ export default function PatternDetailClient({
           initialDescription={pattern.description}
           initialLicense={pattern.license}
           initialMadeOn={pattern.madeOn}
+          parentLicense={pattern.parent?.license ?? null}
           onClose={() => setDetailsModalOpen(false)}
+        />
+      )}
+
+      {reportOpen && (
+        <ReportModal
+          targetType="pattern"
+          targetId={pattern.id}
+          targetLabel={pattern.title}
+          onClose={() => setReportOpen(false)}
         />
       )}
     </div>

--- a/web/src/app/community/p/[id]/page.tsx
+++ b/web/src/app/community/p/[id]/page.tsx
@@ -72,7 +72,16 @@ export default async function CommunityPatternPage(props: RouteParams) {
         createdAt: pattern.createdAt.toISOString(),
         username: pattern.username,
         displayUsername: pattern.displayUsername,
-        parent: parent ? { id: parent.id, title: parent.title } : null,
+        parent: parent
+          ? {
+              id: parent.id,
+              title: parent.title,
+              // Carried so the download's credit line matches the stored source.
+              handle: parent.displayUsername ?? parent.username ?? null,
+              // Bounds what this fork may be relicensed to.
+              license: parent.license,
+            }
+          : null,
         likeCount: pattern.likeCount,
         forkCount: pattern.forkCount,
       }}

--- a/web/src/app/pattern-lab/HardwareModal.tsx
+++ b/web/src/app/pattern-lab/HardwareModal.tsx
@@ -317,6 +317,7 @@ export default function HardwareModal({
           codeCpp={assembled}
           parentId={forkOf?.id ?? null}
           parentTitle={forkOf?.title ?? null}
+          parentLicense={forkOf?.license ?? null}
           onClose={() => setPublishCode(null)}
         />
       )}

--- a/web/src/app/pattern-lab/PatternLabClient.tsx
+++ b/web/src/app/pattern-lab/PatternLabClient.tsx
@@ -236,7 +236,11 @@ export default function PatternLabClient() {
         handoff.code,
         handoff.parentTitle ?? undefined,
         handoff.parentId
-          ? { id: handoff.parentId, title: handoff.parentTitle ?? "a community pattern" }
+          ? {
+              id: handoff.parentId,
+              title: handoff.parentTitle ?? "a community pattern",
+              license: handoff.parentLicense,
+            }
           : undefined,
       );
     }
@@ -470,6 +474,7 @@ export default function PatternLabClient() {
           code={shareCode}
           parentId={forkOf?.id ?? null}
           parentTitle={forkOf?.title ?? null}
+          parentLicense={forkOf?.license ?? null}
           onClose={() => setShareCode(null)}
         />
       )}

--- a/web/src/app/sitemap.ts
+++ b/web/src/app/sitemap.ts
@@ -14,6 +14,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
     { url: `${siteUrl}/inside`, lastModified: now, changeFrequency: "monthly", priority: 0.7 },
     { url: `${siteUrl}/roadmap`, lastModified: now, changeFrequency: "weekly", priority: 0.6 },
     { url: `${siteUrl}/contact`, lastModified: now, changeFrequency: "yearly", priority: 0.5 },
+    { url: `${siteUrl}/terms`, lastModified: now, changeFrequency: "yearly", priority: 0.3 },
     { url: `${siteUrl}/journal`, lastModified: now, changeFrequency: "weekly", priority: 0.7 },
     { url: `${siteUrl}/journal/en`, lastModified: now, changeFrequency: "weekly", priority: 0.7 },
   ];

--- a/web/src/app/terms/Terms.module.css
+++ b/web/src/app/terms/Terms.module.css
@@ -1,0 +1,142 @@
+/* Terms & privacy. A legal page nobody reads is a legal page that does not
+   work, so this is set as prose — one column, generous measure, real hierarchy
+   — using the project's own tokens rather than a wall of small grey text. */
+
+.page {
+  min-height: 100vh;
+  padding: 48px 24px 96px;
+  background: var(--pf-cream);
+  color: var(--pf-ink);
+  font-family: var(--pf-sans);
+}
+
+.doc {
+  max-width: 68ch;
+  margin: 0 auto;
+}
+
+.head {
+  padding-bottom: 28px;
+  margin-bottom: 32px;
+  border-bottom: var(--pf-rule-w) solid var(--pf-rule);
+}
+
+.brand {
+  display: inline-block;
+  margin-bottom: 24px;
+  font-family: var(--pf-mono);
+  font-size: var(--pf-fs-mono);
+  letter-spacing: var(--pf-track-mono);
+  text-transform: uppercase;
+  color: var(--pf-ink-muted);
+  text-decoration: none;
+}
+
+.brand:hover {
+  color: var(--pf-led);
+}
+
+.head h1 {
+  margin: 0;
+  font-size: var(--pf-fs-h2);
+  letter-spacing: var(--pf-track-tight);
+  font-weight: 600;
+}
+
+.updated {
+  margin: 10px 0 0;
+  font-family: var(--pf-mono);
+  font-size: var(--pf-fs-mono);
+  letter-spacing: var(--pf-track-mono);
+  text-transform: uppercase;
+  color: var(--pf-ink-faint);
+}
+
+.lede {
+  margin: 0 0 40px;
+  font-family: var(--pf-serif);
+  font-size: 19px;
+  line-height: 1.6;
+  color: var(--pf-ink);
+}
+
+.doc section {
+  margin-bottom: 36px;
+}
+
+.doc h2 {
+  margin: 0 0 14px;
+  font-size: 19px;
+  font-weight: 600;
+  letter-spacing: var(--pf-track-tight);
+}
+
+.doc h3 {
+  margin: 24px 0 10px;
+  font-family: var(--pf-mono);
+  font-size: var(--pf-fs-mono);
+  letter-spacing: var(--pf-track-mono);
+  text-transform: uppercase;
+  font-weight: 500;
+  color: var(--pf-ink-muted);
+}
+
+.doc p,
+.doc li {
+  font-size: var(--pf-fs-body);
+  line-height: 1.7;
+  color: var(--pf-ink);
+}
+
+.doc p {
+  margin: 0 0 12px;
+}
+
+.doc ul {
+  margin: 0 0 12px;
+  padding-left: 20px;
+}
+
+.doc li {
+  margin-bottom: 7px;
+}
+
+.doc a {
+  color: var(--pf-led);
+  text-underline-offset: 2px;
+}
+
+/* The one clause most likely to surprise someone later — account closure not
+   removing published patterns. Given its own frame so it cannot be skimmed past. */
+.callout {
+  margin-top: 16px;
+  padding: 16px 18px;
+  border-left: 2px solid var(--pf-led);
+  background: var(--pf-cream-2);
+}
+
+.foot {
+  padding-top: 28px;
+  margin-top: 8px;
+  border-top: var(--pf-rule-w) solid var(--pf-rule);
+  font-size: var(--pf-fs-body);
+  color: var(--pf-ink-muted);
+}
+
+.foot p {
+  margin: 0 0 8px;
+}
+
+@media (max-width: 640px) {
+  .page {
+    padding: 32px 20px 72px;
+  }
+
+  .head h1 {
+    font-size: 26px;
+  }
+
+  .lede {
+    font-size: 17px;
+  }
+}

--- a/web/src/app/terms/page.tsx
+++ b/web/src/app/terms/page.tsx
@@ -1,0 +1,280 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import styles from "./Terms.module.css";
+
+// Terms of use + privacy notice, deliberately as one page. Two documents means
+// two things to keep in sync, and a solo-run community will keep one honest
+// long before it keeps two.
+//
+// Written to be read, not to be survived. Every clause here exists because
+// something in the product needs it — the hosting grant covers what the site
+// actually does with a pattern (render it, thumbnail it, compile it), and the
+// retention numbers match what the code actually stores.
+
+export const metadata: Metadata = {
+  title: "Terms & Privacy / Patternflow",
+  description:
+    "Terms of use and privacy notice for the Patternflow community: who owns what, what we do with your patterns, how to report something, and what data we keep.",
+};
+
+const UPDATED = "29 July 2026";
+const CONTACT = "contact@patternflow.work";
+
+export default function TermsPage() {
+  return (
+    <main className={styles.page}>
+      <article className={styles.doc}>
+        <header className={styles.head}>
+          <Link href="/" className={styles.brand}>
+            Patternflow
+          </Link>
+          <h1>Terms &amp; Privacy</h1>
+          <p className={styles.updated}>Last updated {UPDATED}</p>
+        </header>
+
+        <p className={styles.lede}>
+          This covers the Patternflow community — publishing patterns, commenting, and the
+          accounts behind both. The short version: <strong>your patterns stay yours</strong>, you
+          choose their licence, we host and display them, and we can remove things that break
+          these terms.
+        </p>
+
+        <section>
+          <h2>1. Who runs this</h2>
+          <p>
+            Patternflow is operated by Seunghun Lee, an individual based in the Republic of Korea.
+            Contact: <a href={`mailto:${CONTACT}`}>{CONTACT}</a>.
+          </p>
+        </section>
+
+        <section>
+          <h2>2. Your account</h2>
+          <ul>
+            <li>You need an account to publish, comment, or report. Browsing needs nothing.</li>
+            <li>
+              An account is a username and a password. An email address is optional and is only
+              ever used to help you recover access — we send no marketing, and we never verify it.
+            </li>
+            <li>You are responsible for what happens under your account. Keep the password to yourself.</li>
+            <li>You must be old enough to enter into this agreement where you live.</li>
+          </ul>
+        </section>
+
+        <section>
+          <h2>3. Your patterns stay yours</h2>
+          <p>
+            You keep the copyright in everything you publish. There is no copyright assignment and
+            no contributor licence agreement.
+          </p>
+          <p>
+            When you publish, you choose the licence the public gets — currently{" "}
+            <strong>CC&nbsp;BY-SA&nbsp;4.0</strong> (the default) or <strong>CC&nbsp;BY&nbsp;4.0</strong>.
+            Both let anyone use and adapt your work, including commercially, as long as they credit
+            you; CC BY-SA additionally requires their versions to carry the same licence. That
+            choice is a licence to the world, and{" "}
+            <strong>a licence once given cannot be taken back</strong> — deleting a pattern stops us
+            distributing it, but it does not undo anyone&apos;s existing rights.
+          </p>
+          <p>
+            See the <a href="https://github.com/engmung/Patternflow/blob/main/docs/LICENSE-SUMMARY.md">
+              licence summary
+            </a>{" "}
+            for how this fits with the rest of the project.
+          </p>
+        </section>
+
+        <section>
+          <h2>4. What you let us do</h2>
+          <p>
+            So that the site can function, you grant Patternflow a non-exclusive, worldwide,
+            royalty-free licence to host, store, display, and transmit what you publish, and to:
+          </p>
+          <ul>
+            <li>render it in the browser preview and generate thumbnail images from it,</li>
+            <li>compile it into firmware images and loadable pattern modules on request,</li>
+            <li>distribute those build artifacts to the person who asked for them,</li>
+            <li>show excerpts of it in listings, search results, and link previews.</li>
+          </ul>
+          <p>
+            This licence exists only to run the service and ends when you remove the content,
+            except for copies already distributed and for backups that age out normally. It does
+            not let us sell your work or licence it to anyone else.
+          </p>
+        </section>
+
+        <section>
+          <h2>5. What you promise</h2>
+          <p>By publishing something here you confirm that:</p>
+          <ul>
+            <li>you made it, or you otherwise have the right to publish it under the licence you chose,</li>
+            <li>it does not infringe anyone else&apos;s copyright, trademark, or other rights,</li>
+            <li>
+              if it is a fork, you have kept the original author&apos;s credit — the site writes this
+              into the source for you, and removing it is a breach of the upstream licence, not just
+              of these terms,
+            </li>
+            <li>
+              it contains no code intended to damage, mislead, or take control of anyone&apos;s device
+              or browser.
+            </li>
+          </ul>
+        </section>
+
+        <section>
+          <h2>6. What is not allowed</h2>
+          <ul>
+            <li>Publishing work that is not yours to publish.</li>
+            <li>Malicious code, or anything designed to break other people&apos;s hardware.</li>
+            <li>Harassment, abuse, or content that is unlawful where it is read.</li>
+            <li>Bulk-publishing low-effort output to flood the feed.</li>
+            <li>Automated scraping or requests that degrade the service for everyone else.</li>
+          </ul>
+        </section>
+
+        <section>
+          <h2>7. Reporting something</h2>
+          <p>
+            Every pattern, post and comment has a <strong>Report</strong> control. If you are not a
+            member — a rights holder sending a takedown notice, for example — email{" "}
+            <a href={`mailto:${CONTACT}`}>{CONTACT}</a>. Please include a link to the content, what
+            is wrong with it, and for a copyright claim a link to the original and enough contact
+            detail for us to reply.
+          </p>
+          <p>
+            Reports are read by a person. We may remove content, and we keep a record of reports so
+            that repeated problems from the same account are visible. Accounts that repeatedly
+            infringe other people&apos;s rights will be suspended.
+          </p>
+        </section>
+
+        <section>
+          <h2>8. Removal and account closure</h2>
+          <p>
+            We may remove content or suspend an account that breaks these terms. Where it is
+            reasonable to do so we will say why.
+          </p>
+          <p>
+            You can delete your own patterns, posts and comments at any time. To close your account,
+            email <a href={`mailto:${CONTACT}`}>{CONTACT}</a>.
+          </p>
+          <p className={styles.callout}>
+            <strong>What closing your account does not do:</strong> patterns you have already
+            published stay up, shown as by a deleted user, with the author credit that was written
+            into the source at publication time. This is not us keeping your data — it is because
+            the licence you granted is irrevocable, other people have built on those patterns, and
+            deleting them would break work that is legitimately theirs. Your account details are
+            removed.
+          </p>
+        </section>
+
+        <section>
+          <h2>9. Privacy</h2>
+          <h3>What we store</h3>
+          <ul>
+            <li>
+              <strong>Account</strong> — username, a hashed password, and an email address if you
+              chose to give one. Passwords are never stored in a readable form.
+            </li>
+            <li>
+              <strong>Sessions</strong> — a session token, plus the IP address and browser
+              user-agent of the sign-in. This is for security and abuse handling, not analytics.
+            </li>
+            <li>
+              <strong>What you publish</strong> — patterns, comments, posts, likes, and firmware
+              build requests.
+            </li>
+          </ul>
+
+          <h3>How long we keep it</h3>
+          <ul>
+            <li>
+              <strong>Sessions</strong> — deleted when they expire, and in any case within{" "}
+              <strong>90 days</strong>.
+            </li>
+            <li>
+              <strong>Firmware build artifacts</strong> — <strong>30 days</strong>. They can always
+              be rebuilt.
+            </li>
+            <li>
+              <strong>Account and published content</strong> — until you remove them, subject to
+              section 8.
+            </li>
+            <li>
+              <strong>Reports</strong> — kept after the reported content is gone, because that
+              record is the only way a repeat problem is visible.
+            </li>
+          </ul>
+
+          <h3>Who else sees it</h3>
+          <p>
+            The community runs on hardware operated by us. We do not sell personal data and we do
+            not share it with advertisers. We use privacy-respecting analytics on the main site to
+            count page views; it does not identify you.
+          </p>
+
+          <h3>Your rights</h3>
+          <p>
+            Email <a href={`mailto:${CONTACT}`}>{CONTACT}</a> to see, correct, export, or delete
+            your personal data. Depending on where you live you may have further rights under local
+            law — including the Korean Personal Information Protection Act (PIPA) or the GDPR — and
+            those apply regardless of anything else in this document.
+          </p>
+        </section>
+
+        <section>
+          <h2>10. No warranty</h2>
+          <p>
+            This is a free service run by one person. It is provided as-is, without warranties of
+            any kind. Patterns are code written by other people: they run in a sandbox in your
+            browser, but firmware you build and flash runs on your own hardware at your own risk.
+          </p>
+          <p>
+            <strong>Patternflow is not a party to any licence between you and someone whose pattern
+            you use.</strong> That licence is between the two of you, and its terms come from the
+            licence the author chose.
+          </p>
+          <p>
+            Nothing here excludes liability that cannot lawfully be excluded, including for death,
+            personal injury, fraud, or wilful misconduct.
+          </p>
+        </section>
+
+        <section>
+          <h2>11. Photosensitivity</h2>
+          <p>
+            Patternflow patterns are rapidly changing light. They can trigger seizures in people
+            with photosensitive epilepsy. Stop immediately if you feel unwell.
+          </p>
+        </section>
+
+        <section>
+          <h2>12. Changes</h2>
+          <p>
+            These terms will change as the community grows. Significant changes will be announced
+            in the community and on <a href="https://discord.gg/Vr9QtsxeTk">Discord</a> before they
+            take effect. The date at the top always reflects the current version.
+          </p>
+        </section>
+
+        <section>
+          <h2>13. Governing law</h2>
+          <p>
+            These terms are governed by the laws of the Republic of Korea, and disputes go to the
+            Seoul Central District Court. If you use this service as a consumer somewhere else, you
+            keep whatever mandatory protections your local law gives you — this clause does not take
+            those away.
+          </p>
+        </section>
+
+        <footer className={styles.foot}>
+          <p>
+            Questions about any of this: <a href={`mailto:${CONTACT}`}>{CONTACT}</a>
+          </p>
+          <p>
+            <Link href="/community">← Back to the community</Link>
+          </p>
+        </footer>
+      </article>
+    </main>
+  );
+}

--- a/web/src/components/community/Community.module.css
+++ b/web/src/components/community/Community.module.css
@@ -739,6 +739,25 @@
   color: var(--pf-led);
 }
 
+/* Sits in the meta row, styled to recede: reporting should be findable without
+   being an invitation. Inherits the row's font so it reads as one more fact,
+   not a call to action. */
+.reportLink {
+  border: 0;
+  padding: 0;
+  background: none;
+  font: inherit;
+  color: var(--pf-ink-dim, inherit);
+  opacity: 0.55;
+  cursor: pointer;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.reportLink:hover {
+  opacity: 1;
+}
+
 .metaDescription {
   margin-top: 14px;
   font-size: 14.5px;
@@ -1795,4 +1814,30 @@
   .cardCartBtn {
     opacity: 1;
   }
+}
+
+/* Community-wide footer: the terms link and the non-member reporting route.
+   Every page in the community needs to be one click from both. */
+.pageFooter {
+  display: flex;
+  gap: 10px;
+  justify-content: center;
+  align-items: center;
+  padding: 32px 0 8px;
+  margin-top: 40px;
+  border-top: var(--pf-rule-w, 1px) solid var(--pf-rule);
+  font-family: var(--pf-mono);
+  font-size: 11px;
+  letter-spacing: var(--pf-track-mono);
+  text-transform: uppercase;
+  color: var(--pf-ink-faint);
+}
+
+.pageFooter a {
+  color: var(--pf-ink-faint);
+  text-decoration: none;
+}
+
+.pageFooter a:hover {
+  color: var(--pf-led);
 }

--- a/web/src/components/community/EditDetailsModal.tsx
+++ b/web/src/components/community/EditDetailsModal.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { DESCRIPTION_MAX, TITLE_MAX } from "@/lib/community/validate";
-import { LICENSE_OPTIONS } from "@/lib/sharePattern";
+import { LICENSE_OPTIONS, forkLicenseOptions, licenseBySpdx } from "@/lib/sharePattern";
 import { captureEvent } from "@/lib/posthogEvents";
 import { COMMUNITY_FETCH_INIT, communityApiUrl } from "@/lib/community/apiBase";
 import styles from "./Community.module.css";
@@ -18,6 +18,7 @@ export default function EditDetailsModal({
   initialDescription,
   initialLicense,
   initialMadeOn,
+  parentLicense,
   onClose,
 }: {
   patternId: string;
@@ -25,6 +26,8 @@ export default function EditDetailsModal({
   initialDescription: string | null;
   initialLicense: string; // SPDX
   initialMadeOn: string | null; // YYYY-MM-DD
+  /** Parent's SPDX id when this pattern is a fork — narrows what it may become. */
+  parentLicense?: string | null;
   onClose: () => void;
 }) {
   const router = useRouter();
@@ -34,6 +37,18 @@ export default function EditDetailsModal({
   const [madeOn, setMadeOn] = useState(initialMadeOn ?? "");
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
+
+  // What this pattern may be relicensed to. The pattern's CURRENT licence is
+  // always included even when it is no longer offered (MIT, CC0): a retired
+  // option must stay selectable, or opening this modal to fix a typo in the
+  // title would silently relicense the pattern to whatever sits first in the
+  // list.
+  const licenseChoices = (() => {
+    const offered = parentLicense ? forkLicenseOptions(parentLicense) : LICENSE_OPTIONS;
+    return offered.some((option) => option.spdx === initialLicense)
+      ? offered
+      : [licenseBySpdx(initialLicense), ...offered];
+  })();
 
   const save = async () => {
     const trimmed = title.trim();
@@ -117,14 +132,17 @@ export default function EditDetailsModal({
           <label className={styles.field}>
             <span className={styles.fieldLabel}>Licence</span>
             <select value={license} onChange={(event) => setLicense(event.target.value)}>
-              {LICENSE_OPTIONS.map((option) => (
-                <option key={option.id} value={option.spdx}>
+              {licenseChoices.map((option) => (
+                <option key={option.spdx} value={option.spdx}>
                   {option.label}
                 </option>
               ))}
             </select>
             <span className={styles.fieldHint}>
               The licence header inside the code is rewritten to match.
+              {parentLicense && licenseChoices.length === 1
+                ? " Fixed by the licence of the pattern this was forked from."
+                : ""}
             </span>
           </label>
 

--- a/web/src/components/community/PublishModal.tsx
+++ b/web/src/components/community/PublishModal.tsx
@@ -5,7 +5,12 @@ import { useRouter } from "next/navigation";
 import { authClient } from "@/lib/community/auth-client";
 import { COMMUNITY_FETCH_INIT, communityApiUrl } from "@/lib/community/apiBase";
 import { DESCRIPTION_MAX, TITLE_MAX } from "@/lib/community/validate";
-import { DEFAULT_LICENSE_ID, LICENSE_OPTIONS, licenseById } from "@/lib/sharePattern";
+import {
+  DEFAULT_LICENSE_ID,
+  LICENSE_OPTIONS,
+  forkLicenseOptions,
+  licenseById,
+} from "@/lib/sharePattern";
 import { captureEvent } from "@/lib/posthogEvents";
 import AuthModal from "./AuthModal";
 import styles from "./Community.module.css";
@@ -18,6 +23,12 @@ type Props = {
   parentId: string | null;
   parentTitle: string | null;
   /**
+   * The parent's SPDX id, when forking. A derivative cannot be looser than what
+   * it came from, so the picker only offers what the API would accept — the
+   * server enforces the same rule regardless.
+   */
+  parentLicense?: string | null;
+  /**
    * Firmware header to publish alongside the pattern, when the hardware flow
    * already produced one. Publishing with it is what makes a pattern show up
    * as hardware-ready straight away instead of needing a second trip through
@@ -27,14 +38,28 @@ type Props = {
   onClose: () => void;
 };
 
-export default function PublishModal({ code, parentId, parentTitle, codeCpp, onClose }: Props) {
+export default function PublishModal({
+  code,
+  parentId,
+  parentTitle,
+  parentLicense,
+  codeCpp,
+  onClose,
+}: Props) {
   const router = useRouter();
   const { data: session, isPending } = authClient.useSession();
   const [title, setTitle] = useState("");
   const [description, setDescription] = useState("");
-  const [licenseId, setLicenseId] = useState(DEFAULT_LICENSE_ID);
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
+
+  const licenseChoices = parentLicense ? forkLicenseOptions(parentLicense) : LICENSE_OPTIONS;
+  // Default to the recommended licence, unless the parent's terms rule it out.
+  const [licenseId, setLicenseId] = useState(
+    licenseChoices.some((option) => option.id === DEFAULT_LICENSE_ID)
+      ? DEFAULT_LICENSE_ID
+      : (licenseChoices[0]?.id ?? DEFAULT_LICENSE_ID),
+  );
 
   const publish = async () => {
     const trimmed = title.trim();
@@ -105,7 +130,8 @@ export default function PublishModal({ code, parentId, parentTitle, codeCpp, onC
             {parentId && (
               <p className={styles.formNote}>
                 Publishing as a fork of <strong>{parentTitle ?? "a community pattern"}</strong> — the
-                original stays linked from your post.
+                original stays linked from your post, and its author is credited in your pattern&apos;s
+                header.
               </p>
             )}
 
@@ -134,14 +160,19 @@ export default function PublishModal({ code, parentId, parentTitle, codeCpp, onC
             <label className={styles.field}>
               <span className={styles.fieldLabel}>License</span>
               <select value={licenseId} onChange={(event) => setLicenseId(event.target.value)}>
-                {LICENSE_OPTIONS.map((option) => (
+                {licenseChoices.map((option) => (
                   <option key={option.id} value={option.id}>
                     {option.label}
                   </option>
                 ))}
               </select>
               <span className={styles.fieldHint}>
-                Publishing shares your pattern under this license, credited to your username.
+                {licenseId === "cc-by-4.0"
+                  ? "Anyone may use and adapt your pattern, including commercially, as long as they credit you. Their versions can be released under any license."
+                  : "Anyone may use and adapt your pattern, including commercially, as long as they credit you — and their versions have to stay under this same license."}
+                {parentLicense && licenseChoices.length === 1
+                  ? " This is fixed by the license of the pattern you forked."
+                  : ""}
               </span>
             </label>
 

--- a/web/src/components/community/ReportModal.tsx
+++ b/web/src/components/community/ReportModal.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+import { useState } from "react";
+import { authClient } from "@/lib/community/auth-client";
+import { COMMUNITY_FETCH_INIT, communityApiUrl } from "@/lib/community/apiBase";
+import {
+  REPORT_DETAIL_MAX,
+  REPORT_REASONS,
+  REPORT_REASON_LABELS,
+  type ReportReason,
+  type ReportTargetType,
+} from "@/lib/community/validate";
+import { captureEvent } from "@/lib/posthogEvents";
+import AuthModal from "./AuthModal";
+import styles from "./Community.module.css";
+
+// Reporting needs an account, same as commenting — a report costs someone
+// nothing to file and real time to read. People who are not members use the
+// address in the terms instead, which the footer of this modal points at.
+
+export default function ReportModal({
+  targetType,
+  targetId,
+  targetLabel,
+  onClose,
+}: {
+  targetType: ReportTargetType;
+  targetId: string;
+  /** What the reporter thinks they are flagging, echoed back for confidence. */
+  targetLabel: string;
+  onClose: () => void;
+}) {
+  const { data: session, isPending } = authClient.useSession();
+  const [reason, setReason] = useState<ReportReason>("copyright");
+  const [detail, setDetail] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [sent, setSent] = useState(false);
+
+  const submit = async () => {
+    setError(null);
+    setBusy(true);
+    try {
+      const response = await fetch(communityApiUrl("/api/community/reports"), {
+        method: "POST",
+        ...COMMUNITY_FETCH_INIT,
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ targetType, targetId, reason, detail }),
+      });
+      const payload = (await response.json()) as { ok?: boolean; error?: string };
+      if (!response.ok) {
+        setError(payload.error ?? "Could not send the report.");
+        return;
+      }
+      captureEvent("community_report", { target_type: targetType, reason });
+      setSent(true);
+    } catch {
+      setError("Network error — is the community server reachable?");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className={styles.modalOverlay} role="dialog" aria-modal="true" onClick={onClose}>
+      <div className={styles.modalCard} onClick={(event) => event.stopPropagation()}>
+        <div className={styles.modalHeader}>
+          <span>Report</span>
+          <button type="button" onClick={onClose} aria-label="Close">
+            ×
+          </button>
+        </div>
+
+        {isPending ? (
+          <div className={styles.modalBody}>
+            <span className={styles.formNote}>Checking session…</span>
+          </div>
+        ) : !session ? (
+          <AuthModal embedded onClose={() => undefined} />
+        ) : sent ? (
+          <div className={styles.modalBody}>
+            <p className={styles.formNote}>
+              Thank you — this has been recorded and will be reviewed. You will not get an
+              automatic reply, but every report is read.
+            </p>
+            <button type="button" className={styles.btnAccent} onClick={onClose}>
+              Close
+            </button>
+          </div>
+        ) : (
+          <div className={styles.modalBody}>
+            <p className={styles.formNote}>
+              Reporting <strong>{targetLabel}</strong>.
+            </p>
+
+            <label className={styles.field}>
+              <span className={styles.fieldLabel}>Reason</span>
+              <select value={reason} onChange={(event) => setReason(event.target.value as ReportReason)}>
+                {REPORT_REASONS.map((value) => (
+                  <option key={value} value={value}>
+                    {REPORT_REASON_LABELS[value]}
+                  </option>
+                ))}
+              </select>
+            </label>
+
+            <label className={styles.field}>
+              <span className={styles.fieldLabel}>Details (optional)</span>
+              <textarea
+                className={styles.textInput}
+                rows={4}
+                value={detail}
+                maxLength={REPORT_DETAIL_MAX}
+                placeholder="If this is a copyright report, a link to the original helps a lot."
+                onChange={(event) => setDetail(event.target.value)}
+              />
+            </label>
+
+            {error && <div className={styles.formError}>{error}</div>}
+
+            <button
+              type="button"
+              className={styles.btnAccent}
+              disabled={busy}
+              onClick={() => void submit()}
+            >
+              {busy ? "Sending…" : "Send report"}
+            </button>
+
+            <span className={styles.formNote}>
+              Are you the rights holder and not a member here? Email{" "}
+              <a href="mailto:contact@patternflow.work">contact@patternflow.work</a> — see the{" "}
+              <a href="/terms">terms</a>.
+            </span>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/layout/Footer.tsx
+++ b/web/src/components/layout/Footer.tsx
@@ -3,8 +3,10 @@ export default function Footer() {
     <footer id="origin">
       <div className="foot-row">
         <div>
-          Firmware &amp; web — MIT License.<br />
-          Hardware &amp; designs — CC BY-SA 4.0.<br />
+          Firmware &amp; web code — MIT License.<br />
+          Hardware, designs &amp; patterns — CC BY-SA 4.0.<br />
+          Community patterns are licensed by their authors.<br />
+          <a href="/terms">Terms &amp; Privacy</a><br />
           <br />
           <em className="wordmark">Patternflow</em> is a trademark of SeungHun Lee.
         </div>

--- a/web/src/lib/community/admin.ts
+++ b/web/src/lib/community/admin.ts
@@ -1,0 +1,39 @@
+import type { CommunitySession } from "./auth";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Moderator identity.
+//
+// Env var, not a database column: the community is run by one person on one
+// box, and a `role` column would need a UI to grant it, an audit trail for who
+// granted it, and a story for what happens when the row is edited by hand. A
+// list in the environment has none of that, and changing it needs shell access
+// to the server — which is a stronger control than anything we would build.
+//
+// Usernames rather than user ids so the value is legible to the person editing
+// it. Better Auth's `username` column is the normalised (lowercased) handle, so
+// comparison is lowercase on both sides.
+//
+//   COMMUNITY_ADMIN_USERNAMES=engmung,someone-else
+//
+// Unset means nobody is a moderator — the safe default, and what every other
+// deployment of this repo gets.
+// ─────────────────────────────────────────────────────────────────────────────
+
+export function adminUsernames(): string[] {
+  return (process.env.COMMUNITY_ADMIN_USERNAMES ?? "")
+    .split(",")
+    .map((entry) => entry.trim().toLowerCase())
+    .filter(Boolean);
+}
+
+export function isAdminUsername(username: string | null | undefined): boolean {
+  if (!username) return false;
+  return adminUsernames().includes(username.toLowerCase());
+}
+
+/** Whether the signed-in user may remove other people's content. */
+export function isAdminSession(session: CommunitySession): boolean {
+  if (!session) return false;
+  const handle = (session.user as { username?: string | null }).username ?? null;
+  return isAdminUsername(handle);
+}

--- a/web/src/lib/community/download.ts
+++ b/web/src/lib/community/download.ts
@@ -1,10 +1,11 @@
 "use client";
 
 import {
-  LICENSE_OPTIONS,
   buildSharedHeaderFile,
   buildSharedPatternFile,
+  licenseBySpdx,
   slugifyName,
+  type ShareLineage,
   type ShareMeta,
 } from "@/lib/sharePattern";
 
@@ -19,6 +20,8 @@ export type DownloadablePattern = {
   createdAt: string; // ISO
   username: string | null;
   displayUsername: string | null;
+  /** Upstream credit when this is a fork — same line the stored source carries. */
+  basedOn?: ShareLineage | null;
 };
 
 function shareMetaFor(pattern: DownloadablePattern): ShareMeta {
@@ -26,11 +29,13 @@ function shareMetaFor(pattern: DownloadablePattern): ShareMeta {
   return {
     title: pattern.title,
     author: handle ? `@${handle}` : "(unknown)",
-    license:
-      LICENSE_OPTIONS.find((option) => option.spdx === pattern.license) ?? LICENSE_OPTIONS[0],
+    // Never fall back to a default licence — an unrecognised SPDX is passed
+    // through so the file cannot claim terms the author did not choose.
+    license: licenseBySpdx(pattern.license),
     // The publication date, not today's — the file records when it was shared.
     date: pattern.createdAt.slice(0, 10),
     source: "community",
+    basedOn: pattern.basedOn ?? null,
   };
 }
 

--- a/web/src/lib/community/handoff.ts
+++ b/web/src/lib/community/handoff.ts
@@ -11,6 +11,8 @@ export type LabHandoff = {
   /** Community pattern this code came from — becomes parent_id if re-shared. */
   parentId: string | null;
   parentTitle: string | null;
+  /** Parent's SPDX id, so the publish picker only offers compatible licences. */
+  parentLicense: string | null;
 };
 
 export function writeLabHandoff(handoff: LabHandoff): void {
@@ -31,6 +33,7 @@ export function readLabHandoff(): LabHandoff | null {
       code: parsed.code,
       parentId: typeof parsed.parentId === "string" ? parsed.parentId : null,
       parentTitle: typeof parsed.parentTitle === "string" ? parsed.parentTitle : null,
+      parentLicense: typeof parsed.parentLicense === "string" ? parsed.parentLicense : null,
     };
   } catch {
     return null;

--- a/web/src/lib/community/license.ts
+++ b/web/src/lib/community/license.ts
@@ -1,7 +1,9 @@
 import {
-  LICENSE_OPTIONS,
+  SHARE_TOOLS,
   buildSharedPatternFile,
+  licenseBySpdx,
   type LicenseOption,
+  type ShareLineage,
   type ShareMeta,
 } from "@/lib/sharePattern";
 
@@ -21,7 +23,29 @@ import {
 // ─────────────────────────────────────────────────────────────────────────────
 
 export function licenseOptionFor(spdx: string): LicenseOption {
-  return LICENSE_OPTIONS.find((option) => option.spdx === spdx) ?? LICENSE_OPTIONS[0];
+  return licenseBySpdx(spdx);
+}
+
+/** Public URL of a community pattern — used for the fork credit line. */
+export function communityPatternUrl(id: string): string {
+  return `${SHARE_TOOLS.community.url}/p/${id}`;
+}
+
+/** Upstream pattern a fork was adapted from, as stored on the parent row. */
+export type ParentCredit = {
+  id: string;
+  title: string;
+  username: string | null;
+  displayUsername: string | null;
+};
+
+export function lineageFrom(parent: ParentCredit | null | undefined): ShareLineage | null {
+  if (!parent) return null;
+  return {
+    title: parent.title,
+    handle: parent.displayUsername ?? parent.username ?? null,
+    url: communityPatternUrl(parent.id),
+  };
 }
 
 export type PatternLicenseMeta = {
@@ -31,6 +55,8 @@ export type PatternLicenseMeta = {
   handle: string | null;
   /** Publication date (ISO or Date) — stays the original date across edits. */
   date: Date | string;
+  /** Set on a fork so the original creator stays credited in the source. */
+  basedOn?: ShareLineage | null;
 };
 
 function shareMeta(meta: PatternLicenseMeta): ShareMeta {
@@ -41,6 +67,7 @@ function shareMeta(meta: PatternLicenseMeta): ShareMeta {
     license: licenseOptionFor(meta.license),
     date: date.slice(0, 10),
     source: "community",
+    basedOn: meta.basedOn ?? null,
   };
 }
 

--- a/web/src/lib/community/queries.ts
+++ b/web/src/lib/community/queries.ts
@@ -128,15 +128,80 @@ export async function getPattern(id: string) {
   return rows[0] ?? null;
 }
 
-/** Minimal parent info for the "forked from" link. */
+/**
+ * Parent info for the "forked from" link — and for the two things a fork owes
+ * its parent: the upstream credit baked into the source, and the licence its
+ * own choice has to stay compatible with.
+ */
 export async function getPatternStub(id: string) {
   const db = getDb();
   const rows = await db
-    .select({ id: patterns.id, title: patterns.title, userId: patterns.userId })
+    .select({
+      id: patterns.id,
+      title: patterns.title,
+      userId: patterns.userId,
+      license: patterns.license,
+      ...authorFields,
+    })
     .from(patterns)
+    .innerJoin(user, eq(patterns.userId, user.id))
     .where(eq(patterns.id, id))
     .limit(1);
   return rows[0] ?? null;
+}
+
+/** Ownership check for comment deletion, without loading the thread. */
+export async function getCommentStub(on: "pattern" | "post", id: string) {
+  const db = getDb();
+  if (on === "pattern") {
+    const rows = await db
+      .select({ id: comments.id, userId: comments.userId })
+      .from(comments)
+      .where(eq(comments.id, id))
+      .limit(1);
+    return rows[0] ?? null;
+  }
+  const rows = await db
+    .select({ id: postComments.id, userId: postComments.userId })
+    .from(postComments)
+    .where(eq(postComments.id, id))
+    .limit(1);
+  return rows[0] ?? null;
+}
+
+/**
+ * Title + author of whatever is being reported, so the report keeps a readable
+ * snapshot. Comments have no title, so the body stands in — truncated, because
+ * this is a label in a moderation list, not a copy of the content.
+ */
+export async function reportTarget(
+  type: "pattern" | "post" | "comment",
+  id: string,
+): Promise<{ title: string; userId: string } | null> {
+  const db = getDb();
+  if (type === "pattern") {
+    const rows = await db
+      .select({ title: patterns.title, userId: patterns.userId })
+      .from(patterns)
+      .where(eq(patterns.id, id))
+      .limit(1);
+    return rows[0] ?? null;
+  }
+  if (type === "post") {
+    const rows = await db
+      .select({ title: posts.title, userId: posts.userId })
+      .from(posts)
+      .where(eq(posts.id, id))
+      .limit(1);
+    return rows[0] ?? null;
+  }
+  const rows = await db
+    .select({ body: comments.body, userId: comments.userId })
+    .from(comments)
+    .where(eq(comments.id, id))
+    .limit(1);
+  const row = rows[0];
+  return row ? { title: row.body.slice(0, 80), userId: row.userId } : null;
 }
 
 export async function listComments(patternId: string) {

--- a/web/src/lib/community/schema.ts
+++ b/web/src/lib/community/schema.ts
@@ -227,6 +227,40 @@ export const builds = sqliteTable(
   ],
 );
 
+// ── Moderation ───────────────────────────────────────────────────────────────
+// A report is a record, not a pointer. `targetId` and `targetUserId` carry NO
+// foreign key on purpose: the whole reason to keep reports is to see that the
+// same account has been reported before, and a cascade would erase exactly that
+// history the moment the offending pattern is removed. The title is snapshotted
+// for the same reason — so a resolved report still reads as something.
+export const reports = sqliteTable(
+  "reports",
+  {
+    id: text("id").primaryKey(),
+    /** "pattern" | "post" | "comment" */
+    targetType: text("target_type").notNull(),
+    targetId: text("target_id").notNull(),
+    /** What it was called when it was reported. */
+    targetTitle: text("target_title"),
+    /** Who authored the reported content — the repeat-infringer signal. */
+    targetUserId: text("target_user_id"),
+    reporterId: text("reporter_id")
+      .notNull()
+      .references(() => user.id, { onDelete: "cascade" }),
+    /** "copyright" | "inappropriate" | "spam" | "malicious" | "other" */
+    reason: text("reason").notNull(),
+    detail: text("detail"),
+    /** "open" | "actioned" | "dismissed" */
+    status: text("status").notNull().default("open"),
+    createdAt: integer("created_at", { mode: "timestamp" }).notNull(),
+    resolvedAt: integer("resolved_at", { mode: "timestamp" }),
+  },
+  (table) => [
+    index("reports_status_created_idx").on(table.status, table.createdAt),
+    index("reports_target_user_idx").on(table.targetUserId),
+  ],
+);
+
 export const comments = sqliteTable(
   "comments",
   {

--- a/web/src/lib/community/validate.ts
+++ b/web/src/lib/community/validate.ts
@@ -90,3 +90,44 @@ export function cleanComment(raw: unknown): string | null {
   if (body.length === 0 || body.length > COMMENT_MAX) return null;
   return body;
 }
+
+// ── Reports ──────────────────────────────────────────────────────────────────
+
+export const REPORT_TARGET_TYPES = ["pattern", "post", "comment"] as const;
+export type ReportTargetType = (typeof REPORT_TARGET_TYPES)[number];
+
+export function isReportTargetType(raw: unknown): raw is ReportTargetType {
+  return typeof raw === "string" && REPORT_TARGET_TYPES.includes(raw as ReportTargetType);
+}
+
+/**
+ * Why something was reported. "malicious" is on the list because a pattern is
+ * executable code that other people run in their browser and flash to their
+ * board — a category the usual report menus have no word for.
+ */
+export const REPORT_REASONS = [
+  "copyright",
+  "inappropriate",
+  "spam",
+  "malicious",
+  "other",
+] as const;
+export type ReportReason = (typeof REPORT_REASONS)[number];
+
+export const REPORT_REASON_LABELS: Record<ReportReason, string> = {
+  copyright: "Copyright — this is someone else's work, or the license is wrong",
+  inappropriate: "Inappropriate or abusive content",
+  spam: "Spam or junk",
+  malicious: "Malicious code",
+  other: "Something else",
+};
+
+export const REPORT_DETAIL_MAX = 2000;
+
+export function cleanReportDetail(raw: unknown): string | null | undefined {
+  if (raw === undefined || raw === null) return null;
+  if (typeof raw !== "string") return undefined;
+  const detail = raw.trim();
+  if (detail.length > REPORT_DETAIL_MAX) return undefined;
+  return detail.length === 0 ? null : detail;
+}

--- a/web/src/lib/lab/serialize.ts
+++ b/web/src/lib/lab/serialize.ts
@@ -287,7 +287,13 @@ export function deserializeProject(json: string): (LabProject & { savedAt: numbe
       ? (() => {
           const entry = raw.forkOf as Record<string, unknown>;
           return typeof entry.id === "string" && typeof entry.title === "string"
-            ? { id: entry.id, title: entry.title.slice(0, 120) }
+            ? {
+                id: entry.id,
+                title: entry.title.slice(0, 120),
+                // Absent on drafts saved before forks tracked the parent's
+                // licence; the publish API enforces compatibility regardless.
+                license: typeof entry.license === "string" ? entry.license : null,
+              }
             : null;
         })()
       : null;

--- a/web/src/lib/lab/types.ts
+++ b/web/src/lib/lab/types.ts
@@ -94,7 +94,12 @@ export type PixelLayer = LayerCommon & {
 
 export type Layer = CodeLayer | PixelLayer;
 
-export type ForkRef = { id: string; title: string } | null;
+/**
+ * `license` is the parent's SPDX id, used to narrow the publish picker to what
+ * a derivative may legally use. Optional because drafts saved before it existed
+ * do not carry it — the publish API enforces the same rule either way.
+ */
+export type ForkRef = { id: string; title: string; license?: string | null } | null;
 
 export type GenSettings = {
   count: number;

--- a/web/src/lib/sharePattern.ts
+++ b/web/src/lib/sharePattern.ts
@@ -4,12 +4,36 @@
 
 export type LicenseOption = { id: string; label: string; spdx: string };
 
+/**
+ * What an author can CHOOSE when publishing or editing.
+ *
+ * Deliberately two. The picker used to offer four (plus MIT and CC0) and every
+ * single pattern published took the default — that is not variety, it is a
+ * default. Fewer options keep the fork-compatibility rules (see
+ * `forkLicenseAllowed`) simple enough to enforce, and make a rights decision
+ * taken in two seconds in a modal less dangerous.
+ *
+ * MIT is a software-distribution licence (warranty/liability clauses) and CC BY
+ * says the same thing in language that fits a creative work. CC0 is an
+ * irrevocable total waiver of rights — not something to put one dropdown click
+ * away from a tired person at 2am.
+ */
 export const LICENSE_OPTIONS: LicenseOption[] = [
   { id: "cc-by-sa-4.0", label: "CC BY-SA 4.0 (recommended)", spdx: "CC-BY-SA-4.0" },
   { id: "cc-by-4.0", label: "CC BY 4.0", spdx: "CC-BY-4.0" },
-  { id: "mit", label: "MIT", spdx: "MIT" },
-  { id: "cc0-1.0", label: "CC0 1.0 (public domain)", spdx: "CC0-1.0" },
 ];
+
+/**
+ * Retired from the picker but still recognised. A copyright grant cannot be
+ * withdrawn, so a pattern published under one of these keeps it — we just stop
+ * offering it to new work.
+ */
+export const RETIRED_LICENSE_OPTIONS: LicenseOption[] = [
+  { id: "mit", label: "MIT (retired)", spdx: "MIT" },
+  { id: "cc0-1.0", label: "CC0 1.0 (retired)", spdx: "CC0-1.0" },
+];
+
+export const KNOWN_LICENSES: LicenseOption[] = [...LICENSE_OPTIONS, ...RETIRED_LICENSE_OPTIONS];
 
 export const DEFAULT_LICENSE_ID = "cc-by-sa-4.0";
 
@@ -24,7 +48,44 @@ export const SHARE_TOOLS: Record<ShareSource, { label: string; url: string }> = 
 };
 
 export function licenseById(id: string): LicenseOption {
-  return LICENSE_OPTIONS.find((option) => option.id === id) ?? LICENSE_OPTIONS[0];
+  return KNOWN_LICENSES.find((option) => option.id === id) ?? LICENSE_OPTIONS[0];
+}
+
+/**
+ * Look up a stored SPDX id for DISPLAY. An unrecognised value is passed through
+ * as-is rather than falling back to the default: silently relabelling someone's
+ * pattern would be us changing their licence for them.
+ */
+export function licenseBySpdx(spdx: string): LicenseOption {
+  return (
+    KNOWN_LICENSES.find((option) => option.spdx === spdx) ?? { id: "custom", label: spdx, spdx }
+  );
+}
+
+/**
+ * Which licences a fork may be published under, given its parent's. A
+ * derivative cannot be looser than what it derives from — ShareAlike is the
+ * whole point of CC BY-SA, and the publish API used to accept any licence for
+ * any fork, which made the platform a party to breaking it.
+ */
+export function forkLicenseAllowed(parentSpdx: string, childSpdx: string): boolean {
+  switch (parentSpdx) {
+    // ShareAlike: the adaptation carries the same terms forward.
+    case "CC-BY-SA-4.0":
+      return childSpdx === "CC-BY-SA-4.0";
+    // Attribution-only: a fork may keep it, or add ShareAlike on top.
+    case "CC-BY-4.0":
+      return childSpdx === "CC-BY-4.0" || childSpdx === "CC-BY-SA-4.0";
+    // Permissive (the retired options, and anything we don't recognise): no
+    // downstream restriction to honour.
+    default:
+      return true;
+  }
+}
+
+/** Licences a fork of this parent may use, for the publish picker. */
+export function forkLicenseOptions(parentSpdx: string): LicenseOption[] {
+  return LICENSE_OPTIONS.filter((option) => forkLicenseAllowed(parentSpdx, option.spdx));
 }
 
 export function slugifyName(name: string): string {
@@ -37,24 +98,48 @@ export function slugifyName(name: string): string {
   );
 }
 
+/** Upstream credit for a fork — the pattern this one was adapted from. */
+export type ShareLineage = {
+  title: string;
+  /** Author handle, without the "@". */
+  handle: string | null;
+  /** Canonical community URL, when there is one. */
+  url?: string | null;
+};
+
 export type ShareMeta = {
   title: string;
   author: string;
   license: LicenseOption;
   date: string;
   source: ShareSource;
+  /**
+   * Set on a fork. Both CC licences require a derivative to keep identifying
+   * the original creator, and the DB's `parent_id` does not travel with the
+   * file — copied code, downloads and compiled .pfm modules all leave the site,
+   * so the credit has to live in the source.
+   */
+  basedOn?: ShareLineage | null;
 };
 
 // Top-of-file licence header. SPDX line is kept machine-readable.
 export function buildLicenseHeader(meta: ShareMeta): string {
-  return [
+  const lines = [
     "// ===== Patternflow pattern =====",
-    `// Title:   ${meta.title || "Untitled pattern"}`,
-    `// Author:  ${meta.author || "(unknown)"}`,
-    `// Date:    ${meta.date}`,
+    `// Title:    ${meta.title || "Untitled pattern"}`,
+    `// Author:   ${meta.author || "(unknown)"}`,
+  ];
+  if (meta.basedOn) {
+    const by = meta.basedOn.handle ? ` by @${meta.basedOn.handle}` : "";
+    const at = meta.basedOn.url ? ` — ${meta.basedOn.url}` : "";
+    lines.push(`// Based on: "${meta.basedOn.title}"${by}${at}`);
+  }
+  lines.push(
+    `// Date:     ${meta.date}`,
     `// SPDX-License-Identifier: ${meta.license.spdx}`,
     "// ===============================",
-  ].join("\n");
+  );
+  return lines.join("\n");
 }
 
 // Bottom-of-file attribution. Worded so people know it is not optional.


### PR DESCRIPTION
## What

Two things the community was missing, both of which stay invisible at eight users and stop being invisible during a campaign.

**Licences**
- Publish picker narrowed from four options to two — **CC BY-SA 4.0** (default) and **CC BY 4.0**. All 58 published patterns had taken the default, so the other two were never a choice anyone made. MIT and CC0 are retired from the picker but still recognised, so already-published patterns keep their terms; an unrecognised SPDX id passes through rather than falling back to the default.
- **Forks can no longer loosen their parent's licence.** Forking a CC BY-SA pattern and publishing it as CC0 used to work — a ShareAlike breach the site was assisting with. Enforced in both the publish and edit routes; the picker only offers what the API accepts.
- **Forks now credit the original author in the source.** Republishing used to strip the upstream header and rebake it under the forker's name. `parent_id` kept the lineage, but the *code* lost it — and the code is what leaves the site as a download, a paste, or a compiled `.pfm`. Forks carry a `Based on:` line, rebuilt from the parent row on every save so it can't be edited away.
- Docs rewritten **asset by asset instead of folder by folder** — the old table had the presets reading as MIT and CC BY-SA simultaneously. The per-file SPDX header is now named as the authority. Repo contribution vs. community publishing are described as the separate things they are.

**Moderation**
- **`/terms`** — terms of use and privacy notice on one page. Hosting grant, author keeps copyright, retention (sessions 90 days, build artifacts 30 days), governing law Korea / Seoul Central District Court, and the clause most likely to surprise someone later: closing an account leaves published patterns up, because the licence granted is irrevocable and other people have built on them.
- **Report control** on patterns → `reports` table. Reports intentionally carry no foreign key to their target, so the record outlives the removal — otherwise a repeat problem from one account is invisible.
- **Moderators** via `COMMUNITY_ADMIN_USERNAMES`. Can remove a pattern, post or comment; cannot edit one. Unset means nobody, which is what every other deployment of this repo gets.
- **Comments had no delete route at all** — not even for their author — so reporting one led nowhere. Added.

## Why

Groundwork for the pattern marketplace, but useful immediately: before this, nothing in the codebase could remove a bad pattern except its own author, and the licence shown on a fork could be one its parent never permitted.

## Tested

- `npm run check:license` — 22 assertions (header generation, idempotent re-baking, fork-compatibility matrix, retired-licence survival, download path)
- `npm run check:moderation` — 26 assertions (admin env parsing incl. empty/whitespace/case/near-miss, report input validation)
- `tsc --noEmit`, `npm run lint` (0 errors), `npm run build` — all pass
- Migration `0006_add-reports` applies cleanly on the existing database
- Unauthenticated calls to every new endpoint return 401
- Browser: `/terms` renders, Report opens the sign-in gate, community footer links resolve
- Fork flow confirmed end-to-end by @engmung on a signed-in account

## Deploying

`COMMUNITY_ADMIN_USERNAMES=engmung` has to be set on the Pi and the app rebuilt, or nobody has moderator rights.

---
- [x] Touches `web/` → it builds (`npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
