### PR TITLE
Comment edit/delete, and a written map of the community

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ So Patternflow is not a single luminous object. It is a living system in which a
 | `tools/` | Desktop-side helpers, including the audio-react browser extension |
 | `integrations/` | Host-software bridges — Ableton Live / Max for Live (OSC knob mapping) |
 
-**Docs:** [Full Build Guide](BUILD_GUIDE.md) · [Assembly Map](docs/assembly/README.md) · [Custom Patterns](firmware/CUSTOM_PATTERNS.md) · [Changelog](CHANGELOG.md) · [License Summary](docs/LICENSE-SUMMARY.md)
+**Docs:** [Full Build Guide](BUILD_GUIDE.md) · [Assembly Map](docs/assembly/README.md) · [Custom Patterns](firmware/CUSTOM_PATTERNS.md) · [Community](docs/COMMUNITY.md) · [Changelog](CHANGELOG.md) · [License Summary](docs/LICENSE-SUMMARY.md)
 
 **Links:** [patternflow.work](https://patternflow.work) · [Community](https://community.patternflow.work/community) · [Crowd Supply](https://www.crowdsupply.com/engmung/patternflow) · [Releases](../../releases) · [Discord](https://discord.gg/Vr9QtsxeTk) · [Instagram](https://www.instagram.com/patternflow.work)
 

--- a/docs/COMMUNITY.md
+++ b/docs/COMMUNITY.md
@@ -1,0 +1,216 @@
+# The Community — how it works, and what it does not do yet
+
+The pattern community at [community.patternflow.work](https://community.patternflow.work/community):
+publishing, forking, comments, moderation, and the deck you build onto a board.
+
+This page is the map. It says what exists, why some of it is shaped the way it
+is, and — at the bottom — what is deliberately missing, so nobody has to read
+the source to find out.
+
+**Last reviewed:** 29 July 2026
+
+---
+
+## Where it runs
+
+The community is one Next.js app backed by **one SQLite file**. Backup is
+copying the file.
+
+It only runs where `COMMUNITY_ENABLED=1` is set, which is the self-hosted box.
+Every other deployment of this repo — including the Vercel mirror of the main
+site — serves the community routes as a pointer to the real host. That is why
+the code checks `communityEnabled()` before touching the database: importing
+the module must never open a file on a deployment that has none.
+
+| Piece | What it is |
+| :--- | :--- |
+| Web server | Next.js, `patternflow-community.service` |
+| Build worker | Separate process, `patternflow-worker.service` — compiles submitted C++, and runs the retention sweep daily |
+| Database | SQLite via Drizzle. Migrations in `web/drizzle/`, applied automatically on first open |
+| Auth | Better Auth — username + password. Email is optional and recovery-only |
+
+Operational commands are in [SERVICES.md](SERVICES.md).
+
+---
+
+## Patterns
+
+A pattern is JavaScript. The stored source is the **source of truth**, and it
+carries its own licence header and attribution footer — rebuilt from the
+database row on every save, never trusted from user input. Most people copy
+code out of the page rather than downloading a file, and a licence that only
+exists in the download is a licence most readers never see.
+
+**The firmware header (`.h`) is separate and optional.** It is the author's
+hand-verified C++ port, attached after the fact; a pattern that has one is
+"hardware ready" and can be flashed or built into a module directly. It is
+never auto-generated and never carried across a fork — the JavaScript may have
+changed, which would make the port a lie.
+
+**Untrusted code only ever runs inside a sandboxed iframe**
+(`web/public/pattern-sandbox.html`, `sandbox="allow-scripts"`, opaque origin,
+postMessage protocol). That boundary is what makes "edit anyone's pattern in
+the browser with no account" safe. The sandbox duplicates the pattern harness
+on purpose — keep the two in step when the pattern contract changes.
+
+### Licences
+
+Two options, chosen by the author at publish time:
+
+| SPDX | What it means |
+| :--- | :--- |
+| `CC-BY-SA-4.0` (default) | Free to use and adapt, including commercially, with credit. **Adaptations carry the same licence.** |
+| `CC-BY-4.0` | Same, but adaptations may use any licence. |
+
+MIT and CC0 were retired from the picker. Patterns published under them keep
+those terms — a licence grant cannot be withdrawn — and an unrecognised SPDX id
+is passed through rather than silently relabelled.
+
+Full breakdown: [LICENSE-SUMMARY.md](LICENSE-SUMMARY.md).
+
+### Forks
+
+A fork is a derivative, so two rules are enforced rather than hoped for:
+
+1. **It cannot be looser than its parent.** A fork of a CC BY-SA pattern must
+   also be CC BY-SA. The publish picker only offers what the API accepts, and
+   the API checks again.
+2. **It credits its parent in the source.** The header gains a `Based on:` line
+   naming the original author and linking the pattern. It is rebuilt from the
+   parent row on every save, so it cannot be edited away — and it matters
+   because the code is the thing that leaves, as a download, a paste, or a
+   compiled `.pfm`. The database's `parent_id` does not travel with the file.
+
+### Provenance
+
+Two different things sit side by side on a pattern page.
+
+**The author's declaration** (`made_how`) — written by hand, AI-assisted, or
+AI-generated then edited. Using AI is not a mark against anything: Pattern Lab
+is built for it. Saying so plainly is what makes the answer worth having.
+
+**Signals read out of the source** — a colour ramp (`@ramp`), declared knob
+ranges (`@knobs`), a layer stack (`@stack`), a composed frame (`@matrix`), a
+hardware-verified header. Pattern Lab writes these while the author works.
+
+This is a record, not a score. A pattern with none of them is not accused of
+anything.
+
+> **Known limitation.** Two of those signals — `@knobs` and `@matrix` — are
+> emitted by the AI generation prompt itself, so they appear on a one-shot
+> generated pattern too. And any of them can be typed by hand. They are honest
+> about what was seen in the file; they are not proof of human authorship, and
+> should not be presented as such if anything ever depends on it.
+
+---
+
+## Moderation
+
+| Capability | Who |
+| :--- | :--- |
+| Edit own pattern / post / comment | The author only |
+| Delete own pattern / post / comment | The author |
+| Delete anyone's pattern / post / comment | Moderators |
+| Edit anyone's content | **Nobody** |
+
+That last row is deliberate. Removing someone's content is moderation;
+rewriting it while their name stays on it is putting words in their mouth.
+
+Moderators come from `COMMUNITY_ADMIN_USERNAMES` — a comma-separated list of
+usernames in the environment, not a database column. Changing it needs shell
+access to the server, which is a stronger control than a permissions UI. Unset
+means nobody, which is what every clone of this repo gets.
+
+**Reporting.** Every pattern has a Report control; rights holders who are not
+members use the address in the [terms](https://patternflow.work/terms).
+Reports land in a queue at `/community/reports`, visible to moderators and a
+404 for everyone else.
+
+A report deliberately carries **no foreign key** to what it points at. The
+record has to outlive the removal, because "this author has been reported four
+times" is the only signal that separates a repeat problem from noise — and a
+cascade would erase exactly that at the moment it starts to matter.
+
+Closing a report never removes anything. Reports cannot be edited: a record you
+can rewrite is not a record.
+
+---
+
+## Deck and Saved
+
+Two lists, both in the browser's local storage. They hold copies of things that
+could be re-collected in a minute, so losing them costs nothing — and keeping
+them out of the database means no schema, no "whose deck is this", and no sync.
+
+| | Saved | Deck |
+| :--- | :--- | :--- |
+| Size | Unbounded | Capped at what one build holds |
+| Order | None | **Ordered, and reorderable** |
+| Builds | No | Yes — one `.pfm` bundle |
+
+The cap on the deck is a fact about firmware, not about how many patterns
+somebody may like. The order is the point: the device cycles patterns with a
+long press on encoder 4, so a deck is a setlist, not a folder.
+
+Saving works on any pattern. Building does not — a pattern with no firmware
+header has nothing to compile, so promoting it is refused with the reason
+rather than sending an empty file to the compiler.
+
+---
+
+## Data and retention
+
+Written into the [terms](https://patternflow.work/terms), and enforced by a
+sweep the build worker runs daily (`npm run sweep`, or `-- --dry-run` to look
+first).
+
+| Data | Kept |
+| :--- | :--- |
+| Sessions (incl. IP and user-agent) | Until they expire, and at most **90 days** |
+| Verification tokens | Until they expire |
+| Build artifacts and build rows | **30 days** — they can always be rebuilt |
+| Unreferenced artifact files | Swept after a 24-hour grace window |
+| Reports | Kept after the reported content is gone |
+| Patterns, posts, comments | Until removed |
+
+Changing a retention period means changing the constant in
+`web/src/lib/community/retention.ts` **and** the terms. Both, or the terms stop
+being true.
+
+---
+
+## Tests
+
+Four suites, all runnable without a server:
+
+```bash
+cd web
+npm run check:license      # licence headers, fork compatibility, downloads
+npm run check:moderation   # admin env parsing, report input
+npm run check:retention    # the sweep, against a throwaway database
+npm run check:deck         # deck cap, ordering, legacy migration
+```
+
+They exist for the failures that are silent. A sweep that deletes too little
+makes the terms a lie; one that deletes too much destroys someone's work.
+Neither announces itself.
+
+---
+
+## Not built yet
+
+Listed because "is this missing or am I holding it wrong" deserves an answer.
+
+| | Status |
+| :--- | :--- |
+| **Pattern visibility (public / private)** | Not built. Everything published is public immediately. Tracked as an issue. |
+| **Shareable decks** | Not built. A deck lives in one browser and cannot be sent to anyone. Tracked as an issue. |
+| **Tags and search** | Not built. The feed sorts by new / most liked / most forked, and filters for hardware-ready. |
+| **Self-serve account deletion** | Not built. Requests go to the address in the terms and are handled by hand. Published patterns are anonymised rather than removed — the licence granted is irrevocable and others may have built on them. |
+| **Email of any kind** | Not sent, ever. No verification, no notifications, no password-reset mail. |
+| **Approval queue for new patterns** | Not built, and not currently wanted — moderation is after the fact. |
+| **Lineage tree view** | Not built. A fork links to its parent; there is no graph. |
+
+---
+
+Corrections and additions welcome — see [CONTRIBUTING.md](../CONTRIBUTING.md).

--- a/web/ARCHITECTURE.md
+++ b/web/ARCHITECTURE.md
@@ -15,6 +15,8 @@ The `web/` app is the Patternflow site at [patternflow.work](https://patternflow
 | `/roadmap` | Roadmap rendered from GitHub issues via `/api/roadmap` |
 | `/api/roadmap` | Server route that pulls open issues + sub-issue progress (10 min revalidate; optional `GITHUB_TOKEN` for rate limit) |
 | `/pattern-lab` | **Internal, noindex.** Pattern authoring/curation workspace: Monaco editor, preset library, BYOK Gemini generation, JS→C++ conversion prompt |
+| `/community/*` | The pattern community — feed, pattern pages, discussions, moderation queue. Only active where `COMMUNITY_ENABLED=1`; see [docs/COMMUNITY.md](../docs/COMMUNITY.md) |
+| `/terms` | Terms of use + privacy notice |
 | `/business` · `/contact` | Static pages |
 | `feed.xml` · `sitemap.ts` · `robots.ts` | Feeds and SEO plumbing |
 

--- a/web/drizzle/0008_add-comment-edited.sql
+++ b/web/drizzle/0008_add-comment-edited.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `comments` ADD `edited_at` integer;--> statement-breakpoint
+ALTER TABLE `post_comments` ADD `edited_at` integer;

--- a/web/drizzle/meta/0008_snapshot.json
+++ b/web/drizzle/meta/0008_snapshot.json
@@ -1,0 +1,1079 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "994083f5-5d6a-4a9e-8b7c-449c978bde6d",
+  "prevId": "24980b6b-d35d-4447-b78c-9e2d02da0033",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "builds": {
+      "name": "builds",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'queued'"
+        },
+        "format": {
+          "name": "format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'bin'"
+        },
+        "patterns": {
+          "name": "patterns",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "namespaces": {
+          "name": "namespaces",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "artifact": {
+          "name": "artifact",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "artifact_bytes": {
+          "name": "artifact_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "worker": {
+          "name": "worker",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "builds_status_created_idx": {
+          "name": "builds_status_created_idx",
+          "columns": [
+            "status",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "builds_user_id_idx": {
+          "name": "builds_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "builds_user_id_user_id_fk": {
+          "name": "builds_user_id_user_id_fk",
+          "tableFrom": "builds",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "comments": {
+      "name": "comments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pattern_id": {
+          "name": "pattern_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "edited_at": {
+          "name": "edited_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "comments_pattern_id_idx": {
+          "name": "comments_pattern_id_idx",
+          "columns": [
+            "pattern_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "comments_pattern_id_patterns_id_fk": {
+          "name": "comments_pattern_id_patterns_id_fk",
+          "tableFrom": "comments",
+          "tableTo": "patterns",
+          "columnsFrom": [
+            "pattern_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "comments_user_id_user_id_fk": {
+          "name": "comments_user_id_user_id_fk",
+          "tableFrom": "comments",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "likes": {
+      "name": "likes",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pattern_id": {
+          "name": "pattern_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "likes_pattern_id_idx": {
+          "name": "likes_pattern_id_idx",
+          "columns": [
+            "pattern_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "likes_user_id_user_id_fk": {
+          "name": "likes_user_id_user_id_fk",
+          "tableFrom": "likes",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "likes_pattern_id_patterns_id_fk": {
+          "name": "likes_pattern_id_patterns_id_fk",
+          "tableFrom": "likes",
+          "tableTo": "patterns",
+          "columnsFrom": [
+            "pattern_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "likes_user_id_pattern_id_pk": {
+          "columns": [
+            "user_id",
+            "pattern_id"
+          ],
+          "name": "likes_user_id_pattern_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "patterns": {
+      "name": "patterns",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code_cpp": {
+          "name": "code_cpp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "license": {
+          "name": "license",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'CC-BY-SA-4.0'"
+        },
+        "made_on": {
+          "name": "made_on",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "made_how": {
+          "name": "made_how",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "patterns_created_at_idx": {
+          "name": "patterns_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "patterns_user_id_idx": {
+          "name": "patterns_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "patterns_user_id_user_id_fk": {
+          "name": "patterns_user_id_user_id_fk",
+          "tableFrom": "patterns",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "patterns_parent_id_patterns_id_fk": {
+          "name": "patterns_parent_id_patterns_id_fk",
+          "tableFrom": "patterns",
+          "tableTo": "patterns",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "post_comments": {
+      "name": "post_comments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "edited_at": {
+          "name": "edited_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "post_comments_post_id_idx": {
+          "name": "post_comments_post_id_idx",
+          "columns": [
+            "post_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "post_comments_post_id_posts_id_fk": {
+          "name": "post_comments_post_id_posts_id_fk",
+          "tableFrom": "post_comments",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_comments_user_id_user_id_fk": {
+          "name": "post_comments_user_id_user_id_fk",
+          "tableFrom": "post_comments",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "posts": {
+      "name": "posts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "posts_created_at_idx": {
+          "name": "posts_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "posts_user_id_idx": {
+          "name": "posts_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "posts_user_id_user_id_fk": {
+          "name": "posts_user_id_user_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "reports": {
+      "name": "reports",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_title": {
+          "name": "target_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "target_user_id": {
+          "name": "target_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reporter_id": {
+          "name": "reporter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'open'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "reports_status_created_idx": {
+          "name": "reports_status_created_idx",
+          "columns": [
+            "status",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "reports_target_user_idx": {
+          "name": "reports_target_user_idx",
+          "columns": [
+            "target_user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "reports_reporter_id_user_id_fk": {
+          "name": "reports_reporter_id_user_id_fk",
+          "tableFrom": "reports",
+          "tableTo": "user",
+          "columnsFrom": [
+            "reporter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "display_username": {
+          "name": "display_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        },
+        "user_username_unique": {
+          "name": "user_username_unique",
+          "columns": [
+            "username"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/web/drizzle/meta/_journal.json
+++ b/web/drizzle/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1785320716351,
       "tag": "0007_add-made-how",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "6",
+      "when": 1785321984220,
+      "tag": "0008_add-comment-edited",
+      "breakpoints": true
     }
   ]
 }

--- a/web/src/app/api/community/comments/[id]/route.ts
+++ b/web/src/app/api/community/comments/[id]/route.ts
@@ -4,7 +4,9 @@ import { getAuth } from "@/lib/community/auth";
 import { originBlocked, preflight, withCors } from "@/lib/community/cors";
 import { communityEnabled, getDb } from "@/lib/community/db";
 import { getCommentStub } from "@/lib/community/queries";
+import { rateLimit } from "@/lib/community/ratelimit";
 import { comments, postComments } from "@/lib/community/schema";
+import { COMMENT_MAX, cleanComment } from "@/lib/community/validate";
 
 // DELETE /api/community/comments/[id]?on=pattern|post
 //
@@ -22,7 +24,71 @@ export async function DELETE(request: Request, context: { params: Promise<{ id: 
   return withCors(request, await handleDelete(request, context));
 }
 
+export async function PATCH(request: Request, context: { params: Promise<{ id: string }> }) {
+  const blocked = originBlocked(request);
+  if (blocked) return blocked;
+  return withCors(request, await handlePatch(request, context));
+}
+
 export const OPTIONS = preflight;
+
+// Editing is author-only, with no moderator override. Removing someone's
+// comment is moderation; rewriting one and leaving their name on it is putting
+// words in their mouth.
+async function handlePatch(request: Request, context: { params: Promise<{ id: string }> }) {
+  if (!communityEnabled()) {
+    return Response.json({ error: "Community is not enabled on this deployment." }, { status: 503 });
+  }
+
+  const session = await getAuth().api.getSession({ headers: request.headers });
+  if (!session) {
+    return Response.json({ error: "Sign in to edit a comment." }, { status: 401 });
+  }
+
+  if (!rateLimit(`comment-edit:${session.user.id}`, 20, 60_000)) {
+    return Response.json({ error: "Too many edits — wait a minute and try again." }, { status: 429 });
+  }
+
+  const on = new URL(request.url).searchParams.get("on");
+  if (on !== "pattern" && on !== "post") {
+    return Response.json({ error: "Unknown comment thread." }, { status: 400 });
+  }
+
+  const { id } = await context.params;
+  const comment = await getCommentStub(on, id);
+  if (!comment) {
+    return Response.json({ error: "Comment not found." }, { status: 404 });
+  }
+  if (comment.userId !== session.user.id) {
+    return Response.json({ error: "You can only edit your own comments." }, { status: 403 });
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return Response.json({ error: "Invalid JSON body." }, { status: 400 });
+  }
+
+  const next = cleanComment((body as Record<string, unknown>).body);
+  if (!next) {
+    return Response.json(
+      { error: `A comment cannot be empty, and must be under ${COMMENT_MAX} characters.` },
+      { status: 400 },
+    );
+  }
+
+  const table = on === "pattern" ? comments : postComments;
+  // `editedAt` is stamped so the thread shows the comment changed. Replies sit
+  // under it, and a comment that quietly becomes something else makes them read
+  // as answers to something never said.
+  await getDb()
+    .update(table)
+    .set({ body: next, editedAt: new Date() })
+    .where(eq(table.id, id));
+
+  return Response.json({ ok: true });
+}
 
 async function handleDelete(request: Request, context: { params: Promise<{ id: string }> }) {
   if (!communityEnabled()) {

--- a/web/src/app/community/discussions/[id]/page.tsx
+++ b/web/src/app/community/discussions/[id]/page.tsx
@@ -33,8 +33,10 @@ export default async function CommunityPostPage(props: RouteParams) {
   const session = await getAuth().api.getSession({ headers: await headers() });
   const comments: CommentView[] = (await listPostComments(post.id)).map((comment) => ({
     id: comment.id,
+    userId: comment.userId,
     body: comment.body,
     createdAt: comment.createdAt.toISOString(),
+    editedAt: comment.editedAt?.toISOString() ?? null,
     username: comment.username,
     displayUsername: comment.displayUsername,
   }));

--- a/web/src/app/community/p/[id]/page.tsx
+++ b/web/src/app/community/p/[id]/page.tsx
@@ -51,8 +51,10 @@ export default async function CommunityPatternPage(props: RouteParams) {
   const parent = pattern.parentId ? await getPatternStub(pattern.parentId) : null;
   const comments: CommentView[] = (await listComments(pattern.id)).map((comment) => ({
     id: comment.id,
+    userId: comment.userId,
     body: comment.body,
     createdAt: comment.createdAt.toISOString(),
+    editedAt: comment.editedAt?.toISOString() ?? null,
     username: comment.username,
     displayUsername: comment.displayUsername,
   }));

--- a/web/src/components/community/CommentSection.tsx
+++ b/web/src/components/community/CommentSection.tsx
@@ -18,8 +18,12 @@ import styles from "./Community.module.css";
 
 export type CommentView = {
   id: string;
+  /** Who wrote it — drives whether the edit/delete controls appear. */
+  userId: string;
   body: string;
   createdAt: string; // ISO
+  /** Set when the author rewrote it, so the thread can say so. */
+  editedAt: string | null;
   username: string | null;
   displayUsername: string | null;
 };
@@ -40,6 +44,68 @@ export default function CommentSection({
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
   const [authOpen, setAuthOpen] = useState(false);
+  // Which comment is open for editing, and the draft inside it.
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [draft, setDraft] = useState("");
+  const [rowBusy, setRowBusy] = useState<string | null>(null);
+  const [rowError, setRowError] = useState<string | null>(null);
+  // Deleting is one click away but takes two, because there is no undo and the
+  // button sits right beside "edit".
+  const [confirmDelete, setConfirmDelete] = useState<string | null>(null);
+
+  const viewerId = session?.user.id ?? null;
+  const on = target.kind === "post" ? "post" : "pattern";
+
+  const saveEdit = async (id: string) => {
+    const text = draft.trim();
+    if (text.length === 0) return;
+    setRowBusy(id);
+    setRowError(null);
+    try {
+      const response = await fetch(
+        communityApiUrl(`/api/community/comments/${id}?on=${on}`),
+        {
+          method: "PATCH",
+          ...COMMUNITY_FETCH_INIT,
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ body: text }),
+        },
+      );
+      if (!response.ok) {
+        const payload = (await response.json()) as { error?: string };
+        setRowError(payload.error ?? "Could not save the edit.");
+        return;
+      }
+      setEditingId(null);
+      router.refresh();
+    } catch {
+      setRowError("Network error.");
+    } finally {
+      setRowBusy(null);
+    }
+  };
+
+  const remove = async (id: string) => {
+    setRowBusy(id);
+    setRowError(null);
+    try {
+      const response = await fetch(
+        communityApiUrl(`/api/community/comments/${id}?on=${on}`),
+        { method: "DELETE", ...COMMUNITY_FETCH_INIT },
+      );
+      if (!response.ok) {
+        const payload = (await response.json()) as { error?: string };
+        setRowError(payload.error ?? "Could not delete the comment.");
+        return;
+      }
+      setConfirmDelete(null);
+      router.refresh();
+    } catch {
+      setRowError("Network error.");
+    } finally {
+      setRowBusy(null);
+    }
+  };
 
   const submit = async () => {
     const text = body.trim();
@@ -75,22 +141,92 @@ export default function CommentSection({
     <section className={styles.commentsBlock}>
       <h2 className={styles.commentsTitle}>Comments ({comments.length})</h2>
 
-      {comments.map((comment) => (
-        <div key={comment.id} className={styles.commentItem}>
-          <div className={styles.commentHead}>
-            <Link
-              href={`/community/u/${comment.username ?? ""}`}
-              className={styles.commentAuthor}
-            >
-              @{comment.displayUsername ?? comment.username ?? "unknown"}
-            </Link>
-            <span className={styles.commentDate}>{formatDate(comment.createdAt)}</span>
+      {comments.map((comment) => {
+        const mine = viewerId !== null && viewerId === comment.userId;
+        const editing = editingId === comment.id;
+        return (
+          <div key={comment.id} className={styles.commentItem}>
+            <div className={styles.commentHead}>
+              <Link
+                href={`/community/u/${comment.username ?? ""}`}
+                className={styles.commentAuthor}
+              >
+                @{comment.displayUsername ?? comment.username ?? "unknown"}
+              </Link>
+              <span className={styles.commentDate}>{formatDate(comment.createdAt)}</span>
+              {comment.editedAt && <span className={styles.commentEdited}>edited</span>}
+              {mine && !editing && (
+                <span className={styles.commentActions}>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setEditingId(comment.id);
+                      setDraft(comment.body);
+                      setRowError(null);
+                    }}
+                  >
+                    edit
+                  </button>
+                  <button
+                    type="button"
+                    disabled={rowBusy === comment.id}
+                    onClick={() => {
+                      if (confirmDelete === comment.id) void remove(comment.id);
+                      else {
+                        setConfirmDelete(comment.id);
+                        window.setTimeout(
+                          () => setConfirmDelete((current) => (current === comment.id ? null : current)),
+                          4000,
+                        );
+                      }
+                    }}
+                  >
+                    {confirmDelete === comment.id ? "press again" : "delete"}
+                  </button>
+                </span>
+              )}
+            </div>
+            {editing ? (
+              <div className={styles.commentForm}>
+                <textarea
+                  value={draft}
+                  maxLength={COMMENT_MAX}
+                  autoFocus
+                  onChange={(event) => setDraft(event.target.value)}
+                />
+                {rowError && <div className={styles.formError}>{rowError}</div>}
+                <div className={styles.commentEditRow}>
+                  <button
+                    type="button"
+                    className={styles.btnPrimary}
+                    disabled={rowBusy === comment.id || draft.trim().length === 0}
+                    onClick={() => void saveEdit(comment.id)}
+                  >
+                    {rowBusy === comment.id ? "Saving…" : "Save"}
+                  </button>
+                  <button
+                    type="button"
+                    className={styles.btn}
+                    onClick={() => {
+                      setEditingId(null);
+                      setRowError(null);
+                    }}
+                  >
+                    Cancel
+                  </button>
+                </div>
+              </div>
+            ) : (
+              <div className={styles.commentBody}>
+                <LinkedText text={comment.body} />
+              </div>
+            )}
+            {!editing && rowError && rowBusy === null && confirmDelete === comment.id && (
+              <div className={styles.formError}>{rowError}</div>
+            )}
           </div>
-          <div className={styles.commentBody}>
-            <LinkedText text={comment.body} />
-          </div>
-        </div>
-      ))}
+        );
+      })}
 
       {session ? (
         <div className={styles.commentForm}>

--- a/web/src/components/community/Community.module.css
+++ b/web/src/components/community/Community.module.css
@@ -2080,3 +2080,47 @@
   color: var(--pf-ink-faint);
   text-align: right;
 }
+
+/* ── Comment author controls ──
+   Sit in the head row beside the date, muted: available to the person who
+   wrote it, invisible to everyone else, and never louder than the comment. */
+.commentActions {
+  display: inline-flex;
+  gap: 8px;
+  margin-left: auto;
+}
+
+.commentActions button {
+  appearance: none;
+  border: 0;
+  padding: 0;
+  background: none;
+  font: inherit;
+  font-size: 11.5px;
+  color: var(--pf-ink-faint);
+  cursor: pointer;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.commentActions button:hover:not(:disabled) {
+  color: var(--pf-led);
+}
+
+.commentActions button:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+/* An edited comment says so. Replies sit under it, and one that quietly became
+   something else makes them read as answers to something never said. */
+.commentEdited {
+  font-size: 11px;
+  color: var(--pf-ink-faint);
+  font-style: italic;
+}
+
+.commentEditRow {
+  display: flex;
+  gap: 8px;
+}

--- a/web/src/lib/community/queries.ts
+++ b/web/src/lib/community/queries.ts
@@ -268,8 +268,10 @@ export async function listComments(patternId: string) {
   return db
     .select({
       id: comments.id,
+      userId: comments.userId,
       body: comments.body,
       createdAt: comments.createdAt,
+      editedAt: comments.editedAt,
       ...authorFields,
     })
     .from(comments)
@@ -383,8 +385,10 @@ export async function listPostComments(postId: string) {
   return getDb()
     .select({
       id: postComments.id,
+      userId: postComments.userId,
       body: postComments.body,
       createdAt: postComments.createdAt,
+      editedAt: postComments.editedAt,
       ...authorFields,
     })
     .from(postComments)

--- a/web/src/lib/community/schema.ts
+++ b/web/src/lib/community/schema.ts
@@ -187,6 +187,9 @@ export const postComments = sqliteTable(
       .references(() => user.id, { onDelete: "cascade" }),
     body: text("body").notNull(),
     createdAt: integer("created_at", { mode: "timestamp" }).notNull(),
+    /** Set when the author rewrites it. A comment that changes with no trace
+     *  makes the replies under it read as answers to something never said. */
+    editedAt: integer("edited_at", { mode: "timestamp" }),
   },
   (table) => [index("post_comments_post_id_idx").on(table.postId)],
 );
@@ -285,6 +288,8 @@ export const comments = sqliteTable(
       .references(() => user.id, { onDelete: "cascade" }),
     body: text("body").notNull(),
     createdAt: integer("created_at", { mode: "timestamp" }).notNull(),
+    /** Set when the author rewrites it — see postComments.editedAt. */
+    editedAt: integer("edited_at", { mode: "timestamp" }),
   },
   (table) => [index("comments_pattern_id_idx").on(table.patternId)],
 );


### PR DESCRIPTION
## What

**Comment editing and deleting.** The delete endpoint shipped in #254 with no button anywhere — it existed and could not be reached. So "report this comment" led nowhere, and an author could not take back their own words. Both controls now sit in the comment's head row, muted, visible only to whoever wrote it.

- Editing is **author-only, no moderator override** — matching patterns and posts. Taking something down is moderation; rewriting it while someone else's name stays on it is not.
- An edited comment **says so**. Replies sit underneath it, and one that quietly becomes something else makes them read as answers to something never said. (`edited_at` on both comment tables.)
- Deleting takes two presses — no undo, and the button is next to "edit".

**`docs/COMMUNITY.md`.** The community had no map at all; `web/ARCHITECTURE.md`'s route table predated it entirely. The new page covers where it runs, how patterns / licences / forks work, what moderators can and cannot do, the deck/saved split, retention, and the test suites.

It ends with **what is deliberately not built** — visibility, shareable decks, tags, self-serve account deletion, email of any kind — because that is the list people actually need. It also states plainly that two of the provenance signals (`@knobs`, `@matrix`) are emitted by the AI generation prompt itself and can be typed by hand, so nobody mistakes them for proof of authorship.

Linked from the README and ARCHITECTURE.

## Why

Both halves came from the same place: things that exist but can't be reached, and things that don't exist but look like they should.

## Tested

- `tsc --noEmit`, `npm run lint` (0 errors), `npm run build` — pass
- All four suites still pass: `check:license` (22) · `check:moderation` (26) · `check:retention` (18) · `check:deck` (27)
- Unauthenticated `PATCH` and `DELETE` on a comment both 401; an unknown `?on=` value is rejected
- Migration `0008_add-comment-edited` generated and applies

The buttons themselves need a signed-in account to see, which I can't do — worth a click-through after deploy.

## Follow-ups opened

- #255 — pattern visibility (public / unlisted / private)
- #256 — shareable decks

---
- [x] Touches `web/` → it builds (`npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
