### PR TITLE
Leave notes at the two knobs a conformance test would send you to

### DIFF
--- a/firmware/patternflow/net_config.h
+++ b/firmware/patternflow/net_config.h
@@ -32,6 +32,15 @@
 #ifndef PF_WIFI_PASS
 #define PF_WIFI_PASS "YOUR_WIFI_PASSWORD"
 #endif
+// ⚠️ If an RF conformance test fails on output power / EIRP:
+// nothing here sets the transmit power, so the radio runs at the ESP32
+// default of 19.5 dBm — the maximum. With the WROOM-1 antenna's gain that
+// can sit at or over the EU 20 dBm EIRP limit. The knob is
+// WiFi.setTxPower(WIFI_POWER_17dBm) in core_wifi.h after the join; ~17 dBm
+// buys margin for roughly a quarter of the range. Take the number from the
+// test report, not from a guess. (This is the RADIO test — for EMC, see the
+// note in core_display.h; Wi-Fi power is almost irrelevant there.)
+
 // Wi-Fi is non-blocking (see core_wifi.h): boot never waits for the join.
 // While disconnected, core_wifi.h re-issues WiFi.begin() at this interval
 // until it links up.

--- a/firmware/patternflow/src/core_display.h
+++ b/firmware/patternflow/src/core_display.h
@@ -25,6 +25,16 @@ inline void initDisplay() {
   // effective color depth (8-bit → 6–7 bit) to hit the target rate,
   // which can introduce mild banding in long smooth gradients. Dial
   // min_refresh_rate down to ~180 if banding is noticeable.
+  //
+  // ⚠️ If an EMC radiated-emissions test fails: this 15 MHz clock and its
+  // harmonics, streamed continuously down the HUB75 ribbon, are the loudest
+  // thing in the product — far louder than Wi-Fi, which is a separate test
+  // entirely. HZ_10M drops the fundamental and every harmonic with it.
+  // It is NOT free: at a lower clock the library either sheds bit-planes to
+  // hold 240 Hz (banding in the gradients these patterns are made of) or
+  // keeps the depth and lets refresh fall (camera banding returns on video).
+  // Try the cheap fixes first — ferrite on the ribbon, shorter ribbon,
+  // routing, grounding — and come here only if a pre-scan says to.
   mxconfig.i2sspeed         = HUB75_I2S_CFG::HZ_15M;
   mxconfig.min_refresh_rate = 240;
   mxconfig.latch_blanking   = 2;


### PR DESCRIPTION
Notes only — no behaviour change.

Compliance testing for a crowdfunding run is on the horizon, and these are the two places a failure would point at. Neither is obvious from the code, and they belong to **different tests** — which is the trap.

- **`net_config.h`** — nothing sets Wi-Fi TX power, so the radio runs at the ESP32 default of **19.5 dBm, the maximum**. With the WROOM-1 antenna's gain that can sit at or over the EU 20 dBm EIRP limit. The note names the API (`WiFi.setTxPower`) and warns that the number comes from a test report, not a guess.
- **`core_display.h`** — the 15 MHz pixel clock, streamed continuously down the HUB75 ribbon, is the loudest emitter in the product. `HZ_10M` drops the fundamental and every harmonic. The note spells out that it is *not* free: at a lower clock the library either sheds bit-planes to hold 240 Hz (banding in the gradients these patterns are made of) or keeps depth and lets refresh fall (camera banding returns on video). Ferrite, ribbon length, routing and grounding come first.

Each note points at the other, because the obvious mistake is reaching for Wi-Fi power when the failure is EMC — where it barely matters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)