### PR TITLE
fix(roadmap): date the project map from commits, not from when the journal was written

### DIFF
--- a/web/src/app/roadmap/RoadmapMap.tsx
+++ b/web/src/app/roadmap/RoadmapMap.tsx
@@ -1,13 +1,14 @@
 'use client';
 
 import Link from 'next/link';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState, useSyncExternalStore } from 'react';
 import styles from './Roadmap.module.css';
 import {
   EDGES,
   LANES,
   NODES,
   NOW,
+  todaySeoul,
   type LaneId,
   type RoadmapNode,
 } from './roadmap-data';
@@ -38,15 +39,43 @@ const ANCHORS: [number, number][] = [
   [Date.UTC(2026, 11, 1), 1.0],
 ];
 
-// No "Jul" tick — the today line sits right on it and marks July by itself.
-const TICKS: { label: string; labelKo: string; utc: number }[] = [
-  { label: 'Jan', labelKo: '1월', utc: Date.UTC(2026, 0, 1) },
-  { label: 'Feb', labelKo: '2월', utc: Date.UTC(2026, 1, 1) },
-  { label: 'Mar', labelKo: '3월', utc: Date.UTC(2026, 2, 1) },
-  { label: 'Apr', labelKo: '4월', utc: Date.UTC(2026, 3, 1) },
-  { label: 'May', labelKo: '5월', utc: Date.UTC(2026, 4, 1) },
-  { label: 'Jun', labelKo: '6월', utc: Date.UTC(2026, 5, 1) },
+const MONTHS: [string, string][] = [
+  ['Jan', '1월'],
+  ['Feb', '2월'],
+  ['Mar', '3월'],
+  ['Apr', '4월'],
+  ['May', '5월'],
+  ['Jun', '6월'],
+  ['Jul', '7월'],
+  ['Aug', '8월'],
+  ['Sep', '9월'],
+  ['Oct', '10월'],
+  ['Nov', '11월'],
+  ['Dec', '12월'],
 ];
+
+const isoDay = (utc: number) => new Date(utc).toISOString().slice(0, 10);
+
+// A month gets a tick once the today line has moved far enough past it that the
+// label and the line don't sit on top of each other — so the current month
+// still gets labelled late in the month, but not on the 2nd.
+const TICK_CLEARANCE = 0.03;
+
+function ticksFor(today: string): { label: string; labelKo: string; utc: number }[] {
+  const nowT = dateToT(today);
+  return MONTHS.map(([label, labelKo], i) => ({
+    label,
+    labelKo,
+    utc: Date.UTC(2026, i, 1),
+  })).filter((tick) => nowT - dateToT(isoDay(tick.utc)) >= TICK_CLEARANCE);
+}
+
+// The today line reads the real Seoul date on the client and the NOW fallback
+// on the server, so it tracks the calendar without a hydration mismatch. The
+// date only has to be read once per mount, hence the no-op subscribe; both
+// snapshots return plain strings, so Object.is keeps the value stable.
+const noopSubscribe = () => () => {};
+const serverToday = () => NOW;
 
 function dateToT(date: string): number {
   const ms = new Date(`${date}T00:00:00Z`).getTime();
@@ -113,7 +142,13 @@ function layoutNodes(detailed: boolean, lang: 'ko' | 'en', containerW: number): 
   });
   let maxRight = GUTTER + innerW + RIGHT_PAD;
   for (const lane of LANES) {
-    const row = placed.filter((n) => n.lane === lane.id).sort((a, b) => a.x - b.x);
+    // Order by date, not by left edge: nodes are centered on their date, so a
+    // wide box a couple of days later can start further left than a narrow one
+    // and get resolved into the wrong order — on a timeline that reads as the
+    // events having happened in the wrong sequence.
+    const row = placed
+      .filter((n) => n.lane === lane.id)
+      .sort((a, b) => (a.date < b.date ? -1 : a.date > b.date ? 1 : 0));
     for (let i = 1; i < row.length; i += 1) {
       const prev = row[i - 1];
       const current = row[i];
@@ -137,6 +172,7 @@ export default function RoadmapMap() {
   const [pan, setPan] = useState({ x: 0, y: 0 });
   const [zoom, setZoom] = useState(1);
   const [canvasSize, setCanvasSize] = useState({ w: 1200, h: 700 });
+  const today = useSyncExternalStore(noopSubscribe, todaySeoul, serverToday);
 
   const canvasRef = useRef<HTMLDivElement>(null);
   const dragRef = useRef({
@@ -182,10 +218,12 @@ export default function RoadmapMap() {
   const byId = useMemo(() => new Map(nodes.map((n) => [n.id, n])), [nodes]);
   const selected = selectedId ? byId.get(selectedId) ?? null : null;
 
-  const nowX = GUTTER + dateToT(NOW) * innerW;
+  const nowX = GUTTER + dateToT(today) * innerW;
+  const ticks = useMemo(() => ticksFor(today), [today]);
 
   // Start with "today" around the right third of the viewport so both the
   // recent past and the future zone are visible on load; center vertically.
+  // Re-runs once when the real date replaces the SSR fallback.
   useEffect(() => {
     const el = canvasRef.current;
     if (!el) return;
@@ -196,7 +234,7 @@ export default function RoadmapMap() {
       y: Math.round((ch - HEIGHT) / 2),
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [today]);
 
   const gate = useMemo(() => {
     const gateNodes = nodes.filter((n) => n.gate);
@@ -461,9 +499,9 @@ export default function RoadmapMap() {
             />
 
             {/* Infinite Seamless Vertical Month Ticks */}
-            {TICKS.map((tick) => {
+            {ticks.map((tick) => {
               const x =
-                GUTTER + dateToT(new Date(tick.utc).toISOString().slice(0, 10)) * innerW;
+                GUTTER + dateToT(isoDay(tick.utc)) * innerW;
               return (
                 <line
                   key={`grid-line-${tick.label}`}
@@ -608,9 +646,9 @@ export default function RoadmapMap() {
               {lang === 'ko' ? '계획' : 'future'}
             </text>
 
-            {TICKS.map((tick) => {
+            {ticks.map((tick) => {
               const x =
-                GUTTER + dateToT(new Date(tick.utc).toISOString().slice(0, 10)) * innerW;
+                GUTTER + dateToT(isoDay(tick.utc)) * innerW;
               return (
                 <text key={`tick-text-${tick.label}`} className={styles.tickText} x={x} y={stickyHeaderY} textAnchor="middle">
                   {lang === 'ko' ? tick.labelKo : tick.label}

--- a/web/src/app/roadmap/roadmap-data.ts
+++ b/web/src/app/roadmap/roadmap-data.ts
@@ -1,10 +1,14 @@
-// Data for the project map. Node dates are real commit/release dates for
+// Data for the project map. Node dates are real commit/release/journal dates for
 // shipped work; planned work is ordered by rough intention and rendered in a
 // single "future" region (no fake months). `level: 1` nodes show in the
 // overview; `level: 2` nodes only appear in the detailed view. `gate: true`
 // marks a node as part of the v3.0.0 build release — hardware + guides, the
 // things people physically build from. Software ships continuously and is
 // never gated.
+//
+// Sourcing rule: every claim here traces to CHANGELOG.md, a git commit, a
+// release note, or a journal entry. If a number or a cause can't be traced to
+// one of those, it doesn't go in the detail text.
 
 export type LaneId = 'pcb' | 'case' | 'guides' | 'firmware' | 'tools' | 'community' | 'media';
 
@@ -25,7 +29,22 @@ export type RoadmapNode = {
 
 export type RoadmapEdge = { from: string; to: string; note: string };
 
-export const NOW = '2026-07-26';
+// The "today" marker resolves at runtime. NOW is the SSR/first-paint fallback
+// (bump it when you like — it only decides where the line sits for the split
+// second before the client resolves the real date), and todaySeoul() is the
+// live value. Both are Asia/Seoul, so the line moves at midnight KST rather
+// than at whatever midnight the visitor's machine happens to be in.
+export const NOW = '2026-07-31';
+
+export function todaySeoul(): string {
+  // en-CA formats as YYYY-MM-DD.
+  return new Intl.DateTimeFormat('en-CA', {
+    timeZone: 'Asia/Seoul',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).format(new Date());
+}
 
 export const LANES: { id: LaneId; label: string; labelKo: string }[] = [
   { id: 'pcb', label: 'PCB', labelKo: 'PCB 회로' },
@@ -48,16 +67,14 @@ export const NODES: RoadmapNode[] = [
     title: 'First hardware prototype',
     titleKo: '첫 실물 프로토타입',
     status: 'done',
-    level: 2,
+    level: 1,
     detail:
-      'First hand-wired prototype built in the club room: HUB75 64x64 LED matrix + ESP32-S3 + 4 potentiometers wired on a breadboard, bringing Patternflow out of the web browser and into physical space at Mapo Saebit Cultural Forest.',
+      'Parts arrived on 29 March and went together the same day in the club room: a 128x64 P2.5 HUB75 panel, an ESP32-S3 and four potentiometers on a breadboard, held in place with a glue gun. No soldering, no enclosure — just the fastest possible route to seeing it run. The Patternflow: Origin shader was ported to the matrix that night and the first footage was shot in Mapo Saebit Cultural Forest. The reel landed flat, which is what made a case feel necessary.',
     detailKo:
-      '동아리방에서 만능기판과 핸드와이어링으로 조립한 첫 실물 프로토타입 (64x64 HUB75 LED 매트릭스 + ESP32-S3 + 4개 가변저항). 웹 브라우저 화면 속에 머물던 패턴플로우 알고리즘을 마포새빛문화숲 야외 공간으로 불러내어 직접 손으로 만지는 빛의 하드웨어로 실재화했습니다.',
+      '3월 29일 부품이 도착한 그날 바로 동아리방에서 올린 첫 실물 프로토타입입니다. 128x64 P2.5 HUB75 패널에 ESP32-S3와 가변저항 4개를 빵판에 꽂고 글루건으로 고정한 물건이었습니다. 납땜도 인클로저도 없는, 작동하는 모습을 가장 빨리 보기 위한 구성이었습니다. 그날 밤 패턴플로우:오리진의 셰이더를 매트릭스용으로 옮겨 올렸고, 보조배터리를 들고 마포새빛문화숲에 나가 첫 영상을 찍었습니다. 반응이 거의 없었고, 그래서 케이스가 필요하다는 결론에 도달합니다.',
     links: [
       { label: 'Instagram Reel (LED & Knobs)', href: 'https://www.instagram.com/p/DWi9wc6gkS0/' },
-      { label: 'Reddit Prototype Post', href: 'https://www.reddit.com/r/arduino/comments/1so9er5/built_a_4knob_generative_pattern_controller_with/' },
       { label: 'Journal (v1 in 30 days)', href: 'https://patternflow.work/journal/v1-30-days' },
-      { label: 'hardware/pcb (v1.0.0)', href: `${REPO}/tree/v1.0.0/hardware/pcb` },
     ],
   },
   {
@@ -69,29 +86,29 @@ export const NODES: RoadmapNode[] = [
     status: 'done',
     level: 1,
     detail:
-      'First public hardware release: KiCad 10.0 schematics, production Gerber files, and a 2-layer hand-solderable ESP32-S3 + HUB75 driver PCB layout with 2.54mm pitch pin headers. Every subsequent board revision descends from this initial floorplan.',
+      'First public hardware release: a KiCad schematic and board drawn over a single weekend by someone who could not read a schematic two days earlier, fabricated free of charge under the PCBWay sponsorship. Through-hole headers plus 0805 SMD passives, ESP32-S3 + HUB75, four EC11 encoders. Every later revision descends from this floorplan.',
     detailKo:
-      '첫 공개 오픈소스 하드웨어 릴리스: KiCad 10.0 회로도, Gerber 파일 및 손납땜이 용이한 2.54mm 핀헤더 방식의 2레이어 ESP32-S3 + HUB75 드라이버 보드. 이후 제작된 모든 보드 개선안의 베이스가 되는 원형 레이아웃입니다.',
+      '첫 공개 오픈소스 하드웨어 릴리스입니다. 이틀 전까지 회로도조차 읽지 못하던 사람이 주말 2일을 통째로 갈아넣어 그린 KiCad 회로도와 아트워크이고, PCBWay 스폰서십으로 무료 제작되었습니다. 스루홀 핀헤더에 0805 SMD 수동소자가 함께 올라간 ESP32-S3 + HUB75 보드이며, EC11 로터리 엔코더 4개를 사용합니다. 이후의 모든 개선안이 이 레이아웃에서 갈라져 나왔습니다.',
     links: [
-      { label: 'KiCad Gerber (v1.0.0)', href: `${REPO}/tree/v1.0.0/hardware/pcb` },
-      { label: 'Journal (Me and Patternflow)', href: 'https://patternflow.work/journal/me-and-patternflow' },
+      { label: 'hardware/pcb (v1.0.0)', href: `${REPO}/tree/v1.0.0/hardware/pcb` },
+      { label: 'Journal (v1 in 30 days)', href: 'https://patternflow.work/journal/v1-30-days' },
     ],
   },
   {
     id: 'pcb-v2',
     lane: 'pcb',
-    date: '2026-05-08',
-    title: 'v2 fixes',
-    titleKo: 'v2 버그 수정',
+    date: '2026-05-07',
+    title: 'v2 cold-boot fix',
+    titleKo: 'v2 콜드부트 수정',
     status: 'done',
     level: 2,
     detail:
-      'GPIO0 boot pull-up resistor fix (Issue #16) preventing random ESP32 bootloops during cold start, along with silkscreen corrections for rotary encoder A/B/SW pin mappings based directly on early DIY community builder feedback.',
+      'The cold-boot failure that shipped with v1 — the board needed a reset press after every power-up — was tracked to a floating GPIO0 strapping pin and fixed with a 10k pull-up (R13), together with silkscreen fixes for the R/C designators and the encoder back-side marking. Contributed as PR #48 by @idranoutof1d, after u/Infrated diagnosed it on r/AskElectronics. Shipped in v2.0.0 on 11 May.',
     detailKo:
-      '초기 DIY 빌더들의 피드백을 바탕으로 부팅 시 무작위 부트룹 현상을 방지하는 GPIO0 풀업 저항 회로 보정(Issue #16) 및 로터리 엔코더 A/B/SW 핀 실크스크린 인쇄 오류 수정.',
+      'v1의 고질병이던 콜드부트 실패 — 전원을 넣을 때마다 리셋 버튼을 눌러야 켜지던 문제 — 의 원인이 GPIO0 스트래핑 핀 플로팅으로 밝혀져 10k 풀업 저항(R13)으로 해결되었습니다. R/C 지시자와 엔코더 뒷면 표기 실크스크린도 함께 정리했습니다. r/AskElectronics의 u/Infrated가 원인을 짚어주었고, @idranoutof1d가 PR #48로 직접 고쳐 보냈습니다. 5월 11일 v2.0.0에 포함되어 배포되었습니다.',
     issues: [16],
     links: [
-      { label: 'Issue #16 (GPIO0 fix)', href: `${REPO}/issues/16` },
+      { label: 'Issue #16 (cold boot)', href: `${REPO}/issues/16` },
       { label: 'Journal (wins and losses)', href: 'https://patternflow.work/journal/wins-and-losses-next-step' },
     ],
   },
@@ -100,13 +117,13 @@ export const NODES: RoadmapNode[] = [
     lane: 'pcb',
     date: '2026-06-18',
     title: 'v2.1 routing',
-    titleKo: 'v2.1 배선 리라우팅',
+    titleKo: 'v2.1 배선 정리',
     status: 'done',
     level: 2,
     detail:
-      'Reworked high-speed ESP32-to-HUB75 trace routing to minimize 20MHz DMA refresh clock EMI line noise and cleaned silkscreen labels. These remain the baseline recommended gerbers for manual hand-assembly, pinned in BUILD_GUIDE.md.',
+      'The tangled ESP32-to-J1 (HUB75) area was re-routed in both schematic and board, with pin assignments left untouched so firmware config.h did not move. A silkscreen pass four days earlier had already disambiguated the R9/R10/C14/C15 labels. These stayed the recommended Gerbers for the whole v2.x line, pinned by the build guide and by the v2.1.0 consolidation release.',
     detailKo:
-      '20MHz DMA 주사 클럭에서 발생하는 고주파 EMI 신호 노이즈를 최적화하기 위해 ESP32-HUB75 배선을 리라우팅하고 실크스크린을 픽셀 단위로 정돈. 현재 수동 납땜 빌더용 기준 Gerber로 BUILD_GUIDE.md에 지정되어 있습니다.',
+      '엉켜 있던 ESP32-J1(HUB75) 구간 배선을 회로도와 보드 양쪽에서 다시 정리했습니다. 핀 할당은 그대로 두어 펌웨어 config.h는 손대지 않아도 되게 했습니다. 나흘 앞선 실크스크린 작업에서 R9/R10/C14/C15 표기 혼동도 이미 정리해 둔 상태였습니다. 이 거버가 v2.x 라인 전체의 권장 보드가 되었고, 빌드 가이드와 v2.1.0 통합 릴리스가 이 버전을 기준으로 고정했습니다.',
     links: [
       { label: 'Gerbers (v2.1.0)', href: `${REPO}/tree/v2.1.0/hardware/pcb` },
       { label: 'BUILD_GUIDE.md (v2.1.0)', href: `${REPO}/blob/v2.1.0/BUILD_GUIDE.md` },
@@ -116,33 +133,34 @@ export const NODES: RoadmapNode[] = [
     id: 'pcb-v22',
     lane: 'pcb',
     date: '2026-06-28',
-    title: 'v2.2 USB-C test',
-    titleKo: 'v2.2 USB-C 테스트',
-    status: 'done',
-    level: 1,
-    detail:
-      'Test board moving power input from 2-pin terminal to USB-C 5V 3A, eliminating all SMD components in favor of 100% Through-Hole (THT) passives. Ordered via PCBWay Gerber sponsorship to validate DIY assembly convenience.',
-    detailKo:
-      '전원 입력을 USB-C(5V 3A)로 변경하고 SMD 소자를 완전히 제거한 100% 스루홀(THT) 테스트 보드 (PCBWay Gerber 스폰서십 제작). 납땜 난이도를 대폭 낮추고 일반 USB PD 충전기와의 호환성을 검증했습니다.',
-    links: [{ label: 'Journal (make it easy to build)', href: 'https://patternflow.work/journal/make-it-easy-to-build' }],
-  },
-  {
-    id: 'pcb-usbc-safety',
-    lane: 'pcb',
-    date: '2026-07-20',
-    title: 'USB-C power on hold & review',
-    titleKo: 'USB-C 전원 재검토 (보류)',
+    title: 'v2.2 USB-C · SMD-free',
+    titleKo: 'v2.2 USB-C · SMD 제거',
     status: 'done',
     level: 2,
     detail:
-      'USB-C power input placed on hold under active re-evaluation (Issue #221): investigating delayed connector pin thermal burnout (20–30 min run under 3A full LED matrix load). DIY builds pinned safely to 2-pin 5.08mm screw terminal (J4).',
+      'Power input moved from the 2-pin terminal to USB-C, and every SMD passive was deleted — the two 5.1k CC pull-downs are hand-soldered, so the whole board can be built with a basic iron. The SMD parts turned out to be unnecessary: a Discord builder pointed out the encoder caps and resistors could come off, and the board ran fine without them. DRC clean but never fabricated as v2.2 — it was absorbed into the v3.0 test board a week later.',
     detailKo:
-      '64x64 매트릭스 최고 밝기(3A 수용) 구동 시 20~30분 후 발생하는 USB-C 핀 지연 탄화/열 손상 원인을 파악하기 위해 USB-C 입력을 보류 및 전면 재검토 (Issue #221). DIY 빌더 안정성을 위해 전원은 2핀 스크류 터미널(J4)로 보정 사용.',
-    issues: [221],
+      '전원 입력을 2핀 터미널에서 USB-C로 옮기고 SMD 수동소자를 전부 제거했습니다. 남은 5.1k CC 풀다운 2개는 손납땜이라, 보드 전체를 일반 인두 하나로 만들 수 있게 되었습니다. SMD가 애초에 필요 없었다는 사실은 디스코드의 한 빌더가 엔코더 캡과 저항을 떼도 괜찮다고 알려준 데서 확인되었습니다. DRC는 통과했지만 v2.2로 제작되지는 않았고, 일주일 뒤 v3.0 테스트 보드로 흡수됩니다.',
+    issues: [114],
     links: [
-      { label: 'Issue #221', href: `${REPO}/issues/221` },
-      { label: 'BUILD_GUIDE.md section 10', href: `${REPO}/blob/main/BUILD_GUIDE.md#10-known-issues` },
+      { label: 'Issue #114', href: `${REPO}/issues/114` },
+      { label: 'Journal (refocus)', href: 'https://patternflow.work/journal/refocus' },
     ],
+  },
+  {
+    id: 'pcb-v3-test',
+    lane: 'pcb',
+    date: '2026-07-07',
+    title: 'v3.0 test board',
+    titleKo: 'v3.0 테스트 보드',
+    status: 'done',
+    level: 2,
+    detail:
+      'The v3.0 test Gerber: hybrid power input — USB-C plus a back-side 2-pin screw terminal as the beginner bypass — all through-hole, DRC clean, shipped in hardware/pcb/gerber/experiment/ under a "do not order, unverified" warning. Boards were ordered on 11 July and came back verified on 17 July.',
+    detailKo:
+      'v3.0 테스트 거버입니다. USB-C와 뒷면 2핀 스크류 터미널을 함께 둔 하이브리드 전원 입력에 100% 스루홀 구성, DRC 클린 상태로 hardware/pcb/gerber/experiment/ 아래에 "미검증, 주문하지 말 것" 경고와 함께 올라갔습니다. 7월 11일에 실제 보드를 주문했고, 17일에 검증 완료로 돌아왔습니다.',
+    issues: [114],
+    links: [{ label: 'Issue #114', href: `${REPO}/issues/114` }],
   },
   {
     id: 'pcb-v3',
@@ -154,16 +172,50 @@ export const NODES: RoadmapNode[] = [
     level: 1,
     gate: true,
     detail:
-      'v3.0.0 production hardware release: reorganized module floorplan, reduced PCB trace area to drop manufacturing costs by 18%, added dual power footprint (Screw terminal + USB-C safety circuit) and official silkscreen "PATTERNFLOW v1.0".',
+      'v3.0.0 production board: fabricated, assembled and verified. Hybrid power input (USB-C footprint plus the J4 screw terminal), zero SMD passives — every part you solder is through-hole — a smaller board with the modules rearranged to cut production cost, and a machine-readable BOM listing every part by manufacturer part number. Not size-compatible with v2.x cases, and vice versa.',
     detailKo:
-      'v3.0.0 양산형 하드웨어 릴리스: 모듈 배치 개편, PCB 면적 축소를 통한 단가 18% 절감, 스크류 터미널과 안전회로가 포함된 USB-C 듀얼 전원 풋프린트 지원 및 공식 "PATTERNFLOW v1.0" 실크스크린 적용.',
+      'v3.0.0 양산형 보드입니다. 실제로 제작·조립·검증까지 마쳤습니다. USB-C 풋프린트와 J4 스크류 터미널을 함께 둔 하이브리드 전원 입력, SMD 수동소자 0개(납땜하는 부품이 전부 스루홀), 모듈 배치를 다시 잡고 전체 크기를 줄여 생산 단가를 낮춘 구성, 그리고 모든 부품을 제조사 부품번호로 명시한 기계 판독용 BOM이 함께 배포되었습니다. v2.x 케이스와는 크기가 호환되지 않습니다.',
+    issues: [114],
     links: [
       { label: 'hardware/pcb (v3.0.0)', href: `${REPO}/tree/v3.0.0/hardware/pcb` },
+      { label: 'bom_v3.0.csv', href: `${REPO}/blob/v3.0.0/hardware/bom/bom_v3.0.csv` },
       { label: 'Journal (v3 and beyond)', href: 'https://patternflow.work/journal/v3-and-beyond' },
+    ],
+  },
+  {
+    id: 'pcb-usbc-safety',
+    lane: 'pcb',
+    date: '2026-07-26',
+    title: 'USB-C power withdrawn',
+    titleKo: 'USB-C 전원 사용 중단',
+    status: 'done',
+    level: 2,
+    detail:
+      'A USB-C-powered board ran fine for 20–30+ minutes and then smoked at a connector pin, destroying the receptacle and the power path (Issue #221). The input was withdrawn from service in v3.1.0, not merely paused: leave USB1/R1/R2 unpopulated and power the board through the J4 screw terminal until a redesign passes. The guide, the assembly map and the v3.0.0 release notes all carry the hold.',
+    detailKo:
+      'USB-C로 전원을 넣은 보드가 20~30분 이상 정상 동작하다가 커넥터 핀에서 연기가 나며 리셉터클과 전원 경로가 파손되었습니다(Issue #221). v3.1.0에서 "보류"가 아니라 사용 중단 조치를 내렸습니다. 재설계가 검증될 때까지 USB1/R1/R2는 비워 두고 J4 스크류 터미널로만 전원을 넣어야 합니다. 빌드 가이드, 조립 맵, v3.0.0 릴리스 노트에 모두 이 경고가 반영되어 있습니다.',
+    issues: [221],
+    links: [
+      { label: 'Issue #221', href: `${REPO}/issues/221` },
+      { label: 'BUILD_GUIDE.md §2', href: `${REPO}/blob/main/BUILD_GUIDE.md#2-power-input--use-the-screw-terminal` },
     ],
   },
 
   // Enclosure
+  {
+    id: 'case-proto',
+    lane: 'case',
+    date: '2026-04-05',
+    title: 'First enclosure prototype',
+    titleKo: '첫 인클로저 프로토타입',
+    status: 'done',
+    level: 2,
+    detail:
+      'The breadboard came apart and the parts went into a printed case, wired by hand — the first version that reads as an object rather than a pile of components, and the first soldering of the project (done wrong, in the wrong order, at the cost of a great many cold joints). Hung in the club-room corridor on 5 April for a reel that went nowhere. Reprinted in plain white and shot on a desk instead: 10,000 views in two days.',
+    detailKo:
+      '빵판을 걷어내고 부품을 출력한 케이스에 넣어 손으로 배선한 버전입니다. 부품 더미가 아니라 하나의 물건으로 보이는 첫 프로토타입이자, 이 프로젝트의 첫 납땜이기도 합니다. 방법을 알아보지도 않고 순서를 거꾸로 해서 냉납과 접촉불량을 잔뜩 얻었습니다. 4월 5일 동아리방 복도에 걸어 릴스를 찍었지만 반응은 없었습니다. 케이스를 흰색으로 통일해 다시 뽑고 집 책상에 두고 찍은 영상이 이틀 만에 조회수 1만을 넘겼습니다.',
+    links: [{ label: 'Journal (v1 in 30 days)', href: 'https://patternflow.work/journal/v1-30-days' }],
+  },
   {
     id: 'case-v1',
     lane: 'case',
@@ -173,11 +225,11 @@ export const NODES: RoadmapNode[] = [
     status: 'done',
     level: 1,
     detail:
-      'The original 3D-printable enclosure released with v1.0: fully modeled Blender design (hardware/case/source/patternflow_case.blend) with print-ready STLs, 4-part breakdown, and slicer settings. Ancestor of all case variations.',
+      'The original 3D-printable enclosure released with v1.0: modeled in Blender around one rule — no wasted space, no decoration, thin enough not to look like a computer is hiding behind it, with an internal bay for the power bank so no cable shows. Three prints total. Printing it flat warped every time; standing it upright solved it after three days of failed beds.',
     detailKo:
-      'v1.0과 함께 공개된 3D 프린팅 전용 인클로저. Blender 4.1 원본 모델 파일과 슬라이서 서포트 설정이 완료된 4분할 STL 파일 제공. 이후 개발된 모든 스냅핏 및 레이저 커팅 케이스의 모태가 되는 모델입니다.',
+      'v1.0과 함께 공개된 3D 프린팅 인클로저입니다. 낭비되는 공간과 장식을 없애고, 뒤에 컴퓨터가 숨어 있는 것처럼 보이지 않도록 최대한 얇게, 선이 보이지 않도록 보조배터리 수납 공간을 안에 두는 것을 원칙으로 블렌더에서 모델링했습니다. 총 3개 파츠를 출력합니다. 눕혀서 뽑으면 매번 모서리가 말려 올라가 3일을 헤맸고, 세워서 출력하니 해결되었습니다.',
     links: [
-      { label: 'Instagram Reel (Viral Case Prototype)', href: 'https://www.instagram.com/p/DW6hZPsAlRj/' },
+      { label: 'Instagram Reel (case prototype)', href: 'https://www.instagram.com/p/DW6hZPsAlRj/' },
       { label: 'hardware/case (v1.0.0)', href: `${REPO}/tree/v1.0.0/hardware/case` },
     ],
   },
@@ -186,28 +238,28 @@ export const NODES: RoadmapNode[] = [
     lane: 'case',
     date: '2026-05-26',
     title: 'Laser-cut acrylic (on hold)',
-    titleKo: '레이저 커팅 아크릴 (실패/재검토)',
+    titleKo: '레이저 커팅 아크릴 (보류)',
     status: 'done',
     level: 2,
     detail:
-      'Initial 3mm laser-cut acrylic plate experiment: mechanical fit and tab joint tolerances failed during physical assembly testing, placing acrylic cases on hold for future redesign.',
+      'Laser-cut acrylic, tried with 0.1mm kerf compensation. The first cut got the tabs and slots into each other but was not a usable case — panel relief depth and the bezel edge both needed work. The revision drawn to fix them came out wrong, and with wood as the next material after that (different material loss, a scorch margin to find), the acrylic path was put on hold rather than iterated further. The v1 Blender/SVG cut source is committed so the work is not lost; no shipped build uses it.',
     detailKo:
-      '3mm 아크릴 레이저 커팅 조립 실험. 파츠 간 결합부 유격 공차 및 인장 강도 부족으로 실물 조립에 실패하여 개발 보류. 향후 보강 구조 재설계 예정.',
-    links: [{ label: 'hardware/case/source (v2.0.0)', href: `${REPO}/tree/v2.0.0/hardware/case/source` }],
+      '0.1mm 커프 보정을 잡고 진행한 레이저 커팅 아크릴 실험입니다. 첫 컷은 탭과 슬롯이 물리기는 했지만 쓸 수 있는 케이스는 아니었습니다. 패널 릴리프 깊이와 베젤 엣지 모두 손봐야 했습니다. 그걸 보완하려고 다시 그린 버전은 잘못 만들어졌고, 그다음 재료로 보던 목재는 재료 손실량도 다르고 그을음 여유도 새로 찾아야 하는 상황이라, 계속 반복하는 대신 아크릴 경로를 보류했습니다. 작업이 사라지지 않도록 v1 블렌더/SVG 컷 소스는 저장소에 커밋해 두었습니다. 현재 배포되는 빌드는 모두 3D 프린팅입니다.',
+    links: [{ label: 'hardware/case/source (v2.1.0)', href: `${REPO}/tree/v2.1.0/hardware/case/source` }],
   },
   {
     id: 'case-exp',
     lane: 'case',
-    date: '2026-06-04',
+    date: '2026-06-05',
     title: 'Print experiments',
     titleKo: '인클로저 출력 실험',
     status: 'done',
     level: 2,
     detail:
-      'Month-long 3D printing tolerance experiments sponsored by PCBWay 3D printing service: test prints for alignment tabs, one-shot print ribs, easybond joints, and wall-hangers to achieve support-free printing.',
+      'Six weeks of enclosure print iteration: two flat print variants, then thicker walls, outer fillets and small snap-pins as an anti-warp pass. Tests ran on a P1S in the club room and on the university makerspace H2S through a professor — a slow loop, since each large-format attempt meant sending the file, waiting, and driving over to see it fail. PCBWay also printed one test set under the sponsorship; it came back mediocre.',
     detailKo:
-      'PCBWay 3D 프린팅 스폰서십을 기반으로 한 한 달간의 정밀 출력 실험. 서포트(보조 구조물) 제거 시 발생하는 표면 손상을 없애기 위해 alignment tab, snap-fit 조인트, 일체형 갈고리 구조 등을 다각도로 검증.',
-    links: [{ label: 'Journal (make it easy to build)', href: 'https://patternflow.work/journal/make-it-easy-to-build' }],
+      '6주에 걸친 인클로저 출력 반복입니다. 평면 출력 변형 두 가지를 시작으로, 워핑을 잡기 위해 벽 두께를 올리고 외곽 필렛과 작은 스냅핀을 더했습니다. 테스트는 동아리방의 P1S와 교수님을 통해 쓰는 학교 메이커스페이스의 H2S에서 진행했는데, 대형 출력은 파일을 보내고 기다렸다가 직접 가서 실패를 확인하는 느린 루프였습니다. PCBWay 스폰서십으로 한 세트를 출력해 보기도 했지만 결과물은 그리 좋지 않았습니다.',
+    links: [{ label: 'Journal (refocus)', href: 'https://patternflow.work/journal/refocus' }],
   },
   {
     id: 'case-snapfit',
@@ -218,9 +270,9 @@ export const NODES: RoadmapNode[] = [
     status: 'done',
     level: 1,
     detail:
-      'Zero-support one-piece snap-fit enclosure (Issue #113) graduated to print-ready status for 330mm print beds. Eliminates screws in favor of snap-in mechanical locking tabs.',
+      'The one-piece snap-fit enclosure (Issue #113) was promoted to a supported print option: a single-piece body plus a snap-fit closing part, no gluing, with a wall-mount hanger hole. Needs a ~330mm bed (H2S-class); stable print confirmed.',
     detailKo:
-      '별도의 나사 조임 없이 파츠끼리 딱 맞춰 맞물리는 0-서포트 일체형 스냅핏 케이스 (Issue #113). 330mm 대형 프린터 베드에서 단 한 번의 출력으로 조립이 완료되는 기계적 락킹 구조 구현.',
+      '일체형 스냅핏 인클로저(Issue #113)가 정식 지원 출력 옵션으로 승격되었습니다. 본체 한 덩어리에 스냅핏 마감 파츠를 끼우는 구조로, 접착 없이 조립되며 벽걸이용 구멍이 포함됩니다. ~330mm 베드(H2S급)가 필요하고, 안정적인 출력까지 확인했습니다.',
     issues: [113],
     links: [{ label: 'Issue #113', href: `${REPO}/issues/113` }],
   },
@@ -234,12 +286,13 @@ export const NODES: RoadmapNode[] = [
     level: 1,
     gate: true,
     detail:
-      'v3.0.0 snap-fit enclosure release: reinforced mechanical clips, updated internal PCB standoff tolerances, and revised power port cutouts matching the v3.0.0 hardware board footprint for the Crowd Supply launch.',
+      'v3.0.0 enclosure, reorganized by printer bed size: bed_256mm/encloser.stl prints the body, back panels and panel mount as one ~10h STL, bed_330mm/ keeps the one-piece snap-fit. Knobs print separately in black. Adds a snap-fit back panel, two wall-mount holes, and recesses for the LED panel alignment bumps — retiring the nipper-trimming step that had been there since v1.0 (Issue #19). Also listed on MakerWorld with tuned print profiles.',
     detailKo:
-      'v3.0.0 전용 인클로저: 스냅핏 조인트 결합력 강화, PCB 서포트 유격 공차 0.15mm 미세 조정 및 v3.0.0 듀얼 전원 포트 위치에 맞춘 크라우드 서플라이 펀딩용 일체형 케이스.',
+      'v3.0.0 인클로저는 프린터 베드 크기 기준으로 폴더가 정리되었습니다. bed_256mm/encloser.stl은 본체·후면 패널·LED 패널 마운트를 하나로 묶어 약 10시간에 출력하고, bed_330mm/에는 일체형 스냅핏이 남아 있습니다. 노브는 검정으로 따로 출력합니다. 스냅핏 후면 패널, 벽걸이 구멍 2개, LED 패널 정렬 돌기를 받아주는 홈이 추가되어 v1.0부터 따라다니던 니퍼 다듬기 단계가 사라졌습니다(Issue #19). 메이커월드에도 출력 프로파일과 함께 등록했습니다.',
+    issues: [19, 169],
     links: [
       { label: 'hardware/case (v3.0.0)', href: `${REPO}/tree/v3.0.0/hardware/case` },
-      { label: 'BUILD_GUIDE.md (v3.0.0)', href: `${REPO}/blob/v3.0.0/BUILD_GUIDE.md` },
+      { label: 'MakerWorld listing', href: 'https://makerworld.com/ko/models/3072492-patternflow-open-source-led-synthesizer-case' },
     ],
   },
 
@@ -253,11 +306,11 @@ export const NODES: RoadmapNode[] = [
     status: 'done',
     level: 1,
     detail:
-      'Initial release of BUILD_GUIDE.md: complete Bill of Materials (BOM), component sourcing links (LCSC/AliExpress), step-by-step soldering instructions, and initial firmware upload via Web Serial.',
+      'First release of docs/BUILD.md: bill of materials, AliExpress sourcing links for every electronic part, assembly walkthrough, pin reference and firmware upload via the Arduino IDE. Drafted by handing the whole build experience to an AI and letting it write the structure — which is exactly why the next two months are mostly rewrites.',
     detailKo:
-      'BUILD_GUIDE.md 첫 릴리스: 상세 BOM(부품명세서), 해외 구매 링크(LCSC/AliExpress), 납땜 순서 가이드, 핀 배치표 및 웹 시리얼 기반 펌웨어 플래싱 안내 수록.',
+      'docs/BUILD.md 첫 릴리스입니다. BOM, 모든 전자부품의 알리익스프레스 구매 링크, 조립 순서, 핀 배치표, 아두이노 IDE 펌웨어 업로드 안내가 들어갔습니다. 빌드 경험을 통째로 AI에 넘겨 정리시킨 초안이었고, 이후 두 달이 대부분 이 문서를 다시 쓰는 작업이 된 이유이기도 합니다.',
     links: [
-      { label: 'BUILD_GUIDE.md (v1.0.0)', href: `${REPO}/blob/v1.0.0/docs/BUILD.md` },
+      { label: 'docs/BUILD.md (v1.0.0)', href: `${REPO}/blob/v1.0.0/docs/BUILD.md` },
       { label: 'Journal (v1 in 30 days)', href: 'https://patternflow.work/journal/v1-30-days' },
     ],
   },
@@ -270,10 +323,24 @@ export const NODES: RoadmapNode[] = [
     status: 'done',
     level: 2,
     detail:
-      'Comprehensive guide rewrite: replaced text descriptions with high-resolution macro photography and video loops for every soldering step, encoder mounting, and matrix pin connection.',
+      'A weekend of guide rewrites: build photos and video stills added for the soldering steps, encoder mounting and case bonding, the firmware section reworked, a pin reference added, and the encoder shaft spec corrected. Author-written this time, replacing the AI-drafted structure.',
     detailKo:
-      '모든 납땜 단계, 로터리 엔코더 체결, LED 매트릭스 와이어링 과정마다 고화질 실물 조립 사진과 루프 영상을 첨부하여 가이드를 대대적으로 개편.',
-    links: [{ label: 'BUILD_GUIDE.md (v1.1.0)', href: `${REPO}/blob/v1.1.0/docs/BUILD.md` }],
+      '주말 내내 가이드를 다시 썼습니다. 납땜 단계, 엔코더 체결, 케이스 접합 과정에 실물 사진과 영상 스틸을 붙이고, 펌웨어 섹션을 재작성하고, 핀 레퍼런스를 추가하고, 엔코더 샤프트 규격 표기를 바로잡았습니다. AI가 잡아둔 초안 구조를 제작자가 직접 쓴 글로 교체한 작업입니다.',
+    links: [{ label: 'docs/BUILD.md (v2.0.0)', href: `${REPO}/blob/v2.0.0/docs/BUILD.md` }],
+  },
+  {
+    id: 'guide-pattern',
+    lane: 'guides',
+    date: '2026-05-11',
+    title: 'Pattern authoring guide',
+    titleKo: '패턴 제작 가이드',
+    status: 'done',
+    level: 2,
+    detail:
+      'firmware/CUSTOM_PATTERNS.md: the 5-step path from a plain-language description to a pattern running on the panel — copy the creation prompt, ask any code-capable model, paste into the Live Editor, tune the knobs, convert to C++. A hand-written route is documented alongside it for anyone comfortable with shader-style code. It has been extended twice since: browser build & flash, then loadable modules.',
+    detailKo:
+      'firmware/CUSTOM_PATTERNS.md 문서입니다. 말로 설명한 패턴을 실제 패널에서 돌아가게 만드는 5단계 경로 — 생성 프롬프트 복사, 아무 코드 생성 모델에 붙여넣기, 라이브 에디터에 붙여넣기, 노브 튜닝, C++ 변환 — 를 안내합니다. 셰이더 스타일 코드가 익숙한 사람을 위한 직접 작성 경로도 함께 정리되어 있습니다. 이후 브라우저 빌드/플래싱, 로더블 모듈이 추가되며 두 차례 확장되었습니다.',
+    links: [{ label: 'firmware/CUSTOM_PATTERNS.md', href: `${REPO}/blob/main/firmware/CUSTOM_PATTERNS.md` }],
   },
   {
     id: 'guide-breadboard',
@@ -284,9 +351,9 @@ export const NODES: RoadmapNode[] = [
     status: 'done',
     level: 2,
     detail:
-      'A non-soldering breadboard assembly path (/build/breadboard): complete pin jumper diagram allowing makers to test Patternflow graphics on a 64x64 matrix without ordering custom PCBs.',
+      'A no-soldering, no-PCB assembly path (/build/breadboard): a full jumper diagram that gets Patternflow running on a breadboard, so anyone can try the hardware before ordering a board. The experiment was run first and worked, then documented.',
     detailKo:
-      '납땜이나 PCB 주문 없이 브레드보드(빵판)와 점퍼 와이어만으로 패턴플로우 하드웨어를 구동해볼 수 있는 무납땜 입문 가이드 (/build/breadboard).',
+      '납땜도 PCB 주문도 없이 만들어 보는 경로입니다(/build/breadboard). 빵판과 점퍼선만으로 패턴플로우를 구동하는 전체 배선도를 제공해, 보드를 주문하기 전에 하드웨어를 먼저 경험할 수 있게 했습니다. 실험을 먼저 해서 작동을 확인한 뒤 문서로 정리했습니다.',
     links: [{ label: 'Breadboard Guide', href: 'https://patternflow.work/build/breadboard' }],
   },
   {
@@ -298,9 +365,9 @@ export const NODES: RoadmapNode[] = [
     status: 'done',
     level: 2,
     detail:
-      'BOM conversion to 100% Through-Hole (THT) components, dropping all SMD surface-mount passives to allow easy assembly with basic soldering irons.',
+      'The BOM was rewritten as all-through-hole — the 0805 SMD passives are gone, so a basic soldering iron is enough — and PCB orders were pinned to the v2.1 Gerbers, with a heads-up about the v3.0 board coming. The guide had moved to the repo root as BUILD_GUIDE.md two weeks earlier.',
     detailKo:
-      'SMD 칩 소자를 완전히 배제하고 100% 스루홀(THT) 다리와 저항으로 BOM을 개편하여 일반 가용 핑거 인체공학 인쇄기 및 초보용 인디키 납땜기로도 수월하게 완성 가능하도록 개선.',
+      'BOM을 100% 스루홀로 다시 썼습니다. 0805 SMD 수동소자가 사라져 일반 인두 하나면 조립이 가능해졌습니다. PCB 주문은 v2.1 거버로 고정했고, 곧 나올 v3.0 보드에 대한 안내도 함께 넣었습니다. 가이드 자체는 2주 앞서 저장소 루트의 BUILD_GUIDE.md로 옮겨진 상태였습니다.',
     links: [{ label: 'BUILD_GUIDE.md (v2.1.0)', href: `${REPO}/blob/v2.1.0/BUILD_GUIDE.md` }],
   },
   {
@@ -313,25 +380,32 @@ export const NODES: RoadmapNode[] = [
     level: 1,
     gate: true,
     detail:
-      'Complete BUILD_GUIDE.md rewrite for v3.0.0 hardware and snap-fit case: updated BOM, assembly photos, troubleshooting section, and safety guidelines for power wiring.',
+      'BUILD_GUIDE.md rewritten for the v3.0 board and snap-fit case, with two full video walkthroughs — PCB soldering, and assembly through first power-on — photo-documented print/case/wiring steps, a netlist-derived pin reference, and a dedicated OSC/Ableton build path. The v2 guide lives on as BUILD_GUIDE_v2.md for existing builds.',
     detailKo:
-      'v3.0.0 하드웨어 보드 및 스냅핏 인클로저에 맞춰 개정된 BUILD_GUIDE.md 정식 출간. 최신 BOM 명세, 단계별 조립 가이드 및 전원 안전 수칙 수록.',
-    links: [{ label: 'BUILD_GUIDE.md (v3.0.0)', href: `${REPO}/blob/v3.0.0/BUILD_GUIDE.md` }],
+      'v3.0 보드와 스냅핏 케이스에 맞춰 BUILD_GUIDE.md를 새로 썼습니다. PCB 납땜과 조립~첫 전원 인가까지 각각 전체 영상 워크스루가 붙었고, 출력·케이스·배선 단계는 사진으로 기록했으며, 넷리스트에서 뽑아낸 핀 레퍼런스와 OSC/에이블톤 빌드 경로가 별도로 들어갔습니다. 기존 v2 빌더를 위해 v2 가이드는 BUILD_GUIDE_v2.md로 남겨두었습니다.',
+    links: [
+      { label: 'BUILD_GUIDE.md (v3.0.0)', href: `${REPO}/blob/v3.0.0/BUILD_GUIDE.md` },
+      { label: 'Video — PCB soldering', href: 'https://youtu.be/NZCjMBCsDAc' },
+      { label: 'Video — assembly to first power-on', href: 'https://youtu.be/J9C9bZgkNKs' },
+    ],
   },
   {
-    id: 'guide-pattern',
+    id: 'guide-panel',
     lane: 'guides',
-    date: '2026-08-28',
-    title: 'Pattern guide',
-    titleKo: '패턴 제작 가이드',
-    status: 'planned',
-    level: 1,
-    gate: true,
+    date: '2026-07-30',
+    title: 'Panel compatibility guide',
+    titleKo: 'LED 패널 호환성 가이드',
+    status: 'done',
+    level: 2,
     detail:
-      'Comprehensive pattern development guide (firmware/CUSTOM_PATTERNS.md): covering PFCanvas drawing APIs, color palette ramps, noise functions, and transferring web presets to device firmware.',
+      'A panel matching the spec line for line can still stay completely black, because HUB75E is a connector and not a protocol — the driver IC decides. And the driver IC is essentially never in the listing. The guide leads with what actually works (read buyer reviews for anyone running it off an ESP32, then ask the seller), with a verified-panel table and a symptom-to-cause table. Opened up by @SimonePDA, who hit the failure and researched it properly.',
     detailKo:
-      '패턴 개발자를 위한 공식 C++ 패턴 제작 가이드 (firmware/CUSTOM_PATTERNS.md). PFCanvas 드라이버, 컬러 램프, Simplex Noise 함수 사용법 및 웹 스튜디오 알고리즘의 C++ 포팅 가이드.',
-    links: [{ label: 'firmware/CUSTOM_PATTERNS.md', href: `${REPO}/blob/main/firmware/CUSTOM_PATTERNS.md` }],
+      '스펙이 한 줄도 틀리지 않는 패널을 사도 화면이 완전히 까맣게 나올 수 있습니다. HUB75E는 프로토콜이 아니라 커넥터일 뿐이고, 실제로는 드라이버 IC가 결정하기 때문입니다. 그런데 드라이버 IC는 판매 페이지에 거의 적혀 있지 않습니다. 그래서 실제로 통하는 방법 — ESP32로 구동한 구매자 후기 찾아보기, 그다음 판매자에게 직접 물어보기 — 을 앞세우고, 검증된 패널 표와 증상-원인 대조표를 함께 실었습니다. 직접 이 문제를 겪고 제대로 조사해 준 @SimonePDA가 열어준 문서입니다.',
+    issues: [259],
+    links: [
+      { label: 'docs/panel-compatibility.md', href: `${REPO}/blob/main/docs/panel-compatibility.md` },
+      { label: 'Issue #259', href: `${REPO}/issues/259` },
+    ],
   },
 
   // Firmware
@@ -344,23 +418,51 @@ export const NODES: RoadmapNode[] = [
     status: 'done',
     level: 1,
     detail:
-      'Initial open-source Arduino sketch (firmware/patternflow/patternflow.ino): hardcoded pattern functions, pin mappings in config.h, and browser flashing via Web Serial.',
+      'The initial open-source Arduino sketch (firmware/patternflow_v1/patternflow_v1.ino): HUB75 DMA driver, the default pattern set, and hardware configuration extracted into config.h. Flashing was still Arduino IDE only.',
     detailKo:
-      '초기 오픈소스 아두이노 스케치 (firmware/patternflow/patternflow.ino). config.h 핀 매핑 구조 설정 및 웹 시리얼(ESP Web Tools) 브라우저 플래싱 지원.',
+      '첫 오픈소스 아두이노 스케치입니다(firmware/patternflow_v1/patternflow_v1.ino). HUB75 DMA 드라이버와 기본 패턴 세트가 들어 있고, 하드웨어 설정은 config.h로 분리했습니다. 이 시점에는 아두이노 IDE로만 업로드할 수 있었습니다.',
     links: [{ label: 'firmware/patternflow_v1 (v1.0.0)', href: `${REPO}/tree/v1.0.0/firmware/patternflow_v1` }],
+  },
+  {
+    id: 'fw-v11',
+    lane: 'firmware',
+    date: '2026-04-27',
+    title: 'v1.1 · browser flasher',
+    titleKo: 'v1.1 · 웹 플래셔',
+    status: 'done',
+    level: 1,
+    detail:
+      'v1.1.0, one day after v1.0.0: patterns modularized into pattern_*.h files behind a central registry, a shared InputFrame for normalized encoder and button state, a long-press pattern-selection UI, and Wave Saw added. The web flasher shipped with it — one prebuilt "PatternFlow OS" image, flashed from the browser, so nobody else has to configure the Arduino IDE. The first step of the platform.',
+    detailKo:
+      'v1.0.0 하루 뒤에 나온 v1.1.0입니다. 패턴을 pattern_*.h 파일로 모듈화해 중앙 레지스트리에 등록하고, 엔코더·버튼 상태를 정규화해 공유하는 InputFrame을 도입하고, 롱프레스 패턴 선택 UI와 Wave Saw 패턴을 추가했습니다. 웹 플래셔도 이때 함께 나왔습니다. 미리 컴파일해 둔 "PatternFlow OS" 이미지 하나를 브라우저에서 바로 올릴 수 있게 해서, 다른 사람은 아두이노 IDE를 설정하지 않아도 되게 만든 플랫폼 영역의 첫걸음입니다.',
+    links: [{ label: 'Flash from the browser', href: 'https://patternflow.work' }],
+  },
+  {
+    id: 'fw-v2',
+    lane: 'firmware',
+    date: '2026-05-11',
+    title: 'v2.0.0 release',
+    titleKo: 'v2.0.0 릴리스',
+    status: 'done',
+    level: 2,
+    detail:
+      'v2.0.0 unified the versioning: project, firmware, PCB and case became one Patternflow version instead of four. It carried the GPIO0 cold-boot fix, the custom-pattern workflow doc, canonical pattern names (Origin, Wave Saw), and a web platform that was by then substantially complete — flasher, Live Editor, journal and build map.',
+    detailKo:
+      'v2.0.0에서 버전 체계를 하나로 통일했습니다. 프로젝트·펌웨어·PCB·케이스가 각자 버전을 갖는 대신 하나의 패턴플로우 버전으로 묶였습니다. GPIO0 콜드부트 수정, 커스텀 패턴 제작 문서, 패턴 이름 정규화(Origin, Wave Saw)가 들어갔고, 이 시점의 웹(플래셔, 라이브 에디터, 저널, 빌드 맵)은 이미 상당 부분 완성된 상태였습니다.',
+    links: [{ label: 'CHANGELOG (2.0.0)', href: `${REPO}/blob/main/CHANGELOG.md` }],
   },
   {
     id: 'fw-foundation',
     lane: 'firmware',
     date: '2026-05-21',
-    title: 'ESP32 optimization',
-    titleKo: 'ESP32 펌웨어 대개편',
+    title: 'Graphics foundation',
+    titleKo: '그래픽 파이프라인 개편',
     status: 'done',
     level: 1,
     detail:
-      'Core graphics pipeline overhaul: PFCanvas drawing abstraction, shared core_math / core_color / core_noise helpers, 2.2 gamma LUT, 240Hz DMA refresh rate eliminating camera shutter flicker, and encoder velocity acceleration.',
+      'The rendering pipeline was rebuilt from under the patterns: they now draw through a PFCanvas abstraction instead of touching the HUB75 driver, on top of shared core_math / core_color / core_noise libraries. A 2.2 gamma LUT applied in present(), per-channel white balance, and refresh raised to ~240Hz to kill the banding phone cameras were picking up. (Encoder acceleration also landed here; it was removed again in the July knob rework.)',
     detailKo:
-      'ESP32-S3 그래픽 렌더링 파이프라인 전면 개편: PFCanvas abstraction 계층, core_math / core_color / core_noise 헬퍼, 2.2 감마 보정 LUT, 스마트폰 카메라 플리커를 없애는 ~240Hz DMA 주사율 및 로터리 엔코더 속도 가속 알고리즘.',
+      '패턴 밑단의 렌더링 파이프라인을 다시 만들었습니다. 패턴이 HUB75 드라이버를 직접 건드리지 않고 PFCanvas 추상화를 통해 그리도록 바꾸고, core_math / core_color / core_noise 공용 라이브러리를 깔았습니다. present()에서 2.2 감마 LUT를 적용하고, 채널별 화이트 밸런스를 잡고, 주사율을 ~240Hz로 올려 휴대폰 카메라에 잡히던 줄무늬를 없앴습니다. (엔코더 가속도 이때 들어갔지만, 7월 노브 개편에서 다시 제거되었습니다.)',
     links: [{ label: 'Journal (faster-faster)', href: 'https://patternflow.work/journal/faster-faster' }],
   },
   {
@@ -372,24 +474,23 @@ export const NODES: RoadmapNode[] = [
     status: 'done',
     level: 2,
     detail:
-      'Bi-directional Open Sound Control (OSC) protocol (docs/osc-spec.md), ArduinoOTA wireless firmware flashing over Wi-Fi, and real-time audio-react DSP FFT spectrum analysis integration.',
+      'Three wireless capabilities within a week: two-way OSC reworked from a content mode into a sidechannel accepting knob, pattern and content commands (21 May); ArduinoOTA flashing over Wi-Fi with the Arduino IDE 2.x workaround documented (26 May); and the audio-react foundation — a WebSocket server routing browser audio analysis through virtual knobs (27 May).',
     detailKo:
-      '양방향 OSC 프로토콜 (docs/osc-spec.md), 무선 Wi-Fi OTA(Over-The-Air) 펌웨어 업데이트 및 실시간 오디오 반응(Audio-reactive) FFT 주파수 분석 연동.',
-    links: [{ label: 'docs/osc-spec.md', href: `${REPO}/blob/main/docs/osc-spec.md` }],
+      '일주일 사이에 무선 기능 세 가지가 들어왔습니다. 양방향 OSC를 콘텐츠 모드가 아닌 사이드채널로 재설계해 노브·패턴·콘텐츠 명령을 받게 했고(5월 21일), Wi-Fi를 통한 ArduinoOTA 플래싱과 아두이노 IDE 2.x 우회 방법을 문서화했으며(5월 26일), 브라우저의 오디오 분석 결과를 가상 노브로 흘려보내는 WebSocket 오디오 리액트 기반을 만들었습니다(5월 27일).',
   },
   {
-    id: 'fw-v2',
+    id: 'fw-presets',
     lane: 'firmware',
     date: '2026-06-22',
-    title: 'v2.0.0 presets',
-    titleKo: 'v2.0.0 프리셋 시스템',
+    title: 'Preset & custom slots',
+    titleKo: '프리셋 · 커스텀 슬롯',
     status: 'done',
     level: 1,
     detail:
-      'v2.0.0 firmware release: modular pattern registry (pattern_registry.h), curated presets (preset_origin.h, preset_wave_saw.h), and user custom slots (custom1.h~custom3.h) under CC-BY-SA 4.0 license.',
+      'The pattern system split in two: a curated preset library, and reusable custom slots a builder can overwrite without touching the presets — with a custom-first registry so your own patterns come up first (Origin stays pattern 1). Licensing metadata was baked into each pattern header (patterns are CC-BY-SA-4.0, inbound = outbound) and the video content mode was dropped. Shipped in v2.1.0.',
     detailKo:
-      'v2.0.0 펌웨어 정식 릴리스: 모듈형 패턴 레지스트리(pattern_registry.h), 큐레이션 프리셋 헤더 및 유저 커스텀 패턴 슬롯(custom1.h~custom3.h) 구축 (CC-BY-SA 4.0 라이선스).',
-    links: [{ label: 'firmware/patternflow (v2.0.0)', href: `${REPO}/tree/v2.0.0/firmware/patternflow` }],
+      '패턴 시스템이 둘로 갈라졌습니다. 큐레이션된 프리셋 라이브러리와, 프리셋을 건드리지 않고 덮어쓸 수 있는 재사용 커스텀 슬롯입니다. 레지스트리는 커스텀 우선으로 두어 자기가 만든 패턴이 먼저 나오게 했습니다(Origin은 1번 유지). 각 패턴 헤더에 라이선스 메타데이터를 넣었고(패턴은 CC-BY-SA-4.0, inbound = outbound), 비디오 콘텐츠 모드는 제거했습니다. v2.1.0에 포함되었습니다.',
+    links: [{ label: 'firmware/patternflow (v2.1.0)', href: `${REPO}/tree/v2.1.0/firmware/patternflow` }],
   },
   {
     id: 'fw-improv',
@@ -400,9 +501,9 @@ export const NODES: RoadmapNode[] = [
     status: 'done',
     level: 2,
     detail:
-      'Improv-Serial Wi-Fi provisioning protocol integration: credentials are set directly over Web Serial during browser flashing without requiring hardcoded Wi-Fi passwords.',
+      'Improv-Serial Wi-Fi provisioning: credentials are entered in the browser during flashing and sent over Web Serial, so no Wi-Fi password ever gets hardcoded into a sketch or committed by accident.',
     detailKo:
-      'Improv-Serial Wi-Fi 프로비저닝 프로토콜 연동. 브라우저 플래싱 중 웹 시리얼 연결을 통해 Wi-Fi SSID/PW를 안전하게 전송 및 설정.',
+      'Improv-Serial Wi-Fi 프로비저닝입니다. 플래싱 중에 브라우저에서 Wi-Fi 정보를 입력하면 웹 시리얼로 전달됩니다. 스케치에 비밀번호를 하드코딩하거나 실수로 커밋할 일이 없어졌습니다.',
   },
   {
     id: 'fw-ableton',
@@ -413,28 +514,64 @@ export const NODES: RoadmapNode[] = [
     status: 'done',
     level: 2,
     detail:
-      'Ableton Live Max for Live bridge (integrations/ableton/): bi-directional OSC control allowing Ableton MIDI & synth parameters to drive Patternflow knobs and pattern switching in real-time.',
+      'A Max for Live bridge device (integrations/ableton/) maps the four hardware knobs to any Live parameter over OSC — relative encoder deltas, per-slot sweep sensitivity, mappings saved with the Live set. The OSC wire protocol was written up as docs/osc-spec.md at the same time, as a versioned contract third-party integrations can build against.',
     detailKo:
-      'Max for Live 기반 Ableton Live 연동 브릿지 (integrations/ableton/). 음악 트랙의 MIDI/신디사이저 파라미터가 패턴플로우의 4개 엔코더 및 노이즈 속도를 양방향 OSC로 직접 드라이브.',
-    links: [{ label: 'integrations/ableton', href: `${REPO}/tree/main/integrations/ableton` }],
+      'Max for Live 브릿지 디바이스(integrations/ableton/)가 하드웨어 노브 4개를 OSC로 라이브의 아무 파라미터에나 연결합니다. 상대 엔코더 델타, 슬롯별 스윕 감도, 라이브 세트와 함께 저장되는 매핑을 지원합니다. 이때 OSC 와이어 프로토콜을 docs/osc-spec.md로 정리해, 서드파티 연동이 기댈 수 있는 버전 관리되는 규약으로 만들었습니다.',
+    links: [
+      { label: 'integrations/ableton', href: `${REPO}/tree/main/integrations/ableton` },
+      { label: 'docs/osc-spec.md', href: `${REPO}/blob/main/docs/osc-spec.md` },
+    ],
   },
   {
     id: 'fw-browser-build',
     lane: 'firmware',
     date: '2026-07-25',
-    title: 'Browser firmware worker',
-    titleKo: '웹 브라우저 펌웨어 빌더',
+    title: 'Browser firmware builds',
+    titleKo: '웹 브라우저 펌웨어 빌드',
     status: 'done',
     level: 1,
     detail:
-      'In-browser C++ compilation pipeline & Web Serial flasher (PR #230, #231): compile custom C++ patterns directly in the browser via build worker and flash to ESP32-S3 over Web Serial without local Arduino IDE setup.',
+      'A build queue and worker compile a complete firmware image containing your pattern in about 30 seconds, and the browser flashes it over Web Serial — no IDE, no board package, no registry editing (#230, with OSC enabled by default per #231). Finished builds can also hand off to the device\'s own update page, so after the first USB flash new patterns go over Wi-Fi (#232). Shipped in v3.1.0.',
     detailKo:
-      '웹 브라우저 C++ 컴파일 파이프라인 및 Web Serial 플래셔 (PR #230, #231). 로컬 아두이노 IDE 설치 없이 웹 스튜디오에서 작성한 패턴 코드를 클라우드 빌드 워커로 C++ 바이너리 컴파일 후 USB 직렬 플래싱.',
-    issues: [230, 231],
+      '빌드 큐와 워커가 내 패턴이 들어간 완전한 펌웨어 이미지를 30초 남짓에 컴파일하고, 브라우저가 웹 시리얼로 바로 플래싱합니다. IDE 설치도, 보드 패키지도, 레지스트리 수정도 필요 없습니다(#230, OSC 기본 활성화는 #231). 완성된 빌드를 기기의 업데이트 페이지로 넘길 수도 있어, 첫 USB 플래싱 이후에는 Wi-Fi로 패턴을 보낼 수 있습니다(#232). v3.1.0에 포함되었습니다.',
+    issues: [230, 231, 232],
     links: [
       { label: 'Issue #230', href: `${REPO}/issues/230` },
-      { label: 'Issue #231', href: `${REPO}/issues/231` },
+      { label: 'Issue #232', href: `${REPO}/issues/232` },
     ],
+  },
+  {
+    id: 'fw-modules',
+    lane: 'firmware',
+    date: '2026-07-28',
+    title: 'Loadable pattern modules',
+    titleKo: '로더블 패턴 모듈 (.pfm)',
+    status: 'done',
+    level: 1,
+    detail:
+      'v3.2.0: patterns stop needing a firmware build. A pattern compiles to a relocatable Xtensa ELF of a few KB, goes to the device over Wi-Fi and appears in the list immediately — no reflash, no reboot, no 1MB image for a 6KB pattern. Up to 128 modules install, switching costs 6–11ms, and the device gets its own pattern manager at /patterns. Design and the working proof of concept came from Simone Majocchi (@SimonePDA): a frozen C ABI, a linker script collapsing each module to four sections, and an on-device relocator.',
+    detailKo:
+      'v3.2.0에서 패턴에 더 이상 펌웨어 빌드가 필요 없어졌습니다. 패턴은 몇 KB짜리 재배치 가능한 Xtensa ELF로 컴파일되어 Wi-Fi로 기기에 전송되고 곧바로 목록에 나타납니다. 다시 플래싱할 필요도, 재부팅할 필요도, 6KB 패턴 하나 때문에 1MB 이미지를 올릴 필요도 없습니다. 최대 128개까지 설치할 수 있고 패턴 전환은 6~11ms이며, 기기에는 /patterns 패턴 관리자가 생겼습니다. 설계와 실제로 동작하는 PoC는 Simone Majocchi(@SimonePDA)가 가져왔습니다. 호스트-모듈 간 고정 C ABI, 모듈을 4개 섹션으로 압축하는 링커 스크립트, 그리고 기기 내 재배치기입니다.',
+    issues: [232, 242],
+    links: [
+      { label: 'PR #242', href: `${REPO}/pull/242` },
+      { label: 'Journal (community)', href: 'https://patternflow.work/journal/community' },
+    ],
+  },
+  {
+    id: 'fw-knobs',
+    lane: 'firmware',
+    date: '2026-07-31',
+    title: 'Knob & render tuning',
+    titleKo: '노브 · 렌더 튜닝',
+    status: 'done',
+    level: 2,
+    detail:
+      'Encoder acceleration removed — one detent, one step. A fast spin used to multiply each detent x2 to x5; measured against a linear build with four curves live at once, linear won outright. Knob travel now derives from the parameter\'s range instead of a fixed constant, the quadrature decoder stopped resyncing onto physically impossible bounced states, and ENCODER_CLICKS_PER_TURN was corrected from 20 to the reference encoder\'s 24. Alongside it: the frame is painted in one call instead of 8,192, and the color calibration became runtime-switchable.',
+    detailKo:
+      '엔코더 가속을 제거했습니다. 이제 한 딸깍에 한 스텝입니다. 빠르게 돌리면 딸깍당 2~5배로 곱해지던 방식이었는데, 네 가지 커브를 동시에 띄워두고 선형 빌드와 비교한 결과 선형이 완승했습니다. 노브 이동량도 고정 상수 대신 파라미터의 실제 범위에서 계산하도록 바꿨고, 물리적으로 불가능한 바운스 상태에 디코더가 동기화되던 버그를 잡았으며, ENCODER_CLICKS_PER_TURN을 기준 엔코더의 실제 값인 24로 고쳤습니다(기존 20). 함께: 프레임을 8,192번이 아니라 한 번의 호출로 그리도록 바꾸고, 색 보정을 런타임에 켜고 끌 수 있게 했습니다.',
+    issues: [262],
+    links: [{ label: 'PR #262', href: `${REPO}/pull/262` }],
   },
   {
     id: 'fw-resolution',
@@ -445,38 +582,65 @@ export const NODES: RoadmapNode[] = [
     status: 'planned',
     level: 1,
     detail:
-      'Resolution-agnostic rendering engine: dynamic matrix dimensions allowing Patternflow firmware to render seamlessly on any HUB75 LED panel configuration (64x32, 128x64, commercial LED signs).',
+      'A pattern already declares the matrix it was composed for (// @matrix), and that travels through Pattern Lab, the community sandbox and the C++ conversion. The firmware is the part still pinned to one panel: the goal is a resolution-agnostic render path so the same pattern runs on 64x32, 128x64 or a commercial LED sign without being rewritten.',
     detailKo:
-      '해상도 비의존적 렌더링 엔진: 64x64 보드뿐만 아니라 상용 128x64, 64x32 전광판 등 모든 HUB75 LED 패널 규격에 맞춰 패턴 좌표계를 동적으로 스케일링하는 범용 엔진.',
+      '패턴은 이미 자기가 어떤 매트릭스를 위해 만들어졌는지 선언하고(// @matrix), 그 정보는 패턴랩·커뮤니티 샌드박스·C++ 변환까지 그대로 따라갑니다. 아직 한 가지 패널에 묶여 있는 쪽은 펌웨어입니다. 같은 패턴을 다시 쓰지 않고 64x32, 128x64, 상용 전광판 어디서든 돌릴 수 있도록 해상도에 의존하지 않는 렌더 경로를 만드는 것이 목표입니다.',
   },
 
   // Pattern tools
   {
     id: 'tools-origin',
     lane: 'tools',
-    date: '2026-01-11',
+    date: '2026-01-03',
     title: 'Patternflow origin',
     titleKo: '패턴플로우 오리진',
     status: 'done',
     level: 1,
     detail:
-      'The original node-based generative art website (origin.patternflow.work), created months before hardware existed — featuring 3D relief shaders, URL preset sharing, and real-time canvas modulation.',
+      'It started with a mistake. Playing with Blender geometry and shader nodes, a parameter got pushed to an extreme and the pattern that came out was worth keeping. Patternflow: Origin (origin.patternflow.work) was built around it months before any hardware existed — an interactive web piece with 3D relief shaders and shareable URL presets, made with an exhibition and 3D-printed objects in mind.',
     detailKo:
-      '하드웨어 제작 몇 달 전 탄생한 원형 노드 기반 제너러티브 아트 웹사이트 (origin.patternflow.work). 3D 릴리프 셰이더, URL 프리셋 공유, 제너레이티브 파동 캔버스 등 프로젝트 알고리즘의 원형이 담겨 있습니다.',
+      '실수에서 시작했습니다. 오랜만에 블렌더의 지오메트리 노드와 셰이더 노드를 만지다가 파라미터를 극단으로 올려버렸고, 거기서 나온 시각 패턴에 매료되어 그대로 붙잡았습니다. 하드웨어가 생기기 몇 달 전에 그 패턴을 중심으로 만든 인터랙티브 웹 작업이 패턴플로우:오리진(origin.patternflow.work)입니다. 3D 릴리프 셰이더와 URL 프리셋 공유를 갖췄고, 처음부터 전시와 3D 프린팅 오브제를 염두에 두고 만들었습니다.',
     links: [{ label: 'origin.patternflow.work', href: 'https://origin.patternflow.work/' }],
+  },
+  {
+    id: 'tools-origin-studio',
+    lane: 'tools',
+    date: '2026-01-11',
+    title: 'Node-based studio',
+    titleKo: '노드 기반 스튜디오',
+    status: 'done',
+    level: 2,
+    detail:
+      'A node editor added to Origin: patterns get composed by wiring nodes rather than editing parameters, with a preset system, curator mode, dynamic resolution and per-preset parameter ranges layered on over the following two weeks.',
+    detailKo:
+      '오리진에 노드 에디터가 붙었습니다. 파라미터를 조정하는 대신 노드를 연결해 패턴을 구성하는 방식이고, 이후 2주에 걸쳐 프리셋 시스템, 큐레이터 모드, 동적 해상도, 프리셋별 파라미터 범위가 차례로 얹혔습니다.',
+    links: [{ label: 'origin.patternflow.work', href: 'https://origin.patternflow.work/' }],
+  },
+  {
+    id: 'tools-reflow',
+    lane: 'tools',
+    date: '2026-02-08',
+    title: 'Reflow cube · 3D export',
+    titleKo: '리플로우 큐브 · 3D 출력',
+    status: 'done',
+    level: 2,
+    detail:
+      'The Reflow cube: a six-face pattern cube driven by one shared heightmap, reachable from a QR/NFC URL that carries its own preset, plus an OBJ exporter for printing the patterns as physical objects. This is the branch that turned Origin\'s patterns into things you could hold — the direct ancestor of the idea of putting them on a panel.',
+    detailKo:
+      '리플로우 큐브입니다. 하나의 하이트맵으로 6면을 함께 구동하는 패턴 큐브이고, QR/NFC URL에 프리셋을 실어 바로 열 수 있게 했습니다. 패턴을 실물 오브제로 뽑기 위한 OBJ 익스포터도 함께 붙었습니다. 오리진의 패턴을 손에 쥘 수 있는 물건으로 바꿔 본 갈래이며, 이걸 패널에 올려보자는 발상의 직계 조상입니다.',
   },
   {
     id: 'tools-paik',
     lane: 'tools',
     date: '2026-01-28',
     title: 'Nam June Paik Art Center',
-    titleKo: '백남준아트센터 영감',
+    titleKo: '백남준아트센터',
     status: 'done',
     level: 1,
     detail:
-      'Visit to Nam June Paik Art Center & encounter with <Participation TV> (1963): reinterpreting video art as a physical interactive instrument where the audience becomes an active performer shaping light and sound.',
+      'A day trip to the Nam June Paik Art Center — to see someone else\'s exhibition, as it happens — landed in the middle of the 20th-anniversary programme. <Participation TV> (1963) and Robot K-456 were both seen for the first time that day. The connection came later: Patternflow did not come out of <Participation TV>, it was already an extension of Origin into physical space. But both are devices for handling light, and only one of them lets the audience build and share their own.',
     detailKo:
-      '백남준아트센터 방문 및 <Participation TV>(1963) 관람: 일방향 시청 대상이었던 TV 비디오 아트를 사용자가 직접 노브를 돌려 신호를 왜곡하고 빛을 연주하는 물리적 참여형 악기로 재해석한 프로젝트의 핵심 철학적 영감.',
+      '백남준아트센터에 놀러 간 날입니다. 사실은 그곳에서 열리던 다른 작가의 전시를 보러 간 것이었는데, 우연히 백남준 서거 20주년 행사 기간이었습니다. 〈참여TV〉(1963)와 〈로봇 K-456〉을 그날 처음 보았습니다. 연결은 나중에 이루어졌습니다. 패턴플로우가 〈참여TV〉에서 나왔다고 할 수는 없고, 그보다 먼저 진행하던 오리진을 현실로 확장한 쪽에 가깝습니다. 다만 둘 다 빛을 조작하는 기기이고, 그중 하나만이 관객에게 직접 만들고 공유할 자리를 내줍니다.',
     links: [
       { label: 'Journal (Nam June Paik, Me, Patternflow)', href: 'https://patternflow.work/journal/nam-june-paik-me-patternflow' },
       { label: 'Journal (v1 in 30 days)', href: 'https://patternflow.work/journal/v1-30-days' },
@@ -491,10 +655,10 @@ export const NODES: RoadmapNode[] = [
     status: 'done',
     level: 1,
     detail:
-      'In-browser Live Pattern Editor (patternflow.work/pattern-lab): featuring JS-to-C++ parity, live 64x64 canvas simulation, real-time knob modulation, and instant C++ code exporter.',
+      'The Live Editor, in the Pattern section of the site: write a pattern in JavaScript, watch it run on a simulated panel with the four knobs live, then convert it to C++ that behaves the same on the device. JS-to-C++ parity is the whole point — what you tune in the browser is what the hardware renders.',
     detailKo:
-      '웹 브라우저 라이브 패턴 에디터 (patternflow.work/pattern-lab). JS 캔버스 시뮬레이터와 C++ 디바이스 드라이버 간의 1:1 파리티, 실시간 노브 변조 및 C++ 헤더 자동 내보내기 지원.',
-    links: [{ label: 'Live Editor', href: 'https://patternflow.work/pattern-lab' }],
+      '사이트의 패턴 섹션에 있는 라이브 에디터입니다. 자바스크립트로 패턴을 쓰고, 시뮬레이션된 패널에서 노브 4개를 실시간으로 돌려보며 확인한 다음, 기기에서 동일하게 동작하는 C++로 변환합니다. JS와 C++의 동작 일치가 핵심입니다. 브라우저에서 맞춘 그대로가 하드웨어에서 나와야 합니다.',
+    links: [{ label: 'Live Editor', href: 'https://patternflow.work/pattern' }],
   },
   {
     id: 'tools-lab',
@@ -505,9 +669,9 @@ export const NODES: RoadmapNode[] = [
     status: 'done',
     level: 2,
     detail:
-      'Pattern Lab harness: featuring calibrated physical knob sliders, color palette selector, noise spectrum visualizers, and pattern performance profiling.',
+      'Pattern Lab, a development harness sitting beside the Live Editor: knob sliders calibrated to the physical encoders, encoder push buttons, and a working surface for tuning a pattern rather than writing one. The Video Baker shipped the same day, baking patterns to PFV1 video for firmware playback.',
     detailKo:
-      '패턴 튜닝 하네스 스튜디오 (Pattern Lab). 4개 로터리 엔코더 가상 슬라이더, 팔레트 색상 램프 조절기, Simplex 노이즈 주파수 시각화 및 FPS 성능 측정 도구 수록.',
+      '라이브 에디터 옆에 붙는 개발용 하네스, 패턴랩입니다. 실물 엔코더에 맞춰 캘리브레이션한 노브 슬라이더와 엔코더 푸시 버튼을 제공해, 패턴을 쓰는 곳이 아니라 다듬는 곳으로 만들었습니다. 같은 날 비디오 베이커도 함께 나와, 패턴을 PFV1 비디오로 구워 펌웨어에서 재생할 수 있게 했습니다.',
     links: [{ label: 'Pattern Lab', href: 'https://patternflow.work/pattern-lab' }],
   },
   {
@@ -519,10 +683,10 @@ export const NODES: RoadmapNode[] = [
     status: 'done',
     level: 1,
     detail:
-      'AI pattern generation in Pattern Lab using Google Gemini API: describe desired visual patterns in natural language and automatically generate running C++ matrix code.',
+      'In-app AI pattern generation in Pattern Lab, bring-your-own Gemini key: describe a pattern in plain language and get running code back inside the tool, instead of copying a prompt out to a chat window and pasting the answer back.',
     detailKo:
-      'Pattern Lab 내 Google Gemini API 키 연동. "소용돌이치는 오로라 파동" 등 자연어 텍스트 설명만으로 디바이스에서 바로 실행되는 C++ 매트릭스 패턴 코드를 자동 생성.',
-    links: [{ label: 'Pattern Lab AI', href: 'https://patternflow.work/pattern-lab' }],
+      '패턴랩 안에서 바로 쓰는 AI 패턴 생성입니다. 본인의 Gemini 키를 넣어 사용하며, 원하는 패턴을 말로 설명하면 도구 안에서 곧바로 동작하는 코드가 나옵니다. 프롬프트를 복사해 채팅창에 붙여넣고 답을 다시 가져오는 과정이 사라졌습니다.',
+    links: [{ label: 'Pattern Lab', href: 'https://patternflow.work/pattern-lab' }],
   },
   {
     id: 'tools-stack',
@@ -533,24 +697,38 @@ export const NODES: RoadmapNode[] = [
     status: 'done',
     level: 1,
     detail:
-      'Color ramp & vector field generator modes in Pattern Lab: layer-stacking engine compiling visual patches into C++ code with pre-baked math decision tables and LUT optimizations.',
+      'Color ramp and v-field modes with a gradient editor, plus an Experiment tab — a layer-stack patch editor that compiles down to pattern code with knob bindings. The C++ conversion prompt was hardened alongside it: exact helper signatures, an expensive-math decision table, and ramps emitted as pre-baked lookup tables so the model never has to reproduce them by hand.',
     detailKo:
-      'Pattern Lab 내 컬러 램프 & 벡터 필드 생성기 모드. 시각 효과 레이어를 쌓아복합 패턴을 구성하고, LUT 디시전 테이블을 통해 고성능 C++ 코드로 자동 합성하는 기능.',
-    links: [{ label: 'Pattern Lab Studio', href: 'https://patternflow.work/pattern-lab' }],
+      '그라디언트 에디터가 붙은 컬러 램프 & v-field 모드, 그리고 실험 탭이 들어왔습니다. 실험 탭은 레이어 스택 패치 에디터로, 노브 바인딩까지 포함한 패턴 코드로 컴파일됩니다. C++ 변환 프롬프트도 함께 단단해졌습니다. 헬퍼 시그니처를 정확히 명시하고, 연산 비용 결정표를 넣고, 램프는 미리 구운 룩업 테이블로 내보내 모델이 손으로 재현하지 않아도 되게 했습니다.',
+    links: [{ label: 'Pattern Lab', href: 'https://patternflow.work/pattern-lab' }],
   },
   {
     id: 'tools-lab-mobile',
     lane: 'tools',
     date: '2026-07-26',
-    title: 'Lab mobile & resolution',
-    titleKo: '패턴랩 모바일 UX & 해상도',
+    title: 'Mobile UX & pattern frames',
+    titleKo: '모바일 UX & 패턴 프레임',
     status: 'done',
     level: 2,
     detail:
-      'Mobile UX overhaul for Pattern Lab: direct clipboard paste/clear buttons, localStorage draft autosave, and custom panel resolution tags (// @matrix W H).',
+      'A pattern now declares the matrix it was composed for with a single // @matrix line, and that fact travels through Pattern Lab, the community sandbox and the firmware conversion — so portrait and custom resolutions render correctly everywhere. On phones: a Copy prompt / Paste response action bar, and session autosave to localStorage.',
     detailKo:
-      '패턴랩 모바일 터치 UX 최적화: 클립보드 원터치 붙여넣기/전체 지우기, 임시 저장 세션 자동 복구 및 커스텀 패널 해상도 설정 주석(// @matrix W H) 지원.',
-    links: [{ label: 'Pattern Lab Mobile', href: 'https://patternflow.work/pattern-lab' }],
+      '이제 패턴은 // @matrix 한 줄로 자기가 어떤 매트릭스를 위해 만들어졌는지 선언하고, 그 정보가 패턴랩·커뮤니티 샌드박스·펌웨어 변환까지 그대로 따라갑니다. 세로형이나 커스텀 해상도도 어디서나 제대로 렌더링됩니다. 모바일에서는 프롬프트 복사 / 응답 붙여넣기 액션 바와 localStorage 세션 자동 저장이 추가되었습니다.',
+    links: [{ label: 'Pattern Lab', href: 'https://patternflow.work/pattern-lab' }],
+  },
+  {
+    id: 'tools-lab-v2',
+    lane: 'tools',
+    date: '2026-07-27',
+    title: 'Pattern Lab v2 — layers',
+    titleKo: '패턴랩 v2 — 레이어',
+    status: 'done',
+    level: 1,
+    detail:
+      'Pattern Lab rebuilt as a layered, dockable editor platform. Code layers and pixel-art layers composite bottom-to-top with opacity and blend modes; any layer can flip to masking the one below it; each code layer carries its own color ramp with alpha. A pixel panel draws straight onto the matrix. Panels dock and float like Photoshop. Publishing flattens the visible stack into one standalone pattern — while the full editable project rides along in a single compressed // @stack comment, so a shared pattern reopens as layers.',
+    detailKo:
+      '패턴랩을 레이어 기반의 도킹 가능한 에디터 플랫폼으로 다시 만들었습니다. 코드 레이어와 픽셀아트 레이어가 아래에서 위로 합성되며 불투명도와 블렌드 모드를 갖고, 어떤 레이어든 바로 아래 레이어를 마스킹하는 역할로 전환할 수 있으며, 코드 레이어마다 알파를 포함한 자기 컬러 램프를 갖습니다. 픽셀 패널에서는 매트릭스에 직접 그림을 그릴 수 있습니다. 패널들은 포토샵처럼 도킹하고 띄울 수 있습니다. 게시하면 보이는 스택이 하나의 독립 패턴으로 평탄화되는데, 동시에 편집 가능한 전체 프로젝트가 압축된 // @stack 주석 한 줄에 실려 함께 나갑니다. 공유받은 패턴을 다시 레이어 상태로 열 수 있다는 뜻입니다.',
+    links: [{ label: 'Pattern Lab', href: 'https://patternflow.work/pattern-lab' }],
   },
   {
     id: 'tools-multiagent',
@@ -561,45 +739,70 @@ export const NODES: RoadmapNode[] = [
     status: 'planned',
     level: 1,
     detail:
-      'Multi-agent AI pattern generation pipeline: autonomous generator, critic, and refiner agents working in a feedback loop to produce complex, visually stunning shaders.',
+      'A multi-agent generation pipeline: generator, critic and refiner agents working in a loop, so the tool can push a pattern past the first plausible result on its own instead of handing every judgement call back to the person at the keyboard.',
     detailKo:
-      '다중 AI 에이전트 렌더링 시스템: 생성기, 비평기, 코드 교정기 에이전트가 루프를 돌며 우수한 비주얼의 셰이더 패턴을 스스로 다듬어내는 차세대 AI 에디터.',
+      '다중 에이전트 생성 파이프라인입니다. 생성기·비평기·교정기 에이전트가 루프를 돌며, 처음 그럴듯하게 나온 결과에서 멈추지 않고 도구가 스스로 더 밀어붙이도록 하는 것이 목표입니다. 판단을 매번 사람에게 되돌려주지 않아도 되게 하는 방향입니다.',
   },
 
   // Community & business
   {
     id: 'biz-reddit',
     lane: 'community',
-    date: '2026-04-21',
-    title: 'Reddit launch',
-    titleKo: '레딧 프로젝트 공개',
+    date: '2026-04-17',
+    title: 'Reddit goes viral',
+    titleKo: '레딧 바이럴',
     status: 'done',
     level: 1,
     detail:
-      'Official public repository release & viral Reddit post on r/arduino: gaining global maker traction and transitioning Patternflow into an open-source community project.',
+      'With the prototype breaking every time a camera came out, an older reel got posted to r/arduino — partly hoping someone would know what was wrong. It passed a thousand upvotes fast. Commenters had fought the same potentiometer noise and switched to rotary encoders; encoders were ordered the same day. Plenty of people asked to buy one. That thread is why this became open source instead of a personal project.',
     detailKo:
-      'r/arduino 레딧 커뮤니티 정식 공개 후 폭발적인 반응 바이럴. 개인 프로젝트에서 전 세계 메이커들이 함께하는 오픈소스 커뮤니티로 전환.',
+      '카메라만 켜면 프로토타입이 고장 나던 시기에, 예전에 찍어둔 릴스를 r/arduino에 올렸습니다. 누군가 원인을 알려주길 바라는 마음도 있었습니다. 금세 업보트 1천을 넘겼고, 댓글에는 같은 가변저항 노이즈로 고생하다 로터리 엔코더로 바꿨다는 이야기가 이어졌습니다. 그날 바로 엔코더를 주문했습니다. 사고 싶다는 사람도 많았습니다. 이 글이 개인 프로젝트를 오픈소스로 바꾼 계기입니다.',
     links: [
-      { label: 'Reddit Viral Post #1', href: 'https://www.reddit.com/r/arduino/comments/1so9er5/built_a_4knob_generative_pattern_controller_with/' },
-      { label: 'Reddit PCB Update #2', href: 'https://www.reddit.com/r/arduino/comments/1szettd/12_days_later_pcb_done_rotary_encoders_done_fully/' },
-      { label: 'Journal (Me and Patternflow)', href: 'https://patternflow.work/journal/me-and-patternflow' },
+      { label: 'Reddit — prototype thread', href: 'https://www.reddit.com/r/arduino/comments/1so9er5/built_a_4knob_generative_pattern_controller_with/' },
+      { label: 'Reddit — PCB update', href: 'https://www.reddit.com/r/arduino/comments/1szettd/12_days_later_pcb_done_rotary_encoders_done_fully/' },
+      { label: 'Journal (v1 in 30 days)', href: 'https://patternflow.work/journal/v1-30-days' },
     ],
   },
   {
     id: 'biz-pcbway-order',
     lane: 'community',
-    date: '2026-04-26',
-    title: 'First PCBWay order',
-    titleKo: '첫 PCBWay 스폰서십',
+    date: '2026-04-20',
+    title: 'PCBWay sponsorship',
+    titleKo: 'PCBWay 스폰서십',
     status: 'done',
     level: 2,
     detail:
-      'PCBWay sponsorship partnership: PCBWay reached out on Reddit and sponsored the first PCB prototype order, initiating ongoing hardware manufacturing support.',
+      'The day after the first PCB artwork was finished — drawn over one weekend, with no idea whether it was correct — an Instagram DM arrived: PCBWay had seen the Reddit thread and wanted to sponsor the fabrication. It read like spam. It was not. The boards arrived three days later on the cheapest shipping option, and the project moved from an idea to something manufacturable.',
     detailKo:
-      '레딧 게시글을 본 PCBWay에서 패턴플로우의 가능성을 알아보고 첫 PCB 제작 전액 스폰서십을 제안. 프로젝트가 아이디어를 넘어 하드웨어 제조 단계로 도약한 순간.',
-    links: [
-      { label: 'Journal (v1 in 30 days)', href: 'https://patternflow.work/journal/v1-30-days' },
-    ],
+      '주말 이틀을 갈아넣어 첫 PCB 아트워크를 끝낸 바로 다음 날, 인스타그램으로 DM이 왔습니다. PCBWay에서 레딧 글을 보았고 제작을 후원하고 싶다는 내용이었습니다. 스팸인 줄 알았는데 진짜였습니다. 가장 저렴한 배송 옵션을 골랐는데도 3일 만에 보드가 도착했고, 프로젝트가 아이디어에서 실제로 제조 가능한 물건으로 넘어갔습니다.',
+    links: [{ label: 'Journal (v1 in 30 days)', href: 'https://patternflow.work/journal/v1-30-days' }],
+  },
+  {
+    id: 'biz-opensource',
+    lane: 'community',
+    date: '2026-04-23',
+    title: 'Repository goes public',
+    titleKo: '저장소 공개',
+    status: 'done',
+    level: 2,
+    detail:
+      'The monorepo went public — web, hardware and firmware in one tree — restructured so someone else could actually follow it. The plan behind it was explicit: not a product, a genre and an ecosystem, with reputation valued over revenue and the other half of the work handed to whoever shows up.',
+    detailKo:
+      '모노레포를 공개했습니다. 웹·하드웨어·펌웨어를 한 트리에 두고, 다른 사람이 실제로 따라올 수 있도록 구조를 다시 잡았습니다. 그 배경에 있는 계획은 분명했습니다. 하나의 상품이 아니라 장르이자 생태계를 만드는 것, 돈보다 명예를 택하는 것, 그리고 남은 절반의 작업을 찾아오는 사람들에게 맡기는 것입니다.',
+    links: [{ label: 'GitHub — engmung/Patternflow', href: REPO }],
+  },
+  {
+    id: 'biz-designright',
+    lane: 'community',
+    date: '2026-04-26',
+    title: 'Design filing · v1.0.0',
+    titleKo: '디자인권 출원 · v1.0.0',
+    status: 'done',
+    level: 2,
+    detail:
+      'The design registration was filed on the same day v1.0.0 was tagged. Licensing was settled at the same time and has not moved since: firmware and web under MIT, hardware and designs under CC-BY-SA 4.0, with "Patternflow" held as a trademark.',
+    detailKo:
+      'v1.0.0을 태깅한 같은 날 미뤄두던 디자인권 출원을 진행했습니다. 라이선스도 이때 정해져 지금까지 그대로입니다. 펌웨어와 웹은 MIT, 하드웨어와 디자인은 CC-BY-SA 4.0이며, "Patternflow"는 상표로 보유합니다.',
   },
   {
     id: 'biz-discord',
@@ -610,9 +813,9 @@ export const NODES: RoadmapNode[] = [
     status: 'done',
     level: 2,
     detail:
-      'Official Discord server & Patternflow Journal launch (patternflow.work/journal): sharing transparent build logs, hardware challenges, and receiving first community PRs.',
+      'The Discord invite went into the README with the v1.0.0 release, and the journal launched three days later with the first build log — a running account of the process, failures included, rather than a polished changelog. The first outside pull requests landed the same day: #22 and #23, both fixing things the guide had gotten wrong.',
     detailKo:
-      '공식 디스코드 커뮤니티 서버 개설 및 개발 이야기(patternflow.work/journal) 연재 시작. 투명한 개발 일지 공유를 통해 전 세계 기여자의 첫 PR 접수.',
+      'v1.0.0 릴리스와 함께 README에 디스코드 초대 링크가 들어갔고, 사흘 뒤 첫 빌드 로그와 함께 저널이 시작되었습니다. 잘 다듬은 체인지로그가 아니라 실패를 포함한 과정을 그대로 적는 기록입니다. 외부에서 온 첫 PR도 같은 날 들어왔습니다. #22와 #23, 둘 다 가이드가 틀리게 적어둔 것을 고치는 내용이었습니다.',
     links: [
       { label: 'Official Discord', href: 'https://discord.gg/Vr9QtsxeTk' },
       { label: 'Journal Index', href: 'https://patternflow.work/journal' },
@@ -627,112 +830,13 @@ export const NODES: RoadmapNode[] = [
     status: 'done',
     level: 1,
     detail:
-      'Official Crowd Supply crowdfunding contract signed: committing Patternflow to become a commercially available open-source hardware kit.',
+      'Crowd Supply signed. The application had been sent and forgotten — everyone said it was hard to get in — and the reply came the next day asking why a kit rather than a finished product, and how manufacturing would be handled. Signing committed Patternflow to being something people can actually buy, as a kit or assembled.',
     detailKo:
-      '세계 최대 오픈소스 하드웨어 펀딩 플랫폼인 Crowd Supply와 공식 입점 계약 체결. 누구나 쉽게 완제품 또는 DIY 키트로 구매할 수 있는 기반 마련.',
+      'Crowd Supply와 계약했습니다. 되기 어렵다는 말을 들어 기대 없이 신청해 두고 잊고 있었는데, 바로 다음 날 답장이 왔습니다. 왜 완제품이 아니라 키트로 가는지, 펀딩을 진행하면 제조는 어떻게 처리할 것인지를 묻는 내용이었습니다. 계약과 함께 패턴플로우는 실제로 사서 만들 수 있는 물건이 되기로 확정되었습니다.',
     links: [
-      { label: 'Crowd Supply Page', href: 'https://www.crowdsupply.com/engmung/patternflow' },
-      { label: 'Journal (refocus)', href: 'https://patternflow.work/journal/refocus' },
+      { label: 'Crowd Supply page', href: 'https://www.crowdsupply.com/engmung/patternflow' },
+      { label: 'Journal (stopped)', href: 'https://patternflow.work/journal/stopped' },
     ],
-  },
-  // Media & Press
-  {
-    id: 'media-hackster-1',
-    lane: 'media',
-    date: '2026-05-02',
-    title: 'Hackster.io #1',
-    titleKo: 'Hackster.io (1차 피처)',
-    status: 'done',
-    level: 1,
-    detail:
-      'Hackster.io published an organic feature article titled "You\'ll Want This LED Pattern Generator on Your Desk" by Gareth Halfacree, published right after Patternflow\'s first viral Reddit post.',
-    detailKo:
-      '첫 레딧 포스트 바이럴 직후 Gareth Halfacree 기자가 보도한 Hackster.io 1차 자발적 언론 피처 기사 ("You\'ll Want This LED Pattern Generator on Your Desk"). 4개 노브 하드웨어 인터페이스와 제너러티브 알고리즘에 주목.',
-    links: [{ label: 'Hackster.io Article #1', href: 'https://www.hackster.io/news/you-ll-want-this-led-pattern-generator-on-your-desk-007c411e74e4' }],
-  },
-  {
-    id: 'media-twitter-viral',
-    lane: 'media',
-    date: '2026-05-12',
-    title: 'Twitter/X Viral',
-    titleKo: '트위터(X) 자발적 바이럴',
-    status: 'done',
-    level: 2,
-    detail:
-      'Spontaneous viral tweet on May 12, 2026 by third-party creator (@Inspector_9) showcasing Patternflow\'s visual patterns (noting author\'s name misspelled as "Seung-hun Lee").',
-    detailKo:
-      '5월 12일 해외 유저(@Inspector_9)가 작성한 트위터(X) 자발적 소개 포스트 바이럴. 제작자명이 \'이승헌\'으로 오기되었으나 유저들의 자발적 대량 공유로 글로벌 트래픽 유입 형성.',
-    links: [{ label: 'Twitter/X Post (@Inspector_9)', href: 'https://x.com/Inspector_9/status/2053926198049226794' }],
-  },
-  {
-    id: 'media-yanko',
-    lane: 'media',
-    date: '2026-05-14',
-    title: 'Yanko Design',
-    titleKo: '얀코디자인 (Yanko Design)',
-    status: 'done',
-    level: 2,
-    detail:
-      'Featured on May 14, 2026 on Yanko Design\'s official Instagram (@yankodesign), highlighting Patternflow\'s tactile industrial enclosure design and light matrix interaction.',
-    detailKo:
-      '5월 14일 글로벌 인더스트리얼 디자인 매체 얀코디자인(Yanko Design) 공식 인스타그램(@yankodesign) 자발적 프로젝트 피처 게시글 게재.',
-    links: [{ label: 'Yanko Design Instagram', href: 'https://www.instagram.com/p/DYUYZzxMBa6/' }],
-  },
-  {
-    id: 'media-hackster-2',
-    lane: 'media',
-    date: '2026-05-18',
-    title: 'Hackster.io #2',
-    titleKo: 'Hackster.io (2차 피처)',
-    status: 'done',
-    level: 2,
-    detail:
-      'Hackster.io published an organic follow-up article titled "A Living Canvas of Shifting Colors and Motion", exploring Patternflow\'s hardware evolution and open-source generative algorithms.',
-    detailKo:
-      'Hackster.io 자발적 2차 후속 피처 기사 ("A Living Canvas of Shifting Colors and Motion"). 패턴플로우의 하드웨어 발전과 오픈소스 렌더링 알고리즘 조명.',
-    links: [{ label: 'Hackster.io Article #2', href: 'https://www.hackster.io/news/a-living-canvas-of-shifting-colors-and-motion-c53f6fd6e478' }],
-  },
-  {
-    id: 'media-howtogeek',
-    lane: 'media',
-    date: '2026-07-03',
-    title: 'How-To Geek',
-    titleKo: '하우투긱 (How-To Geek)',
-    status: 'done',
-    level: 1,
-    detail:
-      'How-To Geek featured Patternflow in their curated article "Beautiful ESP32 Projects to Make This Weekend (Jul 3-5)", recommending the DIY hardware build to global makers.',
-    detailKo:
-      '글로벌 IT 매체 How-To Geek의 주말 추천 DIY 프로젝트 큐레이션 기사 수록 ("Beautiful ESP32 Projects to Make This Weekend", 7월 3~5일 자발적 추천).',
-    links: [{ label: 'How-To Geek Article', href: 'https://www.howtogeek.com/beautiful-esp32-projects-to-make-this-weekend-jul-3-5/' }],
-  },
-  {
-    id: 'media-digikey-youtube',
-    lane: 'media',
-    date: '2026-07-09',
-    title: 'DigiKey YouTube',
-    titleKo: '디지키(DigiKey) 공식 유튜브 피처',
-    status: 'done',
-    level: 2,
-    detail:
-      'Featured on DigiKey\'s official YouTube channel on July 9, 2026: a video spotlighting Patternflow\'s open-source hardware architecture, 4-knob control interface, and generative matrix performance.',
-    detailKo:
-      '7월 9일 글로벌 대표 전자부품 유통기업 디지키(DigiKey) 공식 유튜브 채널 수록. 패턴플로우의 오픈소스 하드웨어 설계 및 제너러티브 매트릭스 인터페이스를 조명한 공식 영상 피처.',
-    links: [{ label: 'DigiKey YouTube Video', href: 'https://www.youtube.com/watch?v=3Y-rTNgBq6w&t=18s' }],
-  },
-  {
-    id: 'media-can',
-    lane: 'media',
-    date: '2026-07-15',
-    title: 'Creative Applications',
-    titleKo: 'Creative Applications (CAN)',
-    status: 'done',
-    level: 1,
-    detail:
-      'Creative Applications Network (CAN) published a comprehensive feature titled "Patternflow – An open-source LED synthesizer reinterpreting Participation TV", submitted directly by the author to articulate the project\'s Nam June Paik artistic roots.',
-    detailKo:
-      '제작자가 직접 CAN(Creative Applications Network)에 신청/투고하여 성공적으로 게재된 정식 아티클 ("Patternflow – An open-source LED synthesizer reinterpreting Participation TV"). 백남준 <Participation TV> 재해석 철학 수록.',
-    links: [{ label: 'Creative Applications Article', href: 'https://www.creativeapplications.net/news/patternflow-an-open-source-led-synthesizer-reinterpreting-participation-tv/' }],
   },
   {
     id: 'biz-nath-build',
@@ -743,10 +847,38 @@ export const NODES: RoadmapNode[] = [
     status: 'done',
     level: 2,
     detail:
-      'First fully independent external community build by UK maker Nath (/inside/nath-uk): validating that the open-source BUILD_GUIDE.md works seamlessly for third-party builders.',
+      'Nath, in the UK, built a complete Patternflow from the published files alone — the first person outside the project to do so. Proof that the guide works for someone who cannot walk over and ask.',
     detailKo:
-      '영국의 유저 Nath가 오픈소스 빌드 가이드만 보고 완전히 스스로 제작에 성공한 첫 커뮤니티 실물 빌드 (/inside/nath-uk). 누구나 만들 수 있는 하드웨어 문서화 검증.',
+      '영국의 Nath가 공개된 자료만 보고 패턴플로우를 완성했습니다. 프로젝트 바깥에서 처음 나온 완성품입니다. 옆에 와서 물어볼 수 없는 사람에게도 가이드가 통한다는 증거입니다.',
     links: [{ label: 'Nath UK Build', href: 'https://patternflow.work/inside/nath-uk' }],
+  },
+  {
+    id: 'biz-exhibition',
+    lane: 'community',
+    date: '2026-06-15',
+    title: 'Exhibition',
+    titleKo: '전시',
+    status: 'done',
+    level: 2,
+    detail:
+      'Patternflow was exhibited through the Hongik course it had been tied to. What went on the wall was not the finished object — the whole written process, every journal entry and failure that could be shown, was pinned up behind it. The exhibited unit died on day one from rough handling, which is what led to pulling the SMD parts off the board.',
+    detailKo:
+      '패턴플로우를 연계해 진행하던 홍익대 수업의 전시입니다. 벽에 건 것은 완성된 물건이 아니라 그 뒷면이었습니다. 작업하며 쓴 글과 과정을, 도저히 보여줄 수 없는 것만 빼고 거의 다 뒤에 붙였습니다. 전시한 기기는 험하게 다뤄진 탓에 하루 만에 고장 났는데, 그 일이 보드에서 SMD 부품을 떼어내는 결정으로 이어졌습니다.',
+    links: [{ label: 'Journal (refocus)', href: 'https://patternflow.work/journal/refocus' }],
+  },
+  {
+    id: 'biz-sdsc',
+    lane: 'community',
+    date: '2026-06-16',
+    title: 'Seoul Design Startup Center',
+    titleKo: '서울디자인창업센터 입주',
+    status: 'done',
+    level: 2,
+    detail:
+      'Accepted as a resident at the Seoul Design Startup Center after a 5-minute pitch and 7 minutes of questions — what kind of business this actually is, how the IP would be handled. The mentoring said the deck was too artistic and needed numbers. Getting in as a solo student is not the usual path.',
+    detailKo:
+      '5분 피칭과 7분 질의응답을 거쳐 서울디자인창업센터 입주기업으로 선정되었습니다. 정확히 어떤 사업인지, IP는 어떻게 할 것인지 같은 질문이 이어졌습니다. 멘토링에서는 너무 예술적으로 간다, 숫자가 필요하다는 지적을 받았습니다. 학생 혼자 입주한 건 흔한 경우는 아닙니다.',
+    links: [{ label: 'Journal (refocus)', href: 'https://patternflow.work/journal/refocus' }],
   },
   {
     id: 'biz-prelaunch',
@@ -757,10 +889,13 @@ export const NODES: RoadmapNode[] = [
     status: 'done',
     level: 1,
     detail:
-      'Crowd Supply pre-launch page live: gathering interest signups and backer notifications across the web ecosystem for campaign launch readiness.',
+      'The Crowd Supply pre-launch page went live a month after signing. The 100-person waitlist was emailed on day one and under 20% converted to subscribers — the first hard lesson that an Instagram audience does not automatically follow you onto a crowdfunding platform it has never heard of.',
     detailKo:
-      'Crowd Supply 공식 프리런칭 페이지 런칭. 전 세계 유저를 대상으로 출시 알림 구독 신청을 수집하기 시작.',
-    links: [{ label: 'Crowd Supply page', href: 'https://www.crowdsupply.com/engmung/patternflow' }],
+      '계약 한 달 만에 Crowd Supply 프리런칭 페이지를 열었습니다. 첫날 웨이트리스트 100명에게 메일을 보냈지만 구독 전환은 20%에 미치지 못했습니다. 인스타그램의 반응이 처음 들어보는 크라우드펀딩 플랫폼 가입까지 자동으로 이어지지는 않는다는 걸 처음으로 확실히 배운 지점입니다.',
+    links: [
+      { label: 'Crowd Supply page', href: 'https://www.crowdsupply.com/engmung/patternflow' },
+      { label: 'Journal (what is Patternflow)', href: 'https://patternflow.work/journal/what-is-patternflow' },
+    ],
   },
   {
     id: 'biz-cs-150',
@@ -771,28 +906,57 @@ export const NODES: RoadmapNode[] = [
     status: 'done',
     level: 1,
     detail:
-      'Surpassed 160+ Crowd Supply pre-launch subscribers — fulfilling the mandatory 150 subscriber threshold for campaign launch approval — driven by viral Instagram pattern videos reaching over 300,000 views.',
+      'The 150-subscriber threshold Crowd Supply requires before a campaign can launch was cleared, landing at 160. It had been stuck: 60 in early July, 93 by the 18th, with the growth visibly flattening. What broke it open was a pattern the author nearly did not post for being a bit grotesque — it went on to be the best-performing one yet, tracking toward roughly 300,000 views.',
     detailKo:
-      '인스타그램 패턴 바이럴 영상(~30만 회) 폭발적 호응에 힘입어 Crowd Supply 프리런칭 구독자 162명 돌파 (펀딩 정식 승인 요건인 150명 달성).',
+      '펀딩 정식 승인 요건인 구독자 150명을 넘겨 160명을 찍었습니다. 그 전까지는 막혀 있었습니다. 7월 초 60명, 18일에 93명이었고 증가세가 눈에 띄게 꺾이던 참이었습니다. 이걸 뚫은 건 조금 징그러울까 봐 올릴까 말까 망설였던 패턴이었습니다. 그 패턴이 지금까지 중 가장 좋은 성적을 냈고, 30만 조회수 근처로 향하고 있습니다.',
     links: [
       { label: 'Instagram @patternflow.work', href: 'https://www.instagram.com/patternflow.work' },
-      { label: 'Crowd Supply page', href: 'https://www.crowdsupply.com/engmung/patternflow' },
       { label: 'Journal (faster-faster)', href: 'https://patternflow.work/journal/faster-faster' },
     ],
   },
   {
     id: 'community-discussions',
     lane: 'community',
-    date: '2026-07-24',
-    title: 'Discussions & pattern forks',
-    titleKo: '커뮤니티 & 패턴 포크',
+    date: '2026-07-22',
+    title: 'Pattern Community',
+    titleKo: '패턴 커뮤니티',
     status: 'done',
     level: 1,
     detail:
-      'Patternflow Community Hub launch (patternflow.work/community): featuring discussion forums and pattern sharing with fork capabilities — copy base patterns, customize color ramps, and republish to the community.',
+      'The Pattern Community: a paged feed with hover-to-play live previews and scroll-wheel knob control, detail pages with in-place editing, publishing with recorded fork lineage, likes, comments and profiles, plus a Discussions board added three days later. Browse and edit without an account. The move off Discord as the main venue was deliberate — Discord is blocked in a number of countries, and locking people out of a community for where they live is not acceptable.',
     detailKo:
-      '패턴플로우 공식 커뮤니티 허브 (patternflow.work/community) 런칭. 유저 간 패턴 공유, 커스텀 색상/코드 변형 후 재게시(Fork) 기능 및 토론 게시판 오픈.',
+      '패턴 커뮤니티입니다. 마우스를 올리면 바로 재생되고 휠로 노브를 돌려볼 수 있는 페이지네이션 피드, 그 자리에서 코드를 고칠 수 있는 상세 페이지, 포크 계보가 기록되는 게시, 좋아요·댓글·프로필을 갖췄고 사흘 뒤 디스커션 게시판이 붙었습니다. 계정 없이도 둘러보고 수정할 수 있습니다. 메인 커뮤니티를 디스코드에서 옮긴 건 의도적인 결정이었습니다. 디스코드 가입이 막힌 국가가 생각보다 많고, 사는 곳 때문에 커뮤니티에서 배제되는 건 있을 수 없는 일이기 때문입니다.',
+    links: [
+      { label: 'Community Hub', href: 'https://patternflow.work/community' },
+      { label: 'Journal (v3 and beyond)', href: 'https://patternflow.work/journal/v3-and-beyond' },
+    ],
+  },
+  {
+    id: 'community-terms',
+    lane: 'community',
+    date: '2026-07-29',
+    title: 'Licence, takedown, decks',
+    titleKo: '라이선스 · 신고 · 덱',
+    status: 'done',
+    level: 2,
+    detail:
+      'The community grew the machinery a shared library needs: licence headers that actually mean something on every published pattern, a moderation queue and takedown path, a provenance record, deletion that really deletes what the terms say it deletes, and the Saved / Deck split — Saved is a bookmark, a Deck is a curated set you can share.',
+    detailKo:
+      '공유 라이브러리에 필요한 장치들이 붙었습니다. 게시되는 모든 패턴에 실효성 있는 라이선스 헤더, 신고 처리 큐와 게시 중단 경로, 출처 기록, 약관에 적힌 대로 실제로 지워지는 삭제, 그리고 Saved / Deck 분리입니다. Saved는 북마크이고, Deck은 골라 담아 공유하는 묶음입니다.',
     links: [{ label: 'Community Hub', href: 'https://patternflow.work/community' }],
+  },
+  {
+    id: 'biz-sfac',
+    lane: 'community',
+    date: '2026-07-30',
+    title: 'SFAC arts incubating',
+    titleKo: '서울문화재단 예술창업인큐베이팅',
+    status: 'done',
+    level: 2,
+    detail:
+      'Accepted into the Seoul Foundation for Arts and Culture\'s arts startup incubating programme — the second support track after the Seoul Design Startup Center residency, and the one that sits on the art side of the split this project keeps straddling.',
+    detailKo:
+      '서울문화재단 예술창업인큐베이팅에 합격했습니다. 서울디자인창업센터 입주에 이은 두 번째 지원 트랙이고, 이 프로젝트가 계속 걸쳐 있는 예술과 사업 사이에서 예술 쪽에 놓인 트랙입니다.',
   },
   {
     id: 'biz-launch',
@@ -803,9 +967,9 @@ export const NODES: RoadmapNode[] = [
     status: 'planned',
     level: 1,
     detail:
-      'Global Crowd Supply crowdfunding campaign launch: offering assembled Patternflow instruments, DIY component kits, and custom enclosures to backers worldwide.',
+      'The Crowd Supply campaign itself: assembled instruments, DIY kits and cases shipped worldwide, on the v3 hardware. Everything since the USB-C rework has been aimed at this.',
     detailKo:
-      '전 세계 유저를 대상으로 한 Crowd Supply 공식 크라우드 펀딩 런칭. 완제품 및 DIY 부품 키트를 글로벌 배송하여 전 세계로 파동을 확산.',
+      'Crowd Supply 정식 펀딩입니다. 완제품, DIY 키트, 케이스를 v3 하드웨어 기준으로 전 세계에 배송합니다. USB-C 개편 이후의 모든 작업이 이 지점을 향해 있었습니다.',
     links: [{ label: 'Crowd Supply page', href: 'https://www.crowdsupply.com/engmung/patternflow' }],
   },
   {
@@ -817,16 +981,149 @@ export const NODES: RoadmapNode[] = [
     status: 'planned',
     level: 1,
     detail:
-      'Open Pattern Marketplace: enabling generative artists to create, publish, and monetize LED matrix patterns for device owners and commercial signboard installations worldwide.',
+      'A licensing rail rather than a shop. The paying side is commercial LED surfaces — shop signage, venue walls, installations — not device owners, who keep everything free. Patterns stay CC-BY-SA for anyone building one; a separate paid track lets creators license their work for commercial display, with the provenance and licence records the community already keeps as its foundation.',
     detailKo:
-      '오픈 패턴 마켓플레이스: 미디어 아티스트 및 개발자가 생성한 매트릭스 패턴을 공유하고 전 세계 기기 소유자 및 상용 전광판에 판매/유통할 수 있는 오픈 생태계.',
+      '상점이 아니라 라이선싱 레일입니다. 돈을 내는 쪽은 상업용 LED 면 — 가게 간판, 공연장 벽, 설치 작업 — 이지, 기기 소유자가 아닙니다. 기기 소유자에게는 계속 무료입니다. 직접 만들어 쓰는 사람에게 패턴은 CC-BY-SA 그대로이고, 별도의 유료 트랙에서 창작자가 상업적 전시용으로 자기 작업을 라이선스할 수 있게 합니다. 커뮤니티가 이미 쌓고 있는 출처·라이선스 기록이 그 토대입니다.',
+  },
+
+  // Media & Press
+  {
+    id: 'media-fabscene',
+    lane: 'media',
+    date: '2026-06-15',
+    title: 'fabscene (JP) ×2',
+    titleKo: '팹씬 (fabscene, 일본)',
+    status: 'done',
+    level: 2,
+    detail:
+      'Two write-ups on the Japanese maker site fabscene, assembled from the two r/arduino threads. Nobody mentioned them — they turned up while looking at where site traffic was coming from. Not a major outlet, but exactly the shape of pickup the project is built for: the material is all public, take it and write.',
+    detailKo:
+      '일본의 메이커 사이트 팹씬(fabscene)에 올라온 두 건입니다. r/arduino에서 화제가 된 두 게시글을 정리한 내용이었습니다. 알려준 사람은 없었고, 사이트 유입 트래픽을 살펴보다 발견했습니다. 크게 유의미한 매체는 아니지만, 이 프로젝트가 지향하는 형태의 소개입니다. 자료가 전부 공개되어 있으니 가져가서 쓰면 됩니다.',
+    links: [
+      { label: 'fabscene — make', href: 'https://fabscene.com/new/make/arduino-patternflow-led-art/' },
+      { label: 'fabscene — news', href: 'https://fabscene.com/new/news/patternflow-esp32-led-synthesizer/' },
+    ],
+  },
+  {
+    id: 'media-hackster-1',
+    lane: 'media',
+    date: '2026-05-02',
+    title: 'Hackster.io #1',
+    titleKo: 'Hackster.io (1차)',
+    status: 'done',
+    level: 1,
+    detail:
+      '"You\'ll Want This LED Pattern Generator on Your Desk", by Gareth Halfacree — the first press pickup, written from the r/arduino thread and the public repo without anyone being asked. The first sign that the project could travel on its own.',
+    detailKo:
+      'Gareth Halfacree 기자의 "You\'ll Want This LED Pattern Generator on Your Desk"입니다. 첫 언론 픽업이고, r/arduino 글과 공개 저장소만 보고 요청 없이 쓰인 기사입니다. 프로젝트가 스스로 굴러갈 수 있다는 첫 신호였습니다.',
+    links: [{ label: 'Hackster.io Article #1', href: 'https://www.hackster.io/news/you-ll-want-this-led-pattern-generator-on-your-desk-007c411e74e4' }],
+  },
+  {
+    id: 'media-hackster-2',
+    lane: 'media',
+    date: '2026-06-28',
+    title: 'Hackster.io #2',
+    titleKo: 'Hackster.io (2차)',
+    status: 'done',
+    level: 2,
+    detail:
+      '"A Living Canvas of Shifting Colors and Motion" — an organic follow-up covering how the hardware had moved on, landing the day after the Crowd Supply pre-launch page opened. Also unprompted.',
+    detailKo:
+      '"A Living Canvas of Shifting Colors and Motion"입니다. 그동안 하드웨어가 어떻게 발전했는지를 다룬 자발적 후속 기사로, 크라우드 서플라이 프리런칭 페이지를 연 바로 다음 날 올라왔습니다. 이 역시 요청하지 않은 기사입니다.',
+    links: [{ label: 'Hackster.io Article #2', href: 'https://www.hackster.io/news/a-living-canvas-of-shifting-colors-and-motion-c53f6fd6e478' }],
+  },
+  {
+    id: 'media-twitter-viral',
+    lane: 'media',
+    date: '2026-05-12',
+    title: 'X / Twitter viral',
+    titleKo: '트위터(X) 바이럴',
+    status: 'done',
+    level: 2,
+    detail:
+      'A third-party post on X (@Inspector_9) went viral on its own, with the author\'s name rendered "Seungheon" instead of Seunghun — hun read as heon. The author\'s own X account, posting the same material, got nothing. Consistency is apparently the whole game on that platform, which is why Instagram stayed the one channel worth maintaining.',
+    detailKo:
+      'X(트위터)에서 한 유저(@Inspector_9)의 게시글이 자발적으로 바이럴되었습니다. 제작자 이름은 이승훈이 아니라 이승헌으로 적혀 있었습니다. hun이 헌으로 읽힌 모양입니다. 정작 본인 계정에 같은 내용을 올렸을 때는 아무 반응이 없었습니다. 그쪽은 결국 꾸준함이 전부인 듯해, 인스타그램 한 채널에만 집중하기로 한 계기가 되었습니다.',
+    links: [{ label: 'X post (@Inspector_9)', href: 'https://x.com/Inspector_9/status/2053926198049226794' }],
+  },
+  {
+    id: 'media-yanko',
+    lane: 'media',
+    date: '2026-05-14',
+    title: 'Yanko Design',
+    titleKo: '얀코디자인 (Yanko Design)',
+    status: 'done',
+    level: 2,
+    detail:
+      'Featured on Yanko Design\'s official Instagram (@yankodesign), focused on the enclosure and the tactile side — the knobs and the light, rather than the electronics.',
+    detailKo:
+      '글로벌 인더스트리얼 디자인 매체 얀코디자인(Yanko Design)의 공식 인스타그램(@yankodesign)에 소개되었습니다. 전자적인 부분보다 인클로저와 촉각적인 면 — 노브와 빛 — 에 초점을 맞춘 게시글이었습니다.',
+    links: [{ label: 'Yanko Design Instagram', href: 'https://www.instagram.com/p/DYUYZzxMBa6/' }],
+  },
+  {
+    id: 'media-howtogeek',
+    lane: 'media',
+    date: '2026-07-03',
+    title: 'How-To Geek',
+    titleKo: '하우투긱 (How-To Geek)',
+    status: 'done',
+    level: 2,
+    detail:
+      'Included in How-To Geek\'s curated "Beautiful ESP32 Projects to Make This Weekend" round-up — a recommendation aimed at people deciding what to build, which is the audience that matters most for a project whose whole point is that you build it.',
+    detailKo:
+      'How-To Geek의 주말 추천 큐레이션 기사 "Beautiful ESP32 Projects to Make This Weekend"에 수록되었습니다. 이번 주말에 뭘 만들지 고르는 사람들을 향한 추천이고, 직접 만드는 것이 핵심인 프로젝트에는 가장 중요한 독자층입니다.',
+    links: [{ label: 'How-To Geek Article', href: 'https://www.howtogeek.com/beautiful-esp32-projects-to-make-this-weekend-jul-3-5/' }],
+  },
+  {
+    id: 'media-digikey-youtube',
+    lane: 'media',
+    date: '2026-07-09',
+    title: 'DigiKey YouTube',
+    titleKo: '디지키(DigiKey) 유튜브',
+    status: 'done',
+    level: 2,
+    detail:
+      'Covered on DigiKey\'s official YouTube channel — the open-source hardware architecture, the four-knob interface, and the panel in motion.',
+    detailKo:
+      '글로벌 전자부품 유통기업 디지키(DigiKey)의 공식 유튜브 채널에 소개되었습니다. 오픈소스 하드웨어 구조, 4개 노브 인터페이스, 그리고 실제로 움직이는 패널을 다뤘습니다.',
+    links: [{ label: 'DigiKey YouTube Video', href: 'https://www.youtube.com/watch?v=3Y-rTNgBq6w&t=18s' }],
+  },
+  {
+    id: 'media-video',
+    lane: 'media',
+    date: '2026-07-17',
+    title: 'Intro video',
+    titleKo: '소개 영상',
+    status: 'done',
+    level: 2,
+    detail:
+      'A two-minute introduction video, three days of work, made for the Crowd Supply campaign and posted to YouTube expecting reach. It did not get out of the low hundreds of views. The same footage with subtitles, posted to Instagram as an afterthought, did fine. A useful correction about where this project\'s audience actually lives.',
+    detailKo:
+      '3일을 들여 만든 2분짜리 소개 영상입니다. Crowd Supply 런칭에 쓸 영상이었고 유튜브에서 조회수가 나오길 기대했지만 세 자릿수도 넘기지 못했습니다. 같은 영상에 자막만 붙여 보너스처럼 올린 인스타그램 쪽이 오히려 괜찮은 성과를 냈습니다. 이 프로젝트의 관객이 실제로 어디 있는지에 대한 유용한 교정이었습니다.',
+    links: [{ label: 'Journal (I hope it works out)', href: 'https://patternflow.work/journal/i-hope-it-works-out' }],
+  },
+  {
+    id: 'media-can',
+    lane: 'media',
+    date: '2026-07-13',
+    title: 'Creative Applications',
+    titleKo: 'Creative Applications (CAN)',
+    status: 'done',
+    level: 1,
+    detail:
+      'Creative Applications Network ran "Patternflow – An open-source LED synthesizer reinterpreting Participation TV" — submitted on 3 July, published on the 13th. This one was asked for rather than picked up: CAN was the art-side magazine the author had wanted a piece in since long before there was anything to show it.',
+    detailKo:
+      'Creative Applications Network에 "Patternflow – An open-source LED synthesizer reinterpreting Participation TV"가 게재되었습니다. 7월 3일에 요청해 13일에 실렸습니다. 알아서 다뤄준 것이 아니라 직접 요청한 건입니다. CAN은 보여줄 것이 생기기 한참 전부터 선망하던 예술 쪽 매거진이었습니다.',
+    links: [{ label: 'Creative Applications Article', href: 'https://www.creativeapplications.net/news/patternflow-an-open-source-led-synthesizer-reinterpreting-participation-tv/' }],
   },
 ];
 
 export const EDGES: RoadmapEdge[] = [
-  { from: 'pcb-v22', to: 'case-v3', note: 'USB-C moved the power input — the case must follow' },
-  { from: 'biz-cs-150', to: 'biz-launch', note: '150 subscriber milestone unlocked launch prep' },
-  { from: 'fw-browser-build', to: 'community-discussions', note: 'in-browser build & flash feeds pattern sharing' },
+  { from: 'biz-exhibition', to: 'pcb-v22', note: 'the exhibited unit died — and the SMD parts turned out to be optional' },
+  { from: 'pcb-v3', to: 'case-v3', note: 'new board size and port positions — the case had to follow' },
+  { from: 'biz-cs-150', to: 'biz-launch', note: '150 subscribers unlocked launch prep' },
+  { from: 'fw-browser-build', to: 'community-discussions', note: 'build & flash in the browser makes sharing worth doing' },
+  { from: 'fw-modules', to: 'biz-market', note: 'a pattern installs in seconds — the precondition for licensing one' },
   { from: 'fw-resolution', to: 'biz-market', note: 'any panel, any size' },
   { from: 'tools-multiagent', to: 'biz-market', note: 'pattern quality at scale' },
 ];


### PR DESCRIPTION
## What

The project map at `/roadmap` had been dated partly from journal frontmatter. The journal is written as periodic catch-up posts — one entry covers weeks of work — so several nodes landed on the day the writing happened rather than the day the thing did. Every node now traces to a commit, a tag, a release note, or a date stated inside the prose. The sourcing rule is written at the top of the data file so the next pass has something to hold to.

## Corrections

Checked against CHANGELOG, git history, release notes, and all 20 journal entries:

- **Laser-cut acrylic** read as a clean first cut. The first cut got the tabs into each other but wasn't a usable case, and the revision drawn to fix it came out wrong — which is why the path is on hold.
- **USB-C** was "on hold, under investigation". It was withdrawn from service in 3.1.0 after a board smoked at a connector pin (#221).
- **Panel is 128×64 P2.5**, not 64×64 — in four places.
- **v2.1 routing** claimed 20MHz DMA EMI reduction; the commit says the tangled ESP32↔J1 area was re-routed, nothing about EMI.
- Dropped an **18% cost figure** and a **0.15mm tolerance** that appear in no source.
- **"v2.0.0 presets"** sat on 06-22 with filenames that didn't exist yet; v2.0.0 was tagged 05-11 and that work shipped in v2.1.0.
- **Firmware is MIT** — CC-BY-SA is the pattern licence.
- **Web Serial flashing was v1.1.0**, not v1.0.0.
- 160 Crowd Supply subscribers, and ~300k views was a projection.
- Three links pointed at tags that predate what they describe.

## Additions

Work that had no node at all: v3.2.0 loadable pattern modules, Pattern Lab v2, the v1.1.0 browser flasher, the first enclosure prototype, the panel compatibility guide, the knob rework, the exhibition, both incubator acceptances, the repo going public, the design filing, and the Origin-era tools. **40 nodes → 77.**

## Rendering fixes that fall out of it

- The today line and month ticks now read the real Seoul date at runtime (`useSyncExternalStore`, no hydration mismatch) instead of a constant that goes stale.
- The per-lane collision pass orders by **date** instead of by box edge. A wide title two days later was starting further left and resolving into the wrong sequence — on a timeline that is just wrong information.

## Verification

`tsc --noEmit` clean; `npm run lint` 0 errors (15 pre-existing warnings unchanged). Overview and detailed views both render, 77 nodes, 0 box overlaps, no console errors.

Known limit, unchanged by this PR: the time-scale anchors only cover 2026, so the today line pins to the right edge once the year rolls over.

🤖 Generated with [Claude Code](https://claude.com/claude-code)