### PR TITLE
Community: pattern visibility, shared decks, and in-app alerts

### DIFF
--- a/docs/COMMUNITY.md
+++ b/docs/COMMUNITY.md
@@ -222,6 +222,36 @@ What follows from a deck being somebody's arrangement:
 
 ---
 
+## Alerts
+
+In-app notifications — the header shows **Alerts (n)** while anything is
+unread, and `/community/notifications` lists them. Opening the page marks
+everything read.
+
+Four things produce one:
+
+| Event | Who hears about it |
+| :--- | :--- |
+| A comment on your pattern or post | you |
+| A comment on something you commented on earlier | everyone earlier in the thread |
+| Your pattern gets forked | you (private forks tell nobody — their page would 404) |
+| Your pattern enters someone's **public** deck | you (quieter decks tell nobody — the deck author chose not to list them) |
+
+The second row is what "reply to my comment" means on a flat thread — there is
+no comment threading, so participation in the thing is the unit.
+
+What it deliberately is not:
+
+- **Not email, not push.** Nothing leaves the site, ever — most accounts have
+  no real address, and the terms promise no mail. Delivery is the next page
+  load.
+- **Not a record.** The opposite of a report: deleting content deletes the
+  notifications about it, and the rest age out after 90 days, read or not.
+  Nobody is notified of their own actions, and repeat events (a deck flipping
+  visibility) are absorbed while the first row is unread.
+
+---
+
 ## Data and retention
 
 Written into the [terms](https://patternflow.work/terms), and enforced by a
@@ -234,6 +264,7 @@ first).
 | Verification tokens | Until they expire |
 | Build artifacts and build rows | **30 days** — they can always be rebuilt |
 | Unreferenced artifact files | Swept after a 24-hour grace window |
+| Notifications | **90 days**, read or not — and gone sooner if their subject is deleted |
 | Reports | Kept after the reported content is gone |
 | Patterns, decks, posts, comments | Until removed |
 
@@ -254,6 +285,7 @@ npm run check:moderation   # admin env parsing, report input
 npm run check:retention    # the sweep, against a throwaway database
 npm run check:deck         # deck cap, ordering, legacy migration
 npm run check:sharing      # visibility read paths, shared-deck rules, gaps
+npm run check:notify       # notification fan-out, cleanup, age-out
 ```
 
 They exist for the failures that are silent. A sweep that deletes too little
@@ -270,7 +302,7 @@ Listed because "is this missing or am I holding it wrong" deserves an answer.
 | :--- | :--- |
 | **Tags and search** | Not built. The feed sorts by new / most liked / most forked / in decks, and filters for hardware-ready. |
 | **Self-serve account deletion** | Not built. Requests go to the address in the terms and are handled by hand. Published patterns are anonymised rather than removed — the licence granted is irrevocable and others may have built on them. |
-| **Email of any kind** | Not sent, ever. No verification, no notifications, no password-reset mail. |
+| **Email of any kind** | Not sent, ever. No verification, no notification, no password-reset mail — alerts exist only inside the site. |
 | **Approval queue for new patterns** | Not built, and not currently wanted — moderation is after the fact. |
 | **Lineage tree view** | Not built. A fork links to its parent; there is no graph. |
 

--- a/docs/COMMUNITY.md
+++ b/docs/COMMUNITY.md
@@ -1,13 +1,14 @@
 # The Community — how it works, and what it does not do yet
 
 The pattern community at [community.patternflow.work](https://community.patternflow.work/community):
-publishing, forking, comments, moderation, and the deck you build onto a board.
+publishing, forking, comments, moderation, shared decks, and the deck you build
+onto a board.
 
 This page is the map. It says what exists, why some of it is shaped the way it
 is, and — at the bottom — what is deliberately missing, so nobody has to read
 the source to find out.
 
-**Last reviewed:** 29 July 2026
+**Last reviewed:** 1 August 2026
 
 ---
 
@@ -52,6 +53,35 @@ changed, which would make the port a lie.
 postMessage protocol). That boundary is what makes "edit anyone's pattern in
 the browser with no account" safe. The sandbox duplicates the pattern harness
 on purpose — keep the two in step when the pattern contract changes.
+
+### Visibility
+
+Three states, chosen at publish time and changeable afterwards from the
+pattern's page:
+
+| State | In the feed | Reachable by link | Who can open it |
+| :--- | :--- | :--- | :--- |
+| Public (default) | yes | yes | everyone |
+| Unlisted | no | yes | anyone with the link |
+| Private | no | no | the author |
+
+Unlisted is the one that earns its keep: it is how you show someone a pattern
+before posting it — and how a pattern can sit in a shared deck without being
+in the feed. Publishing still defaults to public, because the community works
+by things being shared.
+
+Details that follow from it:
+
+- A **private pattern cannot be forked** by anyone but its author — a fork
+  bakes a credit link into its source, and that link would 404 for every
+  reader. Unlisted patterns fork normally.
+- A pattern that goes private **after** being forked keeps its credit in the
+  fork's source (that cannot be edited away), but the fork's "forked from"
+  line drops the link.
+- Moderators can still open anything: visibility is not a shield from a
+  report.
+- Every listing query filters on visibility. When adding a new read path,
+  start from `feedVisible` in `queries.ts` — a missed filter is a leak.
 
 ### Licences
 
@@ -156,6 +186,40 @@ Saving works on any pattern. Building does not — a pattern with no firmware
 header has nothing to compile, so promoting it is refused with the reason
 rather than sending an empty file to the compiler.
 
+### Shared decks
+
+The working deck above stays browser state. **Sharing one is an explicit act**
+("Share deck" in the Deck panel): it stores a titled snapshot of the ids and
+their order, and gets a page at `/community/d/[id]` plus a listing under the
+community's **Decks** tab. Decks take the same three visibility states as
+patterns.
+
+Two rules carry the design:
+
+- **Two public decks per account.** A curation policy, not a technical limit —
+  the deliberate opposite of the build cap. Publishing a deck spends one of two
+  slots, so a published deck is staked reputation rather than overflow storage:
+  a shelf you must ration is a shelf you curate. Private and unlisted decks are
+  not rationed. (`PUBLIC_DECKS_MAX` — raising it is easy; lowering it would
+  strand people over the limit, which is why it starts small.)
+- **No private patterns in a shared deck.** Unlisted ones are welcome — that is
+  the "in a deck but not in the feed" state working as intended.
+
+What follows from a deck being somebody's arrangement:
+
+- A slot whose pattern was deleted, or made private since, renders as a **gap**
+  with the title it had — never a silently shorter set.
+- Every slot renders the pattern's own card, author byline included. The deck
+  is the arrangement; the patterns stay their authors'.
+- "Copy to my deck" loads a shared deck into the working deck, order intact, so
+  a shared deck is a starting point rather than a read-only artifact.
+- **"In decks" is a feed sort**: it counts how many *other* people put a
+  pattern in a public deck (distinct people, own decks excluded). It ranks
+  better than likes because it costs one of somebody's two slots.
+- Decks are reportable and moderator-deletable like everything else, and the
+  build path is untouched: a copied deck builds exactly as the working deck
+  always has.
+
 ---
 
 ## Data and retention
@@ -171,7 +235,7 @@ first).
 | Build artifacts and build rows | **30 days** — they can always be rebuilt |
 | Unreferenced artifact files | Swept after a 24-hour grace window |
 | Reports | Kept after the reported content is gone |
-| Patterns, posts, comments | Until removed |
+| Patterns, decks, posts, comments | Until removed |
 
 Changing a retention period means changing the constant in
 `web/src/lib/community/retention.ts` **and** the terms. Both, or the terms stop
@@ -189,6 +253,7 @@ npm run check:license      # licence headers, fork compatibility, downloads
 npm run check:moderation   # admin env parsing, report input
 npm run check:retention    # the sweep, against a throwaway database
 npm run check:deck         # deck cap, ordering, legacy migration
+npm run check:sharing      # visibility read paths, shared-deck rules, gaps
 ```
 
 They exist for the failures that are silent. A sweep that deletes too little
@@ -203,9 +268,7 @@ Listed because "is this missing or am I holding it wrong" deserves an answer.
 
 | | Status |
 | :--- | :--- |
-| **Pattern visibility (public / private)** | Not built. Everything published is public immediately. Tracked as an issue. |
-| **Shareable decks** | Not built. A deck lives in one browser and cannot be sent to anyone. Tracked as an issue. |
-| **Tags and search** | Not built. The feed sorts by new / most liked / most forked, and filters for hardware-ready. |
+| **Tags and search** | Not built. The feed sorts by new / most liked / most forked / in decks, and filters for hardware-ready. |
 | **Self-serve account deletion** | Not built. Requests go to the address in the terms and are handled by hand. Published patterns are anonymised rather than removed — the licence granted is irrevocable and others may have built on them. |
 | **Email of any kind** | Not sent, ever. No verification, no notifications, no password-reset mail. |
 | **Approval queue for new patterns** | Not built, and not currently wanted — moderation is after the fact. |

--- a/web/drizzle/0009_add-visibility-and-decks.sql
+++ b/web/drizzle/0009_add-visibility-and-decks.sql
@@ -1,0 +1,25 @@
+CREATE TABLE `deck_patterns` (
+	`deck_id` text NOT NULL,
+	`pattern_id` text NOT NULL,
+	`position` integer NOT NULL,
+	`title_snapshot` text NOT NULL,
+	PRIMARY KEY(`deck_id`, `pattern_id`),
+	FOREIGN KEY (`deck_id`) REFERENCES `decks`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `deck_patterns_pattern_id_idx` ON `deck_patterns` (`pattern_id`);--> statement-breakpoint
+CREATE TABLE `decks` (
+	`id` text PRIMARY KEY NOT NULL,
+	`user_id` text NOT NULL,
+	`title` text NOT NULL,
+	`description` text,
+	`visibility` text DEFAULT 'private' NOT NULL,
+	`created_at` integer NOT NULL,
+	`updated_at` integer NOT NULL,
+	FOREIGN KEY (`user_id`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `decks_user_id_idx` ON `decks` (`user_id`);--> statement-breakpoint
+CREATE INDEX `decks_visibility_created_idx` ON `decks` (`visibility`,`created_at`);--> statement-breakpoint
+ALTER TABLE `patterns` ADD `visibility` text DEFAULT 'public' NOT NULL;--> statement-breakpoint
+CREATE INDEX `patterns_visibility_created_idx` ON `patterns` (`visibility`,`created_at`);

--- a/web/drizzle/0010_add-notifications.sql
+++ b/web/drizzle/0010_add-notifications.sql
@@ -1,0 +1,19 @@
+CREATE TABLE `notifications` (
+	`id` text PRIMARY KEY NOT NULL,
+	`user_id` text NOT NULL,
+	`type` text NOT NULL,
+	`actor_id` text NOT NULL,
+	`target_type` text NOT NULL,
+	`target_id` text NOT NULL,
+	`target_title` text NOT NULL,
+	`source_id` text,
+	`snippet` text,
+	`read_at` integer,
+	`created_at` integer NOT NULL,
+	FOREIGN KEY (`user_id`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`actor_id`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `notifications_user_created_idx` ON `notifications` (`user_id`,`created_at`);--> statement-breakpoint
+CREATE INDEX `notifications_target_idx` ON `notifications` (`target_type`,`target_id`);--> statement-breakpoint
+CREATE INDEX `notifications_source_idx` ON `notifications` (`source_id`);

--- a/web/drizzle/meta/0009_snapshot.json
+++ b/web/drizzle/meta/0009_snapshot.json
@@ -1,0 +1,1253 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "950fcdda-1e22-4f09-8e1e-6829a89f461c",
+  "prevId": "994083f5-5d6a-4a9e-8b7c-449c978bde6d",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "builds": {
+      "name": "builds",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'queued'"
+        },
+        "format": {
+          "name": "format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'bin'"
+        },
+        "patterns": {
+          "name": "patterns",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "namespaces": {
+          "name": "namespaces",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "artifact": {
+          "name": "artifact",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "artifact_bytes": {
+          "name": "artifact_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "worker": {
+          "name": "worker",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "builds_status_created_idx": {
+          "name": "builds_status_created_idx",
+          "columns": [
+            "status",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "builds_user_id_idx": {
+          "name": "builds_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "builds_user_id_user_id_fk": {
+          "name": "builds_user_id_user_id_fk",
+          "tableFrom": "builds",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "comments": {
+      "name": "comments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pattern_id": {
+          "name": "pattern_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "edited_at": {
+          "name": "edited_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "comments_pattern_id_idx": {
+          "name": "comments_pattern_id_idx",
+          "columns": [
+            "pattern_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "comments_pattern_id_patterns_id_fk": {
+          "name": "comments_pattern_id_patterns_id_fk",
+          "tableFrom": "comments",
+          "tableTo": "patterns",
+          "columnsFrom": [
+            "pattern_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "comments_user_id_user_id_fk": {
+          "name": "comments_user_id_user_id_fk",
+          "tableFrom": "comments",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "deck_patterns": {
+      "name": "deck_patterns",
+      "columns": {
+        "deck_id": {
+          "name": "deck_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pattern_id": {
+          "name": "pattern_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title_snapshot": {
+          "name": "title_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "deck_patterns_pattern_id_idx": {
+          "name": "deck_patterns_pattern_id_idx",
+          "columns": [
+            "pattern_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "deck_patterns_deck_id_decks_id_fk": {
+          "name": "deck_patterns_deck_id_decks_id_fk",
+          "tableFrom": "deck_patterns",
+          "tableTo": "decks",
+          "columnsFrom": [
+            "deck_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "deck_patterns_deck_id_pattern_id_pk": {
+          "columns": [
+            "deck_id",
+            "pattern_id"
+          ],
+          "name": "deck_patterns_deck_id_pattern_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "decks": {
+      "name": "decks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'private'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "decks_user_id_idx": {
+          "name": "decks_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "decks_visibility_created_idx": {
+          "name": "decks_visibility_created_idx",
+          "columns": [
+            "visibility",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "decks_user_id_user_id_fk": {
+          "name": "decks_user_id_user_id_fk",
+          "tableFrom": "decks",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "likes": {
+      "name": "likes",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pattern_id": {
+          "name": "pattern_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "likes_pattern_id_idx": {
+          "name": "likes_pattern_id_idx",
+          "columns": [
+            "pattern_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "likes_user_id_user_id_fk": {
+          "name": "likes_user_id_user_id_fk",
+          "tableFrom": "likes",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "likes_pattern_id_patterns_id_fk": {
+          "name": "likes_pattern_id_patterns_id_fk",
+          "tableFrom": "likes",
+          "tableTo": "patterns",
+          "columnsFrom": [
+            "pattern_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "likes_user_id_pattern_id_pk": {
+          "columns": [
+            "user_id",
+            "pattern_id"
+          ],
+          "name": "likes_user_id_pattern_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "patterns": {
+      "name": "patterns",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code_cpp": {
+          "name": "code_cpp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "license": {
+          "name": "license",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'CC-BY-SA-4.0'"
+        },
+        "made_on": {
+          "name": "made_on",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "made_how": {
+          "name": "made_how",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'public'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "patterns_created_at_idx": {
+          "name": "patterns_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "patterns_user_id_idx": {
+          "name": "patterns_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "patterns_visibility_created_idx": {
+          "name": "patterns_visibility_created_idx",
+          "columns": [
+            "visibility",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "patterns_user_id_user_id_fk": {
+          "name": "patterns_user_id_user_id_fk",
+          "tableFrom": "patterns",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "patterns_parent_id_patterns_id_fk": {
+          "name": "patterns_parent_id_patterns_id_fk",
+          "tableFrom": "patterns",
+          "tableTo": "patterns",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "post_comments": {
+      "name": "post_comments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "edited_at": {
+          "name": "edited_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "post_comments_post_id_idx": {
+          "name": "post_comments_post_id_idx",
+          "columns": [
+            "post_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "post_comments_post_id_posts_id_fk": {
+          "name": "post_comments_post_id_posts_id_fk",
+          "tableFrom": "post_comments",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_comments_user_id_user_id_fk": {
+          "name": "post_comments_user_id_user_id_fk",
+          "tableFrom": "post_comments",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "posts": {
+      "name": "posts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "posts_created_at_idx": {
+          "name": "posts_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "posts_user_id_idx": {
+          "name": "posts_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "posts_user_id_user_id_fk": {
+          "name": "posts_user_id_user_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "reports": {
+      "name": "reports",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_title": {
+          "name": "target_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "target_user_id": {
+          "name": "target_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reporter_id": {
+          "name": "reporter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'open'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "reports_status_created_idx": {
+          "name": "reports_status_created_idx",
+          "columns": [
+            "status",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "reports_target_user_idx": {
+          "name": "reports_target_user_idx",
+          "columns": [
+            "target_user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "reports_reporter_id_user_id_fk": {
+          "name": "reports_reporter_id_user_id_fk",
+          "tableFrom": "reports",
+          "tableTo": "user",
+          "columnsFrom": [
+            "reporter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "display_username": {
+          "name": "display_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        },
+        "user_username_unique": {
+          "name": "user_username_unique",
+          "columns": [
+            "username"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/web/drizzle/meta/0010_snapshot.json
+++ b/web/drizzle/meta/0010_snapshot.json
@@ -1,0 +1,1391 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "b3a70742-e4d3-4514-a5d0-4a0b1d638bb7",
+  "prevId": "950fcdda-1e22-4f09-8e1e-6829a89f461c",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "builds": {
+      "name": "builds",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'queued'"
+        },
+        "format": {
+          "name": "format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'bin'"
+        },
+        "patterns": {
+          "name": "patterns",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "namespaces": {
+          "name": "namespaces",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "artifact": {
+          "name": "artifact",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "artifact_bytes": {
+          "name": "artifact_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "worker": {
+          "name": "worker",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "builds_status_created_idx": {
+          "name": "builds_status_created_idx",
+          "columns": [
+            "status",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "builds_user_id_idx": {
+          "name": "builds_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "builds_user_id_user_id_fk": {
+          "name": "builds_user_id_user_id_fk",
+          "tableFrom": "builds",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "comments": {
+      "name": "comments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pattern_id": {
+          "name": "pattern_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "edited_at": {
+          "name": "edited_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "comments_pattern_id_idx": {
+          "name": "comments_pattern_id_idx",
+          "columns": [
+            "pattern_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "comments_pattern_id_patterns_id_fk": {
+          "name": "comments_pattern_id_patterns_id_fk",
+          "tableFrom": "comments",
+          "tableTo": "patterns",
+          "columnsFrom": [
+            "pattern_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "comments_user_id_user_id_fk": {
+          "name": "comments_user_id_user_id_fk",
+          "tableFrom": "comments",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "deck_patterns": {
+      "name": "deck_patterns",
+      "columns": {
+        "deck_id": {
+          "name": "deck_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pattern_id": {
+          "name": "pattern_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title_snapshot": {
+          "name": "title_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "deck_patterns_pattern_id_idx": {
+          "name": "deck_patterns_pattern_id_idx",
+          "columns": [
+            "pattern_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "deck_patterns_deck_id_decks_id_fk": {
+          "name": "deck_patterns_deck_id_decks_id_fk",
+          "tableFrom": "deck_patterns",
+          "tableTo": "decks",
+          "columnsFrom": [
+            "deck_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "deck_patterns_deck_id_pattern_id_pk": {
+          "columns": [
+            "deck_id",
+            "pattern_id"
+          ],
+          "name": "deck_patterns_deck_id_pattern_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "decks": {
+      "name": "decks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'private'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "decks_user_id_idx": {
+          "name": "decks_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "decks_visibility_created_idx": {
+          "name": "decks_visibility_created_idx",
+          "columns": [
+            "visibility",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "decks_user_id_user_id_fk": {
+          "name": "decks_user_id_user_id_fk",
+          "tableFrom": "decks",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "likes": {
+      "name": "likes",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pattern_id": {
+          "name": "pattern_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "likes_pattern_id_idx": {
+          "name": "likes_pattern_id_idx",
+          "columns": [
+            "pattern_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "likes_user_id_user_id_fk": {
+          "name": "likes_user_id_user_id_fk",
+          "tableFrom": "likes",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "likes_pattern_id_patterns_id_fk": {
+          "name": "likes_pattern_id_patterns_id_fk",
+          "tableFrom": "likes",
+          "tableTo": "patterns",
+          "columnsFrom": [
+            "pattern_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "likes_user_id_pattern_id_pk": {
+          "columns": [
+            "user_id",
+            "pattern_id"
+          ],
+          "name": "likes_user_id_pattern_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "notifications": {
+      "name": "notifications",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_title": {
+          "name": "target_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "snippet": {
+          "name": "snippet",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "notifications_user_created_idx": {
+          "name": "notifications_user_created_idx",
+          "columns": [
+            "user_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "notifications_target_idx": {
+          "name": "notifications_target_idx",
+          "columns": [
+            "target_type",
+            "target_id"
+          ],
+          "isUnique": false
+        },
+        "notifications_source_idx": {
+          "name": "notifications_source_idx",
+          "columns": [
+            "source_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "notifications_user_id_user_id_fk": {
+          "name": "notifications_user_id_user_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notifications_actor_id_user_id_fk": {
+          "name": "notifications_actor_id_user_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "user",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "patterns": {
+      "name": "patterns",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code_cpp": {
+          "name": "code_cpp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "license": {
+          "name": "license",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'CC-BY-SA-4.0'"
+        },
+        "made_on": {
+          "name": "made_on",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "made_how": {
+          "name": "made_how",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'public'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "patterns_created_at_idx": {
+          "name": "patterns_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "patterns_user_id_idx": {
+          "name": "patterns_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "patterns_visibility_created_idx": {
+          "name": "patterns_visibility_created_idx",
+          "columns": [
+            "visibility",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "patterns_user_id_user_id_fk": {
+          "name": "patterns_user_id_user_id_fk",
+          "tableFrom": "patterns",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "patterns_parent_id_patterns_id_fk": {
+          "name": "patterns_parent_id_patterns_id_fk",
+          "tableFrom": "patterns",
+          "tableTo": "patterns",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "post_comments": {
+      "name": "post_comments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "edited_at": {
+          "name": "edited_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "post_comments_post_id_idx": {
+          "name": "post_comments_post_id_idx",
+          "columns": [
+            "post_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "post_comments_post_id_posts_id_fk": {
+          "name": "post_comments_post_id_posts_id_fk",
+          "tableFrom": "post_comments",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_comments_user_id_user_id_fk": {
+          "name": "post_comments_user_id_user_id_fk",
+          "tableFrom": "post_comments",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "posts": {
+      "name": "posts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "posts_created_at_idx": {
+          "name": "posts_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "posts_user_id_idx": {
+          "name": "posts_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "posts_user_id_user_id_fk": {
+          "name": "posts_user_id_user_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "reports": {
+      "name": "reports",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_title": {
+          "name": "target_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "target_user_id": {
+          "name": "target_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reporter_id": {
+          "name": "reporter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'open'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "reports_status_created_idx": {
+          "name": "reports_status_created_idx",
+          "columns": [
+            "status",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "reports_target_user_idx": {
+          "name": "reports_target_user_idx",
+          "columns": [
+            "target_user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "reports_reporter_id_user_id_fk": {
+          "name": "reports_reporter_id_user_id_fk",
+          "tableFrom": "reports",
+          "tableTo": "user",
+          "columnsFrom": [
+            "reporter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "display_username": {
+          "name": "display_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        },
+        "user_username_unique": {
+          "name": "user_username_unique",
+          "columns": [
+            "username"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/web/drizzle/meta/_journal.json
+++ b/web/drizzle/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1785321984220,
       "tag": "0008_add-comment-edited",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "6",
+      "when": 1785535849348,
+      "tag": "0009_add-visibility-and-decks",
+      "breakpoints": true
     }
   ]
 }

--- a/web/drizzle/meta/_journal.json
+++ b/web/drizzle/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1785535849348,
       "tag": "0009_add-visibility-and-decks",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "6",
+      "when": 1785537782506,
+      "tag": "0010_add-notifications",
+      "breakpoints": true
     }
   ]
 }

--- a/web/package.json
+++ b/web/package.json
@@ -17,7 +17,8 @@
     "check:retention": "tsx scripts/retention-smoke.ts",
     "sweep": "tsx scripts/retention-sweep.ts",
     "check:deck": "tsx scripts/deck-smoke.ts",
-    "check:sharing": "tsx scripts/sharing-smoke.ts"
+    "check:sharing": "tsx scripts/sharing-smoke.ts",
+    "check:notify": "tsx scripts/notify-smoke.ts"
   },
   "dependencies": {
     "@chenglou/pretext": "^0.0.6",

--- a/web/package.json
+++ b/web/package.json
@@ -16,7 +16,8 @@
     "check:moderation": "tsx scripts/moderation-smoke.ts",
     "check:retention": "tsx scripts/retention-smoke.ts",
     "sweep": "tsx scripts/retention-sweep.ts",
-    "check:deck": "tsx scripts/deck-smoke.ts"
+    "check:deck": "tsx scripts/deck-smoke.ts",
+    "check:sharing": "tsx scripts/sharing-smoke.ts"
   },
   "dependencies": {
     "@chenglou/pretext": "^0.0.6",

--- a/web/scripts/notify-smoke.ts
+++ b/web/scripts/notify-smoke.ts
@@ -1,0 +1,309 @@
+/**
+ * Notification smoke test — `npm run check:notify`.
+ *
+ * Against a throwaway SQLite file. What this guards: fan-out picks exactly the
+ * right recipients (never the actor, never twice per event), cleanup means a
+ * notification never outlives its subject, the read path drops rows whose
+ * target went private, and the sweep keeps the 90-day promise in /terms.
+ */
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+// The database is a lazy singleton keyed off this variable, so it has to be set
+// before anything imports it — hence the dynamic imports below.
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "pf-notify-"));
+process.env.COMMUNITY_DB_PATH = path.join(tmp, "test.db");
+process.env.COMMUNITY_ENABLED = "1";
+
+const DAY = 24 * 60 * 60 * 1000;
+const NOW = new Date("2026-08-01T12:00:00Z");
+const ago = (days: number) => new Date(NOW.getTime() - days * DAY);
+
+let failures = 0;
+
+function check(label: string, actual: unknown, expected: unknown) {
+  const ok = JSON.stringify(actual) === JSON.stringify(expected);
+  if (!ok) failures += 1;
+  console.log(
+    `${ok ? "  ok  " : "FAIL  "}${label}${ok ? "" : `\n        got ${JSON.stringify(actual)}\n        want ${JSON.stringify(expected)}`}`,
+  );
+}
+
+async function main() {
+  const { eq } = await import("drizzle-orm");
+  const { getDb } = await import("../src/lib/community/db");
+  const schema = await import("../src/lib/community/schema");
+  const queries = await import("../src/lib/community/queries");
+  const notify = await import("../src/lib/community/notify");
+  const { sweepRetention } = await import("../src/lib/community/retention");
+
+  const db = getDb();
+
+  // ── Seed ───────────────────────────────────────────────────────────────────
+  const person = (id: string) => ({
+    id,
+    name: id,
+    email: `${id}@patternflow.local`,
+    emailVerified: false,
+    createdAt: ago(30),
+    updatedAt: ago(30),
+    username: id,
+    displayUsername: id,
+  });
+  await db.insert(schema.user).values([person("alice"), person("bob"), person("cara")]);
+
+  await db.insert(schema.patterns).values([
+    {
+      id: "p1",
+      userId: "alice",
+      title: "Alice One",
+      code: "// p1",
+      license: "CC-BY-SA-4.0",
+      visibility: "public",
+      createdAt: ago(10),
+      updatedAt: ago(10),
+    },
+    {
+      id: "p-bob",
+      userId: "bob",
+      title: "Bob Own",
+      code: "// pb",
+      license: "CC-BY-SA-4.0",
+      visibility: "public",
+      createdAt: ago(10),
+      updatedAt: ago(10),
+    },
+  ]);
+  await db.insert(schema.posts).values({
+    id: "t1",
+    userId: "alice",
+    title: "Alice Thread",
+    body: "hello",
+    createdAt: ago(10),
+    updatedAt: ago(10),
+  });
+
+  // Mirrors the route: insert the comment, then fan out.
+  const comment = async (id: string, actor: string, body: string) => {
+    await db.insert(schema.comments).values({
+      id,
+      patternId: "p1",
+      userId: actor,
+      body,
+      createdAt: NOW,
+    });
+    await notify.notifyCommentAdded({
+      on: "pattern",
+      targetId: "p1",
+      targetTitle: "Alice One",
+      ownerId: "alice",
+      actorId: actor,
+      commentId: id,
+      body,
+    });
+  };
+
+  console.log("\n── comment fan-out on a flat thread ──");
+  await comment("c1", "bob", "first!");
+  check("the owner hears about the first comment", await queries.countUnreadNotifications("alice"), 1);
+  check("the actor hears nothing", await queries.countUnreadNotifications("bob"), 0);
+
+  await comment("c2", "cara", "second");
+  check("the owner hears again", await queries.countUnreadNotifications("alice"), 2);
+  check("the earlier commenter hears the thread moved", await queries.countUnreadNotifications("bob"), 1);
+
+  await comment("c3", "alice", "thanks both");
+  check("the owner never hears about their own comment", await queries.countUnreadNotifications("alice"), 2);
+  check("both earlier commenters hear it", [
+    await queries.countUnreadNotifications("bob"),
+    await queries.countUnreadNotifications("cara"),
+  ], [2, 1]);
+
+  const bobRows = await queries.listNotifications("bob");
+  check("thread rows say so", bobRows.map((row) => row.type), ["thread", "thread"]);
+  check("and carry the snippet", bobRows[0]?.snippet, "thanks both");
+
+  console.log("\n── post comments use the same path ──");
+  await db.insert(schema.postComments).values({
+    id: "pc1",
+    postId: "t1",
+    userId: "bob",
+    body: "post reply",
+    createdAt: NOW,
+  });
+  await notify.notifyCommentAdded({
+    on: "post",
+    targetId: "t1",
+    targetTitle: "Alice Thread",
+    ownerId: "alice",
+    actorId: "bob",
+    commentId: "pc1",
+    body: "post reply",
+  });
+  check("the post's author hears it", await queries.countUnreadNotifications("alice"), 3);
+  check(
+    "the row points at the post",
+    (await queries.listNotifications("alice"))[0]?.targetType,
+    "post",
+  );
+
+  console.log("\n── forks ──");
+  // The route inserts the fork before notifying, so the row's target exists —
+  // the read path drops rows whose target is missing, and that guard is
+  // exercised separately below.
+  await db.insert(schema.patterns).values({
+    id: "p-fork",
+    userId: "bob",
+    title: "Alice One remix",
+    code: "// fork",
+    license: "CC-BY-SA-4.0",
+    visibility: "public",
+    parentId: "p1",
+    createdAt: NOW,
+    updatedAt: NOW,
+  });
+  await notify.notifyForkPublished({
+    parentOwnerId: "alice",
+    parentTitle: "Alice One",
+    forkId: "p-fork",
+    forkVisibility: "public",
+    actorId: "bob",
+  });
+  check("a public fork tells the parent's author", await queries.countUnreadNotifications("alice"), 4);
+  await notify.notifyForkPublished({
+    parentOwnerId: "alice",
+    parentTitle: "Alice One",
+    forkId: "p-fork2",
+    forkVisibility: "private",
+    actorId: "bob",
+  });
+  check("a private fork tells nobody — its page would 404", await queries.countUnreadNotifications("alice"), 4);
+  await notify.notifyForkPublished({
+    parentOwnerId: "alice",
+    parentTitle: "Alice One",
+    forkId: "p-fork3",
+    forkVisibility: "public",
+    actorId: "alice",
+  });
+  check("forking your own work tells nobody", await queries.countUnreadNotifications("alice"), 4);
+
+  console.log("\n── deck inclusion ──");
+  await db.insert(schema.decks).values({
+    id: "d1",
+    userId: "bob",
+    title: "Bob's Shelf",
+    visibility: "public",
+    createdAt: NOW,
+    updatedAt: NOW,
+  });
+  const deckPatterns = [
+    { id: "p1", title: "Alice One", userId: "alice" },
+    { id: "p-bob", title: "Bob Own", userId: "bob" },
+  ];
+  await notify.notifyDeckInclusion({
+    deckId: "d1",
+    deckTitle: "Bob's Shelf",
+    actorId: "bob",
+    patterns: deckPatterns,
+  });
+  check("the pattern's author hears it", await queries.countUnreadNotifications("alice"), 5);
+  check("the deck owner's own pattern tells nobody", await queries.countUnreadNotifications("bob"), 2);
+  await notify.notifyDeckInclusion({
+    deckId: "d1",
+    deckTitle: "Bob's Shelf",
+    actorId: "bob",
+    patterns: deckPatterns,
+  });
+  check("repeating the event while unread is absorbed", await queries.countUnreadNotifications("alice"), 5);
+
+  console.log("\n── reading ──");
+  await queries.markNotificationsRead("alice");
+  check("opening the page reads everything", await queries.countUnreadNotifications("alice"), 0);
+  check("the rows themselves stay", (await queries.listNotifications("alice")).length, 5);
+
+  console.log("\n── the read path respects visibility ──");
+  await db.update(schema.patterns).set({ visibility: "private" }).where(eq(schema.patterns.id, "p1"));
+  check(
+    "rows about a now-private pattern vanish for others",
+    (await queries.listNotifications("cara")).length,
+    0,
+  );
+  check(
+    "but its own author keeps theirs",
+    (await queries.listNotifications("alice")).some((row) => row.targetId === "p1"),
+    true,
+  );
+  await db.update(schema.patterns).set({ visibility: "public" }).where(eq(schema.patterns.id, "p1"));
+  check("and they return when it does", (await queries.listNotifications("cara")).length, 1);
+
+  await db.update(schema.decks).set({ visibility: "private" }).where(eq(schema.decks.id, "d1"));
+  check(
+    "a deck gone private hides its inclusion row",
+    (await queries.listNotifications("alice")).some((row) => row.targetType === "deck"),
+    false,
+  );
+  await db.update(schema.decks).set({ visibility: "public" }).where(eq(schema.decks.id, "d1"));
+
+  console.log("\n── cleanup — a notification never outlives its subject ──");
+  await notify.clearNotificationsFor({ sourceId: "c3" });
+  check(
+    "deleting a comment takes its rows (bob's thread ping)",
+    (await queries.listNotifications("bob")).map((row) => row.snippet),
+    ["second"],
+  );
+  await notify.clearNotificationsFor({ targetType: "deck", targetId: "d1" });
+  check(
+    "deleting the deck takes the inclusion row",
+    (await queries.listNotifications("alice")).some((row) => row.targetType === "deck"),
+    false,
+  );
+  await notify.clearNotificationsFor({ targetType: "pattern", targetId: "p1", sourceId: "p1" });
+  check(
+    "deleting the pattern takes everything that pointed at it",
+    (await queries.listNotifications("cara")).length,
+    0,
+  );
+
+  console.log("\n── the sweep keeps the 90-day promise ──");
+  await db.insert(schema.notifications).values([
+    {
+      id: "n-old",
+      userId: "alice",
+      type: "comment",
+      actorId: "bob",
+      targetType: "post",
+      targetId: "t1",
+      targetTitle: "Alice Thread",
+      createdAt: ago(91),
+    },
+    {
+      id: "n-new",
+      userId: "alice",
+      type: "comment",
+      actorId: "bob",
+      targetType: "post",
+      targetId: "t1",
+      targetTitle: "Alice Thread",
+      createdAt: ago(1),
+    },
+  ]);
+  const swept = await sweepRetention(NOW);
+  check("ninety-one days is over the line", swept.oldNotifications, 1);
+  const left = await db.select({ id: schema.notifications.id }).from(schema.notifications);
+  check("yesterday's survives", left.some((row) => row.id === "n-new"), true);
+  check("no sweep errors", swept.errors, []);
+}
+
+main()
+  .then(() => {
+    console.log(failures === 0 ? "\nAll notify checks passed.\n" : `\n${failures} check(s) FAILED.\n`);
+    process.exit(failures === 0 ? 0 : 1);
+  })
+  .catch((error: unknown) => {
+    console.error(error);
+    process.exit(1);
+  })
+  .finally(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });

--- a/web/scripts/sharing-smoke.ts
+++ b/web/scripts/sharing-smoke.ts
@@ -1,0 +1,272 @@
+/**
+ * Sharing smoke test — `npm run check:sharing`.
+ *
+ * Pattern visibility (#255) and shared decks (#256), against a throwaway
+ * SQLite file. What this really guards: the feed and profile queries all read
+ * the same `patterns` table that now holds unlisted and private rows, so one
+ * missed filter is a leak — and the deck rules (two public slots, no private
+ * patterns in a shared deck, gaps instead of silent shortening) are the whole
+ * design, so they are pinned here rather than hoped for.
+ */
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+// The database is a lazy singleton keyed off this variable, so it has to be set
+// before anything imports it — hence the dynamic imports below.
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "pf-sharing-"));
+process.env.COMMUNITY_DB_PATH = path.join(tmp, "test.db");
+process.env.COMMUNITY_ENABLED = "1";
+
+const at = (day: number) => new Date(Date.UTC(2026, 6, day, 12, 0, 0));
+
+let failures = 0;
+
+function check(label: string, actual: unknown, expected: unknown) {
+  const ok = JSON.stringify(actual) === JSON.stringify(expected);
+  if (!ok) failures += 1;
+  console.log(
+    `${ok ? "  ok  " : "FAIL  "}${label}${ok ? "" : `\n        got ${JSON.stringify(actual)}\n        want ${JSON.stringify(expected)}`}`,
+  );
+}
+
+async function main() {
+  const { getDb } = await import("../src/lib/community/db");
+  const schema = await import("../src/lib/community/schema");
+  const queries = await import("../src/lib/community/queries");
+  const { canView, forkBlocked } = await import("../src/lib/community/visibility");
+  const { checkDeckPattern, cleanPatternIds } = await import("../src/lib/community/deckShare");
+  const { PUBLIC_DECKS_MAX } = await import("../src/lib/community/deck");
+
+  const db = getDb();
+
+  // ── Seed: two authors, one bystander ──────────────────────────────────────
+  const person = (id: string, n: number) => ({
+    id,
+    name: id,
+    email: `${id}@patternflow.local`,
+    emailVerified: false,
+    createdAt: at(n),
+    updatedAt: at(n),
+    username: id,
+    displayUsername: id,
+  });
+  await db.insert(schema.user).values([person("alice", 1), person("bob", 1), person("cara", 1)]);
+
+  const pattern = (
+    id: string,
+    userId: string,
+    visibility: string,
+    day: number,
+    codeCpp: string | null = null,
+  ) => ({
+    id,
+    userId,
+    title: `Pattern ${id}`,
+    code: `// ${id}`,
+    codeCpp,
+    license: "CC-BY-SA-4.0",
+    visibility,
+    createdAt: at(day),
+    updatedAt: at(day),
+  });
+  await db.insert(schema.patterns).values([
+    pattern("p-pub", "alice", "public", 2, "#pragma once"),
+    pattern("p-unl", "alice", "unlisted", 3),
+    pattern("p-priv", "alice", "private", 4),
+    pattern("p-bob", "bob", "public", 5),
+    pattern("p-g1", "alice", "public", 6),
+    pattern("p-g2", "alice", "unlisted", 7),
+  ]);
+
+  console.log("\n── the feed shows public only ──");
+  const feed = await queries.listFeed();
+  check(
+    "unlisted and private are not in the feed",
+    feed.map((item) => item.id).sort(),
+    ["p-bob", "p-g1", "p-pub"],
+  );
+  check("the count agrees with the list", await queries.countFeed(), 3);
+  check(
+    "the hardware filter stays inside the visible set",
+    (await queries.listFeed({ hardwareOnly: true })).map((item) => item.id),
+    ["p-pub"],
+  );
+
+  console.log("\n── a profile is the whole archive only to its owner ──");
+  check(
+    "the owner sees all three states",
+    (await queries.listPatternsByUser("alice", "alice")).map((i) => i.id).sort(),
+    ["p-g1", "p-g2", "p-priv", "p-pub", "p-unl"].sort(),
+  );
+  check(
+    "a visitor sees public only",
+    (await queries.listPatternsByUser("alice", "bob")).map((i) => i.id).sort(),
+    ["p-g1", "p-pub"],
+  );
+  check(
+    "signed-out sees public only",
+    (await queries.listPatternsByUser("alice", null)).map((i) => i.id).sort(),
+    ["p-g1", "p-pub"],
+  );
+
+  console.log("\n── who may open what ──");
+  check("public opens for anyone", canView("public", "alice", null), true);
+  check("unlisted opens by link for anyone", canView("unlisted", "alice", null), true);
+  check("private is a 404 to a stranger", canView("private", "alice", "bob"), false);
+  check("private opens for its author", canView("private", "alice", "alice"), true);
+  check("a moderator keeps sight of everything", canView("private", "alice", "mod", true), true);
+
+  console.log("\n── forking respects visibility ──");
+  const priv = { visibility: "private", userId: "alice" };
+  check("nobody forks someone else's private work", forkBlocked(priv, "bob"), true);
+  check("the author may fork their own", forkBlocked(priv, "alice"), false);
+  check("unlisted is forkable — its credit link resolves", forkBlocked({ visibility: "unlisted", userId: "alice" }, "bob"), false);
+
+  console.log("\n── what a deck submission accepts ──");
+  check("no patterns is not a deck", cleanPatternIds([]), null);
+  check("eleven patterns is not a deck", cleanPatternIds(Array.from({ length: 11 }, (_, i) => `p${i}`)), null);
+  check("duplicates are refused", cleanPatternIds(["a", "a"]), null);
+  check("a real list passes through", cleanPatternIds(["a", "b"]), ["a", "b"]);
+
+  const stub = (visibility: string, userId: string) => ({ title: "T", userId, visibility });
+  check("a missing pattern is unavailable", checkDeckPattern(undefined, "public", "alice").ok, false);
+  check(
+    "someone else's private answers exactly like missing",
+    checkDeckPattern(stub("private", "alice"), "public", "bob"),
+    { ok: false, reason: "unavailable" },
+  );
+  check(
+    "your own private cannot enter a shared deck",
+    checkDeckPattern(stub("private", "alice"), "public", "alice"),
+    { ok: false, reason: "private", title: "T" },
+  );
+  check(
+    "…but sits fine in a private deck",
+    checkDeckPattern(stub("private", "alice"), "private", "alice").ok,
+    true,
+  );
+  check(
+    "unlisted in a public deck is the intended path",
+    checkDeckPattern(stub("unlisted", "alice"), "public", "bob").ok,
+    true,
+  );
+
+  // ── Seed decks ─────────────────────────────────────────────────────────────
+  const deck = (id: string, userId: string, visibility: string, day: number) => ({
+    id,
+    userId,
+    title: `Deck ${id}`,
+    visibility,
+    createdAt: at(day),
+    updatedAt: at(day),
+  });
+  await db.insert(schema.decks).values([
+    deck("d-alice", "alice", "public", 10),
+    deck("d-alice-priv", "alice", "private", 11),
+    deck("d-bob-1", "bob", "public", 12),
+    deck("d-bob-2", "bob", "public", 13),
+    deck("d-cara-unl", "cara", "unlisted", 14),
+    deck("d-gap", "alice", "public", 15),
+  ]);
+  const slot = (deckId: string, patternId: string, position: number) => ({
+    deckId,
+    patternId,
+    position,
+    titleSnapshot: `Pattern ${patternId}`,
+  });
+  await db.insert(schema.deckPatterns).values([
+    slot("d-alice", "p-pub", 0),
+    slot("d-alice", "p-unl", 1),
+    slot("d-bob-1", "p-pub", 0),
+    slot("d-bob-2", "p-pub", 0),
+    slot("d-cara-unl", "p-pub", 0),
+    slot("d-gap", "p-g1", 0),
+    slot("d-gap", "p-g2", 1),
+  ]);
+
+  console.log("\n── deck listings follow the same visibility rules ──");
+  check(
+    "the deck feed is public decks only",
+    (await queries.listPublicDecks()).map((d) => d.id).sort(),
+    ["d-alice", "d-bob-1", "d-bob-2", "d-gap"],
+  );
+  check(
+    "a profile shows its owner everything",
+    (await queries.listDecksByUser("alice", "alice")).map((d) => d.id).sort(),
+    ["d-alice", "d-alice-priv", "d-gap"],
+  );
+  check(
+    "and a visitor the public ones",
+    (await queries.listDecksByUser("alice", "bob")).map((d) => d.id).sort(),
+    ["d-alice", "d-gap"],
+  );
+  const dAlice = (await queries.listPublicDecks()).find((d) => d.id === "d-alice");
+  check("pattern count rides along", dAlice?.patternCount, 2);
+  check(
+    "the preview strip keeps running order",
+    dAlice?.preview.map((p) => p.id),
+    ["p-pub", "p-unl"],
+  );
+
+  console.log("\n── the two-slot arithmetic ──");
+  check("bob has spent both public slots", await queries.countPublicDecksByUser("bob"), PUBLIC_DECKS_MAX);
+  check(
+    "editing an already-public deck does not count itself",
+    await queries.countPublicDecksByUser("bob", "d-bob-1"),
+    PUBLIC_DECKS_MAX - 1,
+  );
+  check("private decks cost nothing", await queries.countPublicDecksByUser("alice"), 2);
+
+  console.log("\n── a deck shows the gap, not a shorter set ──");
+  const before = await queries.listDeckItems("d-gap", null);
+  check("both slots present before anything happens", before.map((i) => i.gap), [null, null]);
+
+  // p-g2's author withdraws it from view…
+  await db
+    .update(schema.patterns)
+    .set({ visibility: "private" })
+    .where((await import("drizzle-orm")).eq(schema.patterns.id, "p-g2"));
+  const afterPrivate = await queries.listDeckItems("d-gap", null);
+  check("…and its slot becomes a private gap", afterPrivate[1]?.gap, "private");
+  check("the gap keeps the position", afterPrivate[1]?.position, 1);
+  check("and the name it had", afterPrivate[1]?.titleSnapshot, "Pattern p-g2");
+  check(
+    "the pattern's own author still sees it in place",
+    (await queries.listDeckItems("d-gap", "alice"))[1]?.gap,
+    null,
+  );
+
+  // …and p-g1's author deletes it outright.
+  await db.delete(schema.patterns).where((await import("drizzle-orm")).eq(schema.patterns.id, "p-g1"));
+  const afterDelete = await queries.listDeckItems("d-gap", null);
+  check("a deleted pattern leaves a deleted gap", afterDelete[0]?.gap, "deleted");
+  check("its snapshot title survives the row", afterDelete[0]?.titleSnapshot, "Pattern p-g1");
+  check("the set is still two slots long", afterDelete.length, 2);
+
+  console.log("\n── the feed's deck signal ──");
+  // p-pub sits in alice's own deck (does not count), two decks by bob (one
+  // person), and cara's unlisted deck (not public, does not count) → 1.
+  const ranked = await queries.listFeed({ sort: "decks" });
+  const pPub = ranked.find((item) => item.id === "p-pub");
+  check("own decks and unlisted decks do not count", pPub?.deckCount, 1);
+  check("two decks by one person count once", ranked[0]?.id, "p-pub");
+  check(
+    "everything else sits at zero",
+    ranked.filter((i) => i.id !== "p-pub").map((i) => i.deckCount),
+    [0],
+  );
+}
+
+main()
+  .then(() => {
+    console.log(failures === 0 ? "\nAll sharing checks passed.\n" : `\n${failures} check(s) FAILED.\n`);
+    process.exit(failures === 0 ? 0 : 1);
+  })
+  .catch((error: unknown) => {
+    console.error(error);
+    process.exit(1);
+  })
+  .finally(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });

--- a/web/src/app/api/community/comments/[id]/route.ts
+++ b/web/src/app/api/community/comments/[id]/route.ts
@@ -3,6 +3,7 @@ import { isAdminSession } from "@/lib/community/admin";
 import { getAuth } from "@/lib/community/auth";
 import { originBlocked, preflight, withCors } from "@/lib/community/cors";
 import { communityEnabled, getDb } from "@/lib/community/db";
+import { clearNotificationsFor } from "@/lib/community/notify";
 import { getCommentStub } from "@/lib/community/queries";
 import { rateLimit } from "@/lib/community/ratelimit";
 import { comments, postComments } from "@/lib/community/schema";
@@ -117,5 +118,7 @@ async function handleDelete(request: Request, context: { params: Promise<{ id: s
 
   const table = on === "pattern" ? comments : postComments;
   await getDb().delete(table).where(eq(table.id, id));
+  // The notifications this comment caused go with it.
+  await clearNotificationsFor({ sourceId: id });
   return Response.json({ ok: true });
 }

--- a/web/src/app/api/community/decks/[id]/route.ts
+++ b/web/src/app/api/community/decks/[id]/route.ts
@@ -1,0 +1,192 @@
+import { eq } from "drizzle-orm";
+import { isAdminSession } from "@/lib/community/admin";
+import { getAuth } from "@/lib/community/auth";
+import { originBlocked, preflight, withCors } from "@/lib/community/cors";
+import { communityEnabled, getDb } from "@/lib/community/db";
+import { PUBLIC_DECKS_MAX } from "@/lib/community/deck";
+import { checkDeckPattern, cleanPatternIds } from "@/lib/community/deckShare";
+import { countPublicDecksByUser, getDeckStub, getPatternsForDeck } from "@/lib/community/queries";
+import { rateLimit } from "@/lib/community/ratelimit";
+import { deckPatterns, decks } from "@/lib/community/schema";
+import { cleanDescription, cleanTitle } from "@/lib/community/validate";
+import { cleanVisibility, type Visibility } from "@/lib/community/visibility";
+
+// PATCH /api/community/decks/[id] — the owner edits their deck: details,
+// visibility, or the whole running order (replaced in one move, the same way
+// the working deck thinks about it).
+//
+// DELETE — the owner, or a moderator. Editing stays owner-only: same rule as
+// patterns, removing content is moderation, rewriting it is not.
+
+export async function PATCH(request: Request, context: { params: Promise<{ id: string }> }) {
+  const blocked = originBlocked(request);
+  if (blocked) return blocked;
+  return withCors(request, await handlePatch(request, context));
+}
+
+export async function DELETE(request: Request, context: { params: Promise<{ id: string }> }) {
+  const blocked = originBlocked(request);
+  if (blocked) return blocked;
+  return withCors(request, await handleDelete(request, context));
+}
+
+export const OPTIONS = preflight;
+
+async function handleDelete(request: Request, context: { params: Promise<{ id: string }> }) {
+  if (!communityEnabled()) {
+    return Response.json({ error: "Community is not enabled on this deployment." }, { status: 503 });
+  }
+
+  const session = await getAuth().api.getSession({ headers: request.headers });
+  if (!session) {
+    return Response.json({ error: "Sign in to delete your deck." }, { status: 401 });
+  }
+
+  const { id } = await context.params;
+  const deck = await getDeckStub(id);
+  if (!deck) return Response.json({ error: "Deck not found." }, { status: 404 });
+  if (deck.userId !== session.user.id && !isAdminSession(session)) {
+    return Response.json({ error: "You can only delete your own decks." }, { status: 403 });
+  }
+
+  // The join rows cascade; the patterns inside belong to their authors and
+  // are untouched.
+  await getDb().delete(decks).where(eq(decks.id, id));
+  return Response.json({ ok: true });
+}
+
+async function handlePatch(request: Request, context: { params: Promise<{ id: string }> }) {
+  if (!communityEnabled()) {
+    return Response.json({ error: "Community is not enabled on this deployment." }, { status: 503 });
+  }
+
+  const session = await getAuth().api.getSession({ headers: request.headers });
+  if (!session) {
+    return Response.json({ error: "Sign in to edit your deck." }, { status: 401 });
+  }
+
+  if (!rateLimit(`deck:${session.user.id}`, 5, 60_000)) {
+    return Response.json({ error: "Too many deck updates — wait a minute and try again." }, { status: 429 });
+  }
+
+  const { id } = await context.params;
+  const deck = await getDeckStub(id);
+  if (!deck) return Response.json({ error: "Deck not found." }, { status: 404 });
+  if (deck.userId !== session.user.id) {
+    return Response.json({ error: "You can only edit your own decks." }, { status: 403 });
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return Response.json({ error: "Invalid JSON body." }, { status: 400 });
+  }
+  const raw = body as Record<string, unknown>;
+
+  let title = deck.title;
+  if (raw.title !== undefined) {
+    const next = cleanTitle(raw.title);
+    if (!next) return Response.json({ error: "Title is required (max 80 chars)." }, { status: 400 });
+    title = next;
+  }
+
+  let description: string | null | undefined;
+  if (raw.description !== undefined) {
+    description = cleanDescription(raw.description);
+    if (description === undefined) {
+      return Response.json({ error: "Description is too long (max 2000 chars)." }, { status: 400 });
+    }
+  }
+
+  let visibility = deck.visibility as Visibility;
+  if (raw.visibility !== undefined) {
+    const next = cleanVisibility(raw.visibility);
+    if (!next) return Response.json({ error: "Unknown visibility value." }, { status: 400 });
+    visibility = next;
+  }
+
+  // The slot check runs whenever the result is public — countPublicDecksByUser
+  // excludes this deck, so an already-public deck editing its title passes.
+  if (
+    visibility === "public" &&
+    (await countPublicDecksByUser(session.user.id, id)) >= PUBLIC_DECKS_MAX
+  ) {
+    return Response.json(
+      {
+        error: `You already have ${PUBLIC_DECKS_MAX} public decks — that is the shelf. Make one of them unlisted or private to free a slot.`,
+      },
+      { status: 400 },
+    );
+  }
+
+  let patternIds: string[] | null = null;
+  if (raw.patternIds !== undefined) {
+    patternIds = cleanPatternIds(raw.patternIds);
+    if (!patternIds) {
+      return Response.json(
+        { error: "A deck is 1 to 10 patterns, in order, with no duplicates." },
+        { status: 400 },
+      );
+    }
+  }
+
+  const db = getDb();
+
+  // Whatever list the deck ends up with has to be allowed at the visibility it
+  // ends up at. A replaced list is checked strictly; for a visibility-only
+  // change the rows that still exist are checked and gaps stay gaps — a deck
+  // is not held hostage by a pattern its author already deleted.
+  const effectiveIds =
+    patternIds ??
+    (
+      await db
+        .select({ patternId: deckPatterns.patternId })
+        .from(deckPatterns)
+        .where(eq(deckPatterns.deckId, id))
+    ).map((row) => row.patternId);
+  const rows = await getPatternsForDeck(effectiveIds);
+  const byId = new Map(rows.map((row) => [row.id, row]));
+  for (const patternId of effectiveIds) {
+    const pattern = byId.get(patternId);
+    if (!pattern && patternIds === null) continue; // existing gap
+    const check = checkDeckPattern(pattern, visibility, session.user.id);
+    if (!check.ok) {
+      return check.reason === "private"
+        ? Response.json(
+            {
+              error: `"${check.title}" is private — make it public or unlisted before putting it in a shared deck.`,
+            },
+            { status: 400 },
+          )
+        : Response.json(
+            { error: "A pattern in this deck is no longer available." },
+            { status: 400 },
+          );
+    }
+  }
+
+  await db
+    .update(decks)
+    .set({
+      title,
+      ...(description !== undefined ? { description } : {}),
+      visibility,
+      updatedAt: new Date(),
+    })
+    .where(eq(decks.id, id));
+
+  if (patternIds) {
+    await db.delete(deckPatterns).where(eq(deckPatterns.deckId, id));
+    await db.insert(deckPatterns).values(
+      patternIds.map((patternId, position) => ({
+        deckId: id,
+        patternId,
+        position,
+        titleSnapshot: byId.get(patternId)?.title ?? "",
+      })),
+    );
+  }
+
+  return Response.json({ ok: true });
+}

--- a/web/src/app/api/community/decks/[id]/route.ts
+++ b/web/src/app/api/community/decks/[id]/route.ts
@@ -5,6 +5,7 @@ import { originBlocked, preflight, withCors } from "@/lib/community/cors";
 import { communityEnabled, getDb } from "@/lib/community/db";
 import { PUBLIC_DECKS_MAX } from "@/lib/community/deck";
 import { checkDeckPattern, cleanPatternIds } from "@/lib/community/deckShare";
+import { clearNotificationsFor, notifyDeckInclusion } from "@/lib/community/notify";
 import { countPublicDecksByUser, getDeckStub, getPatternsForDeck } from "@/lib/community/queries";
 import { rateLimit } from "@/lib/community/ratelimit";
 import { deckPatterns, decks } from "@/lib/community/schema";
@@ -52,6 +53,7 @@ async function handleDelete(request: Request, context: { params: Promise<{ id: s
   // The join rows cascade; the patterns inside belong to their authors and
   // are untouched.
   await getDb().delete(decks).where(eq(decks.id, id));
+  await clearNotificationsFor({ targetType: "deck", targetId: id });
   return Response.json({ ok: true });
 }
 
@@ -133,18 +135,20 @@ async function handlePatch(request: Request, context: { params: Promise<{ id: st
 
   const db = getDb();
 
+  // The list as it stands — the fallback when no replacement came, and the
+  // baseline for "which patterns are NEW here" when one did.
+  const currentIds = (
+    await db
+      .select({ patternId: deckPatterns.patternId })
+      .from(deckPatterns)
+      .where(eq(deckPatterns.deckId, id))
+  ).map((row) => row.patternId);
+
   // Whatever list the deck ends up with has to be allowed at the visibility it
   // ends up at. A replaced list is checked strictly; for a visibility-only
   // change the rows that still exist are checked and gaps stay gaps — a deck
   // is not held hostage by a pattern its author already deleted.
-  const effectiveIds =
-    patternIds ??
-    (
-      await db
-        .select({ patternId: deckPatterns.patternId })
-        .from(deckPatterns)
-        .where(eq(deckPatterns.deckId, id))
-    ).map((row) => row.patternId);
+  const effectiveIds = patternIds ?? currentIds;
   const rows = await getPatternsForDeck(effectiveIds);
   const byId = new Map(rows.map((row) => [row.id, row]));
   for (const patternId of effectiveIds) {
@@ -186,6 +190,30 @@ async function handlePatch(request: Request, context: { params: Promise<{ id: st
         titleSnapshot: byId.get(patternId)?.title ?? "",
       })),
     );
+  }
+
+  // A deck that just became public announces its whole running order to the
+  // pattern authors; one already public announces only what was added. A
+  // title edit announces nothing, and notifyDeckInclusion's unread guard
+  // absorbs visibility flip-flopping.
+  if (visibility === "public") {
+    const wasPublic = deck.visibility === "public";
+    const announceIds = !wasPublic
+      ? effectiveIds
+      : patternIds
+        ? patternIds.filter((patternId) => !currentIds.includes(patternId))
+        : [];
+    const announce = announceIds
+      .map((patternId) => byId.get(patternId))
+      .filter((pattern): pattern is NonNullable<typeof pattern> => Boolean(pattern));
+    if (announce.length > 0) {
+      await notifyDeckInclusion({
+        deckId: id,
+        deckTitle: title,
+        actorId: session.user.id,
+        patterns: announce,
+      });
+    }
   }
 
   return Response.json({ ok: true });

--- a/web/src/app/api/community/decks/route.ts
+++ b/web/src/app/api/community/decks/route.ts
@@ -1,0 +1,128 @@
+import { getAuth } from "@/lib/community/auth";
+import { originBlocked, preflight, withCors } from "@/lib/community/cors";
+import { communityEnabled, getDb } from "@/lib/community/db";
+import { PUBLIC_DECKS_MAX } from "@/lib/community/deck";
+import { checkDeckPattern, cleanPatternIds } from "@/lib/community/deckShare";
+import { countPublicDecksByUser, getPatternsForDeck, newId } from "@/lib/community/queries";
+import { rateLimit } from "@/lib/community/ratelimit";
+import { deckPatterns, decks } from "@/lib/community/schema";
+import { cleanDescription, cleanTitle } from "@/lib/community/validate";
+import { cleanVisibility } from "@/lib/community/visibility";
+
+// POST /api/community/decks — share the working deck as a deck other people
+// can open. The localStorage deck stays the scratch list; this is the explicit
+// act of publishing a snapshot of it (#256).
+//
+// Two rules with teeth:
+//   - at most PUBLIC_DECKS_MAX public decks per account — the curation cap
+//   - no private patterns in a deck others can see
+
+export async function POST(request: Request) {
+  const blocked = originBlocked(request);
+  if (blocked) return blocked;
+  return withCors(request, await handlePost(request));
+}
+
+export const OPTIONS = preflight;
+
+async function handlePost(request: Request) {
+  if (!communityEnabled()) {
+    return Response.json({ error: "Community is not enabled on this deployment." }, { status: 503 });
+  }
+
+  const session = await getAuth().api.getSession({ headers: request.headers });
+  if (!session) {
+    return Response.json({ error: "Sign in to share a deck." }, { status: 401 });
+  }
+
+  if (!rateLimit(`deck:${session.user.id}`, 5, 60_000)) {
+    return Response.json({ error: "Too many deck updates — wait a minute and try again." }, { status: 429 });
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return Response.json({ error: "Invalid JSON body." }, { status: 400 });
+  }
+  const raw = body as Record<string, unknown>;
+
+  const title = cleanTitle(raw.title);
+  if (!title) return Response.json({ error: "Title is required (max 80 chars)." }, { status: 400 });
+
+  const description = cleanDescription(raw.description);
+  if (description === undefined) {
+    return Response.json({ error: "Description is too long (max 2000 chars)." }, { status: 400 });
+  }
+
+  // Absent means private — the deliberate act here is making it visible, so
+  // that one is never a fallback.
+  const visibility = raw.visibility === undefined ? "private" : cleanVisibility(raw.visibility);
+  if (!visibility) {
+    return Response.json({ error: "Unknown visibility value." }, { status: 400 });
+  }
+
+  const patternIds = cleanPatternIds(raw.patternIds);
+  if (!patternIds) {
+    return Response.json(
+      { error: "A deck is 1 to 10 patterns, in order, with no duplicates." },
+      { status: 400 },
+    );
+  }
+
+  const rows = await getPatternsForDeck(patternIds);
+  const byId = new Map(rows.map((row) => [row.id, row]));
+  for (const patternId of patternIds) {
+    const check = checkDeckPattern(byId.get(patternId), visibility, session.user.id);
+    if (!check.ok) {
+      return check.reason === "private"
+        ? Response.json(
+            {
+              error: `"${check.title}" is private — make it public or unlisted before putting it in a shared deck.`,
+            },
+            { status: 400 },
+          )
+        : Response.json(
+            { error: "A pattern in this deck is no longer available." },
+            { status: 400 },
+          );
+    }
+  }
+
+  if (
+    visibility === "public" &&
+    (await countPublicDecksByUser(session.user.id)) >= PUBLIC_DECKS_MAX
+  ) {
+    return Response.json(
+      {
+        error: `You already have ${PUBLIC_DECKS_MAX} public decks — that is the shelf. Make one of them unlisted or private to free a slot.`,
+      },
+      { status: 400 },
+    );
+  }
+
+  const now = new Date();
+  const id = newId();
+  const db = getDb();
+
+  await db.insert(decks).values({
+    id,
+    userId: session.user.id,
+    title,
+    description,
+    visibility,
+    createdAt: now,
+    updatedAt: now,
+  });
+  await db.insert(deckPatterns).values(
+    patternIds.map((patternId, position) => ({
+      deckId: id,
+      patternId,
+      position,
+      // Snapshotted so a deleted pattern still leaves a named gap in the set.
+      titleSnapshot: byId.get(patternId)?.title ?? "",
+    })),
+  );
+
+  return Response.json({ id }, { status: 201 });
+}

--- a/web/src/app/api/community/decks/route.ts
+++ b/web/src/app/api/community/decks/route.ts
@@ -3,6 +3,7 @@ import { originBlocked, preflight, withCors } from "@/lib/community/cors";
 import { communityEnabled, getDb } from "@/lib/community/db";
 import { PUBLIC_DECKS_MAX } from "@/lib/community/deck";
 import { checkDeckPattern, cleanPatternIds } from "@/lib/community/deckShare";
+import { notifyDeckInclusion } from "@/lib/community/notify";
 import { countPublicDecksByUser, getPatternsForDeck, newId } from "@/lib/community/queries";
 import { rateLimit } from "@/lib/community/ratelimit";
 import { deckPatterns, decks } from "@/lib/community/schema";
@@ -123,6 +124,17 @@ async function handlePost(request: Request) {
       titleSnapshot: byId.get(patternId)?.title ?? "",
     })),
   );
+
+  // Tell each pattern's author their work made someone's public shelf — the
+  // same act the feed's "in decks" sort counts. Quieter decks tell nobody.
+  if (visibility === "public") {
+    await notifyDeckInclusion({
+      deckId: id,
+      deckTitle: title,
+      actorId: session.user.id,
+      patterns: rows,
+    });
+  }
 
   return Response.json({ id }, { status: 201 });
 }

--- a/web/src/app/api/community/notifications/read/route.ts
+++ b/web/src/app/api/community/notifications/read/route.ts
@@ -1,0 +1,31 @@
+import { getAuth } from "@/lib/community/auth";
+import { originBlocked, preflight, withCors } from "@/lib/community/cors";
+import { communityEnabled } from "@/lib/community/db";
+import { markNotificationsRead } from "@/lib/community/queries";
+
+// POST /api/community/notifications/read — the notifications page calls this
+// once after it has actually rendered. It is not done during the page render:
+// Next prefetches links, and a prefetch that marked everything read would eat
+// notifications nobody saw.
+
+export async function POST(request: Request) {
+  const blocked = originBlocked(request);
+  if (blocked) return blocked;
+  return withCors(request, await handlePost(request));
+}
+
+export const OPTIONS = preflight;
+
+async function handlePost(request: Request) {
+  if (!communityEnabled()) {
+    return Response.json({ error: "Community is not enabled on this deployment." }, { status: 503 });
+  }
+
+  const session = await getAuth().api.getSession({ headers: request.headers });
+  if (!session) {
+    return Response.json({ error: "Sign in first." }, { status: 401 });
+  }
+
+  await markNotificationsRead(session.user.id);
+  return Response.json({ ok: true });
+}

--- a/web/src/app/api/community/patterns/[id]/comments/route.ts
+++ b/web/src/app/api/community/patterns/[id]/comments/route.ts
@@ -1,6 +1,7 @@
 import { getAuth } from "@/lib/community/auth";
 import { originBlocked, preflight, withCors } from "@/lib/community/cors";
 import { communityEnabled, getDb } from "@/lib/community/db";
+import { notifyCommentAdded } from "@/lib/community/notify";
 import { getPatternStub, newId } from "@/lib/community/queries";
 import { rateLimit } from "@/lib/community/ratelimit";
 import { comments } from "@/lib/community/schema";
@@ -51,12 +52,25 @@ async function handlePost(request: Request, context: { params: Promise<{ id: str
     return Response.json({ error: "Comment is empty or over 2000 chars." }, { status: 400 });
   }
 
+  // Fan-out reads the thread as it was BEFORE this insert, so the id is fixed
+  // first and the notify call comes after the row exists.
+  const commentId = newId();
   await getDb().insert(comments).values({
-    id: newId(),
+    id: commentId,
     patternId,
     userId: session.user.id,
     body: text,
     createdAt: new Date(),
+  });
+
+  await notifyCommentAdded({
+    on: "pattern",
+    targetId: patternId,
+    targetTitle: pattern.title,
+    ownerId: pattern.userId,
+    actorId: session.user.id,
+    commentId,
+    body: text,
   });
 
   return Response.json({ ok: true }, { status: 201 });

--- a/web/src/app/api/community/patterns/[id]/comments/route.ts
+++ b/web/src/app/api/community/patterns/[id]/comments/route.ts
@@ -5,6 +5,7 @@ import { getPatternStub, newId } from "@/lib/community/queries";
 import { rateLimit } from "@/lib/community/ratelimit";
 import { comments } from "@/lib/community/schema";
 import { cleanComment } from "@/lib/community/validate";
+import { canView } from "@/lib/community/visibility";
 
 // POST /api/community/patterns/[id]/comments — add a comment (login required).
 // Comments are stored as plain text and escaped on output by React.
@@ -33,7 +34,8 @@ async function handlePost(request: Request, context: { params: Promise<{ id: str
 
   const { id: patternId } = await context.params;
   const pattern = await getPatternStub(patternId);
-  if (!pattern) {
+  // Private patterns take no drive-by interaction — same 404 as a missing row.
+  if (!pattern || !canView(pattern.visibility, pattern.userId, session.user.id)) {
     return Response.json({ error: "Pattern not found." }, { status: 404 });
   }
 

--- a/web/src/app/api/community/patterns/[id]/header/route.ts
+++ b/web/src/app/api/community/patterns/[id]/header/route.ts
@@ -1,8 +1,11 @@
 import { eq } from "drizzle-orm";
 
+import { isAdminSession } from "@/lib/community/admin";
+import { getAuth } from "@/lib/community/auth";
 import { originBlocked, preflight, withCors } from "@/lib/community/cors";
 import { communityEnabled, getDb } from "@/lib/community/db";
 import { patterns } from "@/lib/community/schema";
+import { canView } from "@/lib/community/visibility";
 
 // GET /api/community/patterns/[id]/header — the pattern's firmware header.
 //
@@ -11,8 +14,9 @@ import { patterns } from "@/lib/community/schema";
 // carrying up to 200 KB per card for something most visitors never click, so
 // the card fetches just this one when the button is pressed.
 //
-// No auth: the header is already public on the detail page, which renders it
-// in full. This only saves a round trip through the HTML.
+// Auth only when the pattern is private (the owner adding their own private
+// pattern to their deck). Public and unlisted stay session-free — the header
+// is rendered in full on any page the visitor can already open.
 
 export async function OPTIONS(request: Request) {
   return preflight(request);
@@ -21,23 +25,38 @@ export async function OPTIONS(request: Request) {
 export async function GET(request: Request, context: { params: Promise<{ id: string }> }) {
   const blocked = originBlocked(request);
   if (blocked) return blocked;
-  return withCors(request, await handleGet(context));
+  return withCors(request, await handleGet(request, context));
 }
 
-async function handleGet(context: { params: Promise<{ id: string }> }) {
+async function handleGet(request: Request, context: { params: Promise<{ id: string }> }) {
   if (!communityEnabled()) {
     return Response.json({ error: "Community is not configured." }, { status: 503 });
   }
   const { id } = await context.params;
 
   const rows = await getDb()
-    .select({ id: patterns.id, title: patterns.title, codeCpp: patterns.codeCpp })
+    .select({
+      id: patterns.id,
+      title: patterns.title,
+      codeCpp: patterns.codeCpp,
+      userId: patterns.userId,
+      visibility: patterns.visibility,
+    })
     .from(patterns)
     .where(eq(patterns.id, id))
     .limit(1);
 
   const pattern = rows[0];
   if (!pattern) return Response.json({ error: "No such pattern." }, { status: 404 });
+
+  if (pattern.visibility === "private") {
+    const session = await getAuth().api.getSession({ headers: request.headers });
+    if (!canView(pattern.visibility, pattern.userId, session?.user.id ?? null, isAdminSession(session))) {
+      // Same body as a missing row — a 403 would confirm the id exists.
+      return Response.json({ error: "No such pattern." }, { status: 404 });
+    }
+  }
+
   if (!pattern.codeCpp) {
     return Response.json({ error: "This pattern has no firmware header." }, { status: 404 });
   }

--- a/web/src/app/api/community/patterns/[id]/like/route.ts
+++ b/web/src/app/api/community/patterns/[id]/like/route.ts
@@ -5,6 +5,7 @@ import { communityEnabled, getDb } from "@/lib/community/db";
 import { countLikes, getPatternStub, hasLiked } from "@/lib/community/queries";
 import { rateLimit } from "@/lib/community/ratelimit";
 import { likes } from "@/lib/community/schema";
+import { canView } from "@/lib/community/visibility";
 
 // POST /api/community/patterns/[id]/like — toggle the viewer's like.
 // Reading like counts is free; liking is a save, so it needs a session.
@@ -33,7 +34,9 @@ async function handlePost(request: Request, context: { params: Promise<{ id: str
 
   const { id: patternId } = await context.params;
   const pattern = await getPatternStub(patternId);
-  if (!pattern) {
+  // A private pattern's page is only reachable by its owner, so anyone else
+  // arriving here is probing ids — same 404 as a missing row.
+  if (!pattern || !canView(pattern.visibility, pattern.userId, session.user.id)) {
     return Response.json({ error: "Pattern not found." }, { status: 404 });
   }
 

--- a/web/src/app/api/community/patterns/[id]/route.ts
+++ b/web/src/app/api/community/patterns/[id]/route.ts
@@ -15,6 +15,7 @@ import {
   cleanMadeOn,
   cleanTitle,
 } from "@/lib/community/validate";
+import { cleanVisibility } from "@/lib/community/visibility";
 import { KNOWN_LICENSES, forkLicenseAllowed, stripShareWrapping } from "@/lib/sharePattern";
 
 // PATCH /api/community/patterns/[id] — the author edits their own pattern.
@@ -159,6 +160,16 @@ async function handlePatch(request: Request, context: { params: Promise<{ id: st
     madeHow = next;
   }
 
+  // Going private leaves any published deck carrying this pattern with a gap
+  // at its position — deliberate: the author's withdrawal wins, and the deck
+  // page says what happened rather than silently closing the hole.
+  let visibility = pattern.visibility;
+  if (raw.visibility !== undefined) {
+    const next = cleanVisibility(raw.visibility);
+    if (!next) return Response.json({ error: "Unknown visibility value." }, { status: 400 });
+    visibility = next;
+  }
+
   // Compare the bodies with any licence wrapping removed, so re-saving without
   // touching the code isn't mistaken for a code change.
   let bareCode = stripShareWrapping(pattern.code);
@@ -218,6 +229,7 @@ async function handlePatch(request: Request, context: { params: Promise<{ id: st
         basedOn: lineageFrom(parent),
       }),
       codeCpp,
+      visibility,
       updatedAt: new Date(),
     })
     .where(eq(patterns.id, id));

--- a/web/src/app/api/community/patterns/[id]/route.ts
+++ b/web/src/app/api/community/patterns/[id]/route.ts
@@ -3,6 +3,7 @@ import { isAdminSession } from "@/lib/community/admin";
 import { getAuth } from "@/lib/community/auth";
 import { originBlocked, preflight, withCors } from "@/lib/community/cors";
 import { communityEnabled, getDb } from "@/lib/community/db";
+import { clearNotificationsFor } from "@/lib/community/notify";
 import { getPattern, getPatternStub } from "@/lib/community/queries";
 import { rateLimit } from "@/lib/community/ratelimit";
 import { patterns } from "@/lib/community/schema";
@@ -65,6 +66,9 @@ async function handleDelete(request: Request, context: { params: Promise<{ id: s
   }
 
   await getDb().delete(patterns).where(eq(patterns.id, id));
+  // Rows pointing at the pattern, and "deck took your pattern" rows triggered
+  // by it — a notification for something gone is noise, not a record.
+  await clearNotificationsFor({ targetType: "pattern", targetId: id, sourceId: id });
   return Response.json({ ok: true });
 }
 

--- a/web/src/app/api/community/patterns/route.ts
+++ b/web/src/app/api/community/patterns/route.ts
@@ -11,6 +11,7 @@ import {
   cleanMadeHow,
   cleanTitle,
 } from "@/lib/community/validate";
+import { cleanVisibility, forkBlocked } from "@/lib/community/visibility";
 import { buildStoredPatternCode, lineageFrom } from "@/lib/community/license";
 import { LICENSE_OPTIONS, forkLicenseAllowed, stripShareWrapping } from "@/lib/sharePattern";
 
@@ -84,6 +85,13 @@ async function handlePost(request: Request) {
     return Response.json({ error: "Unknown \"made how\" value." }, { status: 400 });
   }
 
+  // Absent means public — the community works because things are shared. The
+  // quieter states are a choice made at the picker, not a silent default.
+  const visibility = raw.visibility === undefined ? "public" : cleanVisibility(raw.visibility);
+  if (!visibility) {
+    return Response.json({ error: "Unknown visibility value." }, { status: 400 });
+  }
+
   // New work can only take a currently-offered licence (the retired ones stay
   // readable but are not selectable — see LICENSE_OPTIONS).
   const license =
@@ -96,6 +104,15 @@ async function handlePost(request: Request) {
   if (typeof raw.parentId === "string" && raw.parentId.length > 0) {
     parent = await getPatternStub(raw.parentId);
     parentId = parent?.id ?? null;
+  }
+
+  // A fork of a private pattern would bake a credit link that 404s for every
+  // reader (#255). The author forking their own private work is fine.
+  if (parent && forkBlocked(parent, session.user.id)) {
+    return Response.json(
+      { error: "That pattern is private — it cannot be forked." },
+      { status: 400 },
+    );
   }
 
   // A fork is a derivative: it cannot be published under looser terms than the
@@ -137,6 +154,7 @@ async function handlePost(request: Request) {
     license,
     madeHow,
     parentId,
+    visibility,
     createdAt: now,
     updatedAt: now,
   });

--- a/web/src/app/api/community/patterns/route.ts
+++ b/web/src/app/api/community/patterns/route.ts
@@ -1,6 +1,7 @@
 import { getAuth } from "@/lib/community/auth";
 import { originBlocked, preflight, withCors } from "@/lib/community/cors";
 import { communityEnabled, getDb } from "@/lib/community/db";
+import { notifyForkPublished } from "@/lib/community/notify";
 import { getPatternStub, newId } from "@/lib/community/queries";
 import { rateLimit } from "@/lib/community/ratelimit";
 import { patterns } from "@/lib/community/schema";
@@ -158,6 +159,16 @@ async function handlePost(request: Request) {
     createdAt: now,
     updatedAt: now,
   });
+
+  if (parent) {
+    await notifyForkPublished({
+      parentOwnerId: parent.userId,
+      parentTitle: parent.title,
+      forkId: id,
+      forkVisibility: visibility,
+      actorId: session.user.id,
+    });
+  }
 
   return Response.json({ id }, { status: 201 });
 }

--- a/web/src/app/api/community/posts/[id]/comments/route.ts
+++ b/web/src/app/api/community/posts/[id]/comments/route.ts
@@ -1,6 +1,7 @@
 import { getAuth } from "@/lib/community/auth";
 import { originBlocked, preflight, withCors } from "@/lib/community/cors";
 import { communityEnabled, getDb } from "@/lib/community/db";
+import { notifyCommentAdded } from "@/lib/community/notify";
 import { getPostStub, newId } from "@/lib/community/queries";
 import { rateLimit } from "@/lib/community/ratelimit";
 import { postComments } from "@/lib/community/schema";
@@ -51,12 +52,23 @@ async function handlePost(request: Request, context: { params: Promise<{ id: str
     return Response.json({ error: "Comment is empty or over 2000 chars." }, { status: 400 });
   }
 
+  const commentId = newId();
   await getDb().insert(postComments).values({
-    id: newId(),
+    id: commentId,
     postId,
     userId: session.user.id,
     body: text,
     createdAt: new Date(),
+  });
+
+  await notifyCommentAdded({
+    on: "post",
+    targetId: postId,
+    targetTitle: post.title,
+    ownerId: post.userId,
+    actorId: session.user.id,
+    commentId,
+    body: text,
   });
 
   return Response.json({ ok: true }, { status: 201 });

--- a/web/src/app/api/community/posts/[id]/route.ts
+++ b/web/src/app/api/community/posts/[id]/route.ts
@@ -3,6 +3,7 @@ import { isAdminSession } from "@/lib/community/admin";
 import { getAuth } from "@/lib/community/auth";
 import { originBlocked, preflight, withCors } from "@/lib/community/cors";
 import { communityEnabled, getDb } from "@/lib/community/db";
+import { clearNotificationsFor } from "@/lib/community/notify";
 import { getPostStub } from "@/lib/community/queries";
 import { rateLimit } from "@/lib/community/ratelimit";
 import { posts } from "@/lib/community/schema";
@@ -65,6 +66,7 @@ async function handleDelete(request: Request, context: { params: Promise<{ id: s
   if (gate.error) return gate.error;
 
   await getDb().delete(posts).where(eq(posts.id, id));
+  await clearNotificationsFor({ targetType: "post", targetId: id });
   return Response.json({ ok: true });
 }
 

--- a/web/src/app/community/d/[id]/DeckDetailClient.tsx
+++ b/web/src/app/community/d/[id]/DeckDetailClient.tsx
@@ -1,0 +1,413 @@
+"use client";
+
+import Link from "next/link";
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import PatternCard from "@/components/community/PatternCard";
+import ReportModal from "@/components/community/ReportModal";
+import { COMMUNITY_FETCH_INIT, communityApiUrl } from "@/lib/community/apiBase";
+import { deckItems, deckReplace, type CollectedPattern } from "@/lib/community/deck";
+import {
+  VISIBILITY_LABELS,
+  VISIBILITY_VALUES,
+  type Visibility,
+} from "@/lib/community/visibility";
+import { DESCRIPTION_MAX, TITLE_MAX } from "@/lib/community/validate";
+import type { DeckPageItem } from "@/lib/community/serialize";
+import { captureEvent } from "@/lib/posthogEvents";
+import styles from "@/components/community/Community.module.css";
+
+// The deck page. Every slot renders its pattern's own card — author byline
+// included, which is the attribution rule for decks: curation credits the
+// curated (#256). "Copy to my deck" makes a shared deck a starting point
+// rather than a read-only artifact.
+
+export type DeckView = {
+  id: string;
+  title: string;
+  description: string | null;
+  visibility: string;
+  createdAt: string; // ISO
+  username: string | null;
+  displayUsername: string | null;
+};
+
+export default function DeckDetailClient({
+  deck,
+  items,
+  isOwner = false,
+}: {
+  deck: DeckView;
+  items: DeckPageItem[];
+  isOwner?: boolean;
+}) {
+  const router = useRouter();
+  const [note, setNote] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [reportOpen, setReportOpen] = useState(false);
+  const [editOpen, setEditOpen] = useState(false);
+  const [confirmCopy, setConfirmCopy] = useState(false);
+  const [confirmReplace, setConfirmReplace] = useState(false);
+  const [confirmDelete, setConfirmDelete] = useState(false);
+
+  const playable = items.filter((item) => item.pattern !== null);
+
+  const patch = async (body: Record<string, unknown>): Promise<boolean> => {
+    setBusy(true);
+    setError(null);
+    try {
+      const response = await fetch(communityApiUrl(`/api/community/decks/${deck.id}`), {
+        method: "PATCH",
+        ...COMMUNITY_FETCH_INIT,
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      const payload = (await response.json()) as { error?: string };
+      if (!response.ok) {
+        setError(payload.error ?? "Could not save.");
+        return false;
+      }
+      router.refresh();
+      return true;
+    } catch {
+      setError("Network error — is the community server reachable?");
+      return false;
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  // Pull each pattern's CURRENT header (the deck stores ids, not code) and
+  // load the lot into the working deck, keeping this deck's order. Patterns
+  // that lost their header since — or went away — are skipped and counted.
+  const copyToMine = async () => {
+    if (deckItems().length > 0 && !confirmCopy) {
+      setConfirmCopy(true);
+      window.setTimeout(() => setConfirmCopy(false), 4000);
+      return;
+    }
+    setConfirmCopy(false);
+    setBusy(true);
+    setNote(null);
+    setError(null);
+    try {
+      const collected: CollectedPattern[] = [];
+      let skipped = 0;
+      for (const item of items) {
+        if (!item.pattern) {
+          skipped += 1;
+          continue;
+        }
+        try {
+          const response = await fetch(
+            communityApiUrl(`/api/community/patterns/${item.pattern.id}/header`),
+            COMMUNITY_FETCH_INIT,
+          );
+          const payload = (await response.json()) as { codeCpp?: string };
+          if (!response.ok || !payload.codeCpp) {
+            skipped += 1;
+            continue;
+          }
+          collected.push({
+            patternId: item.pattern.id,
+            title: item.pattern.title,
+            code: payload.codeCpp,
+          });
+        } catch {
+          skipped += 1;
+        }
+      }
+      if (collected.length === 0) {
+        setError("Nothing to copy — none of these patterns has a firmware header right now.");
+        return;
+      }
+      deckReplace(collected);
+      captureEvent("community_deck_copied", { deck_id: deck.id, patterns: collected.length });
+      setNote(
+        `Loaded ${collected.length} pattern${collected.length === 1 ? "" : "s"} into your deck` +
+          (skipped > 0 ? ` — ${skipped} skipped (missing or no firmware header).` : "."),
+      );
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const replaceFromWorkingDeck = async () => {
+    const working = deckItems();
+    if (working.length === 0) {
+      setError("Your working deck is empty — add patterns to it first.");
+      return;
+    }
+    if (!confirmReplace) {
+      setConfirmReplace(true);
+      window.setTimeout(() => setConfirmReplace(false), 4000);
+      return;
+    }
+    setConfirmReplace(false);
+    const ok = await patch({ patternIds: working.map((item) => item.patternId) });
+    if (ok) setNote(`Contents replaced with your working deck (${working.length} patterns).`);
+  };
+
+  const remove = async () => {
+    if (!confirmDelete) {
+      setConfirmDelete(true);
+      window.setTimeout(() => setConfirmDelete(false), 4000);
+      return;
+    }
+    setBusy(true);
+    try {
+      const response = await fetch(communityApiUrl(`/api/community/decks/${deck.id}`), {
+        method: "DELETE",
+        ...COMMUNITY_FETCH_INIT,
+      });
+      if (!response.ok) {
+        const payload = (await response.json()) as { error?: string };
+        setError(payload.error ?? "Could not delete the deck.");
+        return;
+      }
+      router.push("/community/decks");
+      router.refresh();
+    } catch {
+      setError("Network error.");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className={styles.deckPage}>
+      <div className={styles.metaBlock}>
+        <div className={styles.metaTitleRow}>
+          <h1 className={styles.metaTitle}>{deck.title}</h1>
+          {deck.visibility !== "public" && (
+            <span
+              className={styles.visChip}
+              title={
+                deck.visibility === "private"
+                  ? "Private — only you can open this page"
+                  : "Unlisted — off the deck feed, anyone with this link can open it"
+              }
+            >
+              {deck.visibility}
+            </span>
+          )}
+        </div>
+
+        <div className={styles.metaByline}>
+          <span>
+            a deck by{" "}
+            <Link href={`/community/u/${deck.username ?? ""}`}>
+              @{deck.displayUsername ?? deck.username ?? "unknown"}
+            </Link>
+          </span>
+          <span>{deck.createdAt.slice(0, 10)}</span>
+          <span>
+            {items.length} {items.length === 1 ? "pattern" : "patterns"}
+          </span>
+          {!isOwner && (
+            <button type="button" className={styles.reportLink} onClick={() => setReportOpen(true)}>
+              Report
+            </button>
+          )}
+        </div>
+
+        {deck.description && <p className={styles.metaDescription}>{deck.description}</p>}
+
+        <div className={styles.actionRow}>
+          <button
+            type="button"
+            className={styles.btnAccent}
+            disabled={busy || playable.length === 0}
+            title="Load these patterns, in this order, into your own working deck"
+            onClick={() => void copyToMine()}
+          >
+            {confirmCopy ? "Press again to replace your deck" : "Copy to my deck"}
+          </button>
+          <span className={styles.formNote}>
+            The order here is the order they cycle on the device.
+          </span>
+        </div>
+
+        {isOwner && (
+          <div className={styles.ownerBar}>
+            <label className={styles.deckVisControl}>
+              <span>Who can see it?</span>
+              <select
+                value={deck.visibility}
+                disabled={busy}
+                onChange={(event) => void patch({ visibility: event.target.value as Visibility })}
+              >
+                {VISIBILITY_VALUES.map((value) => (
+                  <option key={value} value={value}>
+                    {VISIBILITY_LABELS[value]}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <button type="button" className={styles.btn} onClick={() => setEditOpen(true)}>
+              Edit details
+            </button>
+            <button
+              type="button"
+              className={styles.btn}
+              disabled={busy}
+              title="Overwrite this deck's contents with your current working deck, in its order"
+              onClick={() => void replaceFromWorkingDeck()}
+            >
+              {confirmReplace ? "Press again to replace contents" : "Replace with my working deck"}
+            </button>
+            <span className={styles.ownerBarSpacer} />
+            <button
+              type="button"
+              className={styles.btnDanger}
+              disabled={busy}
+              onClick={() => void remove()}
+            >
+              {confirmDelete ? "Press again to delete" : "Delete deck"}
+            </button>
+          </div>
+        )}
+
+        {note && <div className={styles.formNote}>{note}</div>}
+        {error && <div className={styles.formError}>{error}</div>}
+      </div>
+
+      <ol className={styles.deckSlots}>
+        {items.map((item) => (
+          <li key={`${item.position}-${item.patternId}`} className={styles.deckSlot}>
+            <span className={styles.deckSlotIndex}>{item.position + 1}</span>
+            {item.pattern ? (
+              <PatternCard item={item.pattern} />
+            ) : (
+              <div className={styles.deckGap}>
+                <span className={styles.deckGapTitle}>{item.titleSnapshot || "Untitled"}</span>
+                <span className={styles.deckGapReason}>
+                  {item.gap === "private"
+                    ? "made private by its author"
+                    : "removed by its author"}
+                </span>
+              </div>
+            )}
+          </li>
+        ))}
+      </ol>
+
+      <p className={styles.profileFootNote}>
+        Every pattern belongs to its own author — the deck is the arrangement. Open a card for the
+        pattern&rsquo;s licence and credits.
+      </p>
+
+      {reportOpen && (
+        <ReportModal
+          targetType="deck"
+          targetId={deck.id}
+          targetLabel={deck.title}
+          onClose={() => setReportOpen(false)}
+        />
+      )}
+
+      {editOpen && (
+        <EditDeckModal
+          deckId={deck.id}
+          initialTitle={deck.title}
+          initialDescription={deck.description}
+          onSaved={() => {
+            setEditOpen(false);
+            router.refresh();
+          }}
+          onClose={() => setEditOpen(false)}
+        />
+      )}
+    </div>
+  );
+}
+
+// Title and description only — visibility and contents have their own
+// controls on the page, where their consequences are visible.
+function EditDeckModal({
+  deckId,
+  initialTitle,
+  initialDescription,
+  onSaved,
+  onClose,
+}: {
+  deckId: string;
+  initialTitle: string;
+  initialDescription: string | null;
+  onSaved: () => void;
+  onClose: () => void;
+}) {
+  const [title, setTitle] = useState(initialTitle);
+  const [description, setDescription] = useState(initialDescription ?? "");
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  const save = async () => {
+    const trimmed = title.trim();
+    setError(null);
+    if (trimmed.length === 0 || trimmed.length > TITLE_MAX) {
+      setError(`Title is required (max ${TITLE_MAX} characters).`);
+      return;
+    }
+    setBusy(true);
+    try {
+      const response = await fetch(communityApiUrl(`/api/community/decks/${deckId}`), {
+        method: "PATCH",
+        ...COMMUNITY_FETCH_INIT,
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ title: trimmed, description }),
+      });
+      const payload = (await response.json()) as { error?: string };
+      if (!response.ok) {
+        setError(payload.error ?? "Could not save.");
+        return;
+      }
+      onSaved();
+    } catch {
+      setError("Network error.");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className={styles.modalOverlay} role="dialog" aria-modal="true" onClick={onClose}>
+      <div className={styles.modalCard} onClick={(event) => event.stopPropagation()}>
+        <div className={styles.modalHeader}>
+          <span>Edit deck details</span>
+          <button type="button" onClick={onClose} aria-label="Close">
+            ×
+          </button>
+        </div>
+        <div className={styles.modalBody}>
+          <label className={styles.field}>
+            <span className={styles.fieldLabel}>Title</span>
+            <input
+              className={styles.textInput}
+              value={title}
+              maxLength={TITLE_MAX}
+              autoFocus
+              onChange={(event) => setTitle(event.target.value)}
+            />
+          </label>
+          <label className={styles.field}>
+            <span className={styles.fieldLabel}>Description (optional)</span>
+            <textarea
+              className={styles.textInput}
+              rows={4}
+              value={description}
+              maxLength={DESCRIPTION_MAX}
+              placeholder="What is this set for — a mood, a place, a night?"
+              onChange={(event) => setDescription(event.target.value)}
+            />
+          </label>
+          {error && <div className={styles.formError}>{error}</div>}
+          <button type="button" className={styles.btnAccent} disabled={busy} onClick={() => void save()}>
+            {busy ? "Saving…" : "Save details"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/app/community/d/[id]/page.tsx
+++ b/web/src/app/community/d/[id]/page.tsx
@@ -1,0 +1,66 @@
+import { headers } from "next/headers";
+import { notFound } from "next/navigation";
+import type { Metadata } from "next";
+import { isAdminSession } from "@/lib/community/admin";
+import { getAuth } from "@/lib/community/auth";
+import { communityEnabled } from "@/lib/community/db";
+import { getDeck, listDeckItems } from "@/lib/community/queries";
+import { toDeckPageItem } from "@/lib/community/serialize";
+import { canView } from "@/lib/community/visibility";
+import DeckDetailClient from "./DeckDetailClient";
+
+// A shared deck: the running order somebody arranged, each slot a live pattern
+// card credited to its own author. Slots whose pattern is gone (deleted, or
+// made private since) render as gaps — the arrangement is the deck author's
+// work, and silently closing a hole would misrepresent it.
+
+export const dynamic = "force-dynamic";
+
+type RouteParams = { params: Promise<{ id: string }> };
+
+export async function generateMetadata(props: RouteParams): Promise<Metadata> {
+  if (!communityEnabled()) return {};
+  const { id } = await props.params;
+  const deck = await getDeck(id);
+  if (!deck || deck.visibility === "private") return {};
+  return {
+    title: `${deck.title} / Patternflow Community`,
+    description:
+      deck.description ??
+      `A deck of LED matrix patterns arranged by @${deck.displayUsername ?? deck.username}.`,
+  };
+}
+
+export default async function CommunityDeckPage(props: RouteParams) {
+  if (!communityEnabled()) return null; // layout already rendered the notice
+
+  const { id } = await props.params;
+  const deck = await getDeck(id);
+  if (!deck) notFound();
+
+  const session = await getAuth().api.getSession({ headers: await headers() });
+  const viewerId = session?.user.id ?? null;
+
+  if (!canView(deck.visibility, deck.userId, viewerId, isAdminSession(session))) {
+    notFound();
+  }
+
+  const items = (await listDeckItems(deck.id, viewerId)).map(toDeckPageItem);
+
+  return (
+    <DeckDetailClient
+      key={`${deck.id}:${deck.updatedAt.getTime()}`}
+      deck={{
+        id: deck.id,
+        title: deck.title,
+        description: deck.description,
+        visibility: deck.visibility,
+        createdAt: deck.createdAt.toISOString(),
+        username: deck.username,
+        displayUsername: deck.displayUsername,
+      }}
+      items={items}
+      isOwner={viewerId === deck.userId}
+    />
+  );
+}

--- a/web/src/app/community/decks/page.tsx
+++ b/web/src/app/community/decks/page.tsx
@@ -1,0 +1,50 @@
+import type { Metadata } from "next";
+import { communityEnabled } from "@/lib/community/db";
+import { listPublicDecks } from "@/lib/community/queries";
+import { toDeckCardItem } from "@/lib/community/serialize";
+import DeckCard from "@/components/community/DeckCard";
+import styles from "@/components/community/Community.module.css";
+
+// The deck feed: curated, ordered sets somebody chose to stake a public slot
+// on. Deliberately small — two public decks per account keeps this a shelf,
+// not a firehose, and that scarcity is what makes "in decks" a ranking signal
+// worth having on the pattern feed.
+
+export const dynamic = "force-dynamic";
+
+export const metadata: Metadata = {
+  title: "Decks / Patternflow Community",
+  description:
+    "Curated, ordered sets of LED matrix patterns — arranged by the community, buildable onto a board in one go.",
+};
+
+export default async function CommunityDecksPage() {
+  if (!communityEnabled()) return null; // layout already rendered the notice
+
+  const items = (await listPublicDecks()).map(toDeckCardItem);
+
+  return (
+    <div className={styles.decksPage}>
+      <div className={styles.introRow}>
+        <span>
+          Decks are ordered sets — the order they cycle on the device. Open one to play it, or
+          copy it into your own deck as a starting point. Each account gets two public decks, so
+          what is here is what somebody chose to stand behind.
+        </span>
+      </div>
+
+      {items.length === 0 ? (
+        <div className={styles.empty}>
+          No decks shared yet. Arrange one in the Deck panel above, then press &ldquo;Share
+          deck&rdquo;.
+        </div>
+      ) : (
+        <div className={styles.deckGrid}>
+          {items.map((deck) => (
+            <DeckCard key={deck.id} deck={deck} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/app/community/layout.tsx
+++ b/web/src/app/community/layout.tsx
@@ -5,7 +5,7 @@ import type { Metadata } from "next";
 import { isAdminSession } from "@/lib/community/admin";
 import { getAuth } from "@/lib/community/auth";
 import { communityEnabled, communityHomeUrl } from "@/lib/community/db";
-import { countOpenReports } from "@/lib/community/queries";
+import { countOpenReports, countUnreadNotifications } from "@/lib/community/queries";
 import AuthStatus from "@/components/community/AuthStatus";
 import CommunityNav from "@/components/community/CommunityNav";
 import DeckPanel from "@/components/community/DeckPanel";
@@ -55,6 +55,9 @@ export default async function CommunityLayout({ children }: { children: React.Re
   const session = await getAuth().api.getSession({ headers: await headers() });
   const isAdmin = isAdminSession(session);
   const openReports = isAdmin ? await countOpenReports() : 0;
+  // Read fresh on every page load — that is the whole notification system's
+  // idea of "delivery" on a server-rendered site.
+  const unread = session ? await countUnreadNotifications(session.user.id) : 0;
 
   return (
     <main className={styles.page}>
@@ -75,6 +78,16 @@ export default async function CommunityLayout({ children }: { children: React.Re
             <Link href="/pattern-lab" title="Open Pattern Lab editor">
               Pattern Lab ↗
             </Link>
+            {session && (
+              <Link
+                href="/community/notifications"
+                className={styles.notifyLink}
+                data-unread={unread > 0}
+                title="Comments on your work, forks, and decks your patterns joined"
+              >
+                Alerts{unread > 0 ? ` (${unread})` : ""}
+              </Link>
+            )}
             <AuthStatus />
           </nav>
         </header>

--- a/web/src/app/community/notifications/page.tsx
+++ b/web/src/app/community/notifications/page.tsx
@@ -1,0 +1,46 @@
+import { headers } from "next/headers";
+import type { Metadata } from "next";
+import { getAuth } from "@/lib/community/auth";
+import { communityEnabled } from "@/lib/community/db";
+import { listNotifications } from "@/lib/community/queries";
+import NotificationsList from "@/components/community/NotificationsList";
+import styles from "@/components/community/Community.module.css";
+
+// What happened to your things while you were away: comments on your work,
+// threads you joined, forks, and decks your patterns entered. Opening this
+// page marks everything read (the client fires that after render — never
+// during it, or a link prefetch would eat the unread state).
+
+export const dynamic = "force-dynamic";
+
+export const metadata: Metadata = {
+  title: "Alerts / Patternflow Community",
+  description: "Comments, forks and deck inclusions on your patterns and posts.",
+};
+
+export default async function CommunityNotificationsPage() {
+  if (!communityEnabled()) return null; // layout already rendered the notice
+
+  const session = await getAuth().api.getSession({ headers: await headers() });
+  if (!session) {
+    return (
+      <div className={styles.empty}>
+        Sign in to see alerts about your patterns, posts and comments.
+      </div>
+    );
+  }
+
+  const items = (await listNotifications(session.user.id)).map((row) => ({
+    id: row.id,
+    type: row.type,
+    targetType: row.targetType,
+    targetId: row.targetId,
+    targetTitle: row.targetTitle,
+    snippet: row.snippet,
+    unread: row.readAt === null,
+    createdAt: row.createdAt.toISOString(),
+    actor: row.actorDisplayUsername ?? row.actorUsername ?? "unknown",
+  }));
+
+  return <NotificationsList items={items} />;
+}

--- a/web/src/app/community/p/[id]/PatternDetailClient.tsx
+++ b/web/src/app/community/p/[id]/PatternDetailClient.tsx
@@ -51,11 +51,19 @@ export type PatternView = {
   madeOn: string | null;
   /** Author's declaration of how it was made, when they gave one. */
   madeHow: string | null;
+  /** "public" | "unlisted" | "private" — the page is already gated server-side. */
+  visibility: string;
   provenance: Provenance;
   createdAt: string; // ISO
   username: string | null;
   displayUsername: string | null;
-  parent: { id: string; title: string; handle: string | null; license: string } | null;
+  parent: {
+    id: string;
+    title: string;
+    handle: string | null;
+    license: string;
+    visibility: string;
+  } | null;
   likeCount: number;
   forkCount: number;
 };
@@ -478,10 +486,28 @@ export default function PatternDetailClient({
               <span className={styles.hwChip}>.h</span> hardware ready
             </span>
           )}
+          {pattern.visibility !== "public" && (
+            <span
+              className={styles.visChip}
+              title={
+                pattern.visibility === "private"
+                  ? "Private — only you can open this page"
+                  : "Unlisted — off the feed, anyone with this link can open it"
+              }
+            >
+              {pattern.visibility}
+            </span>
+          )}
           {pattern.parent && (
             <span className={styles.forkNote}>
               forked from{" "}
-              <Link href={`/community/p/${pattern.parent.id}`}>{pattern.parent.title}</Link>
+              {pattern.parent.visibility === "private" ? (
+                // The parent went private after this fork: the credit stands
+                // (it is baked into the source) but the link would 404.
+                <span title="The original is now private">{pattern.parent.title}</span>
+              ) : (
+                <Link href={`/community/p/${pattern.parent.id}`}>{pattern.parent.title}</Link>
+              )}
             </span>
           )}
           {/* Last in the row on purpose: available, never the thing you notice. */}
@@ -572,6 +598,7 @@ export default function PatternDetailClient({
           initialLicense={pattern.license}
           initialMadeOn={pattern.madeOn}
           initialMadeHow={pattern.madeHow}
+          initialVisibility={pattern.visibility}
           parentLicense={pattern.parent?.license ?? null}
           onClose={() => setDetailsModalOpen(false)}
         />

--- a/web/src/app/community/p/[id]/page.tsx
+++ b/web/src/app/community/p/[id]/page.tsx
@@ -1,10 +1,12 @@
 import { headers } from "next/headers";
 import { notFound } from "next/navigation";
 import type { Metadata } from "next";
+import { isAdminSession } from "@/lib/community/admin";
 import { communityEnabled } from "@/lib/community/db";
 import { getAuth } from "@/lib/community/auth";
 import { getPattern, getPatternStub, hasLiked, listComments } from "@/lib/community/queries";
 import { provenanceFor } from "@/lib/community/provenance";
+import { canView } from "@/lib/community/visibility";
 import type { CommentView } from "@/components/community/CommentSection";
 import PatternDetailClient from "./PatternDetailClient";
 
@@ -22,7 +24,9 @@ export async function generateMetadata(props: RouteParams): Promise<Metadata> {
   if (!communityEnabled()) return {};
   const { id } = await props.params;
   const pattern = await getPattern(id);
-  if (!pattern) return {};
+  // Metadata is what previews and crawlers read, so a private pattern's title
+  // must not surface here — even the owner's tab goes generic.
+  if (!pattern || pattern.visibility === "private") return {};
   return {
     title: `${pattern.title} / Patternflow Community`,
     description: pattern.description ?? `An LED matrix pattern by ${pattern.displayUsername ?? pattern.username}.`,
@@ -38,14 +42,21 @@ export default async function CommunityPatternPage(props: RouteParams) {
   const pattern = await getPattern(id);
   if (!pattern) notFound();
 
-  const initialKnobs = k
-    ? k.split(",").map(Number).filter((v) => Number.isFinite(v))
-    : undefined;
-
   // Viewer context: whether they already liked this, and whether it's theirs to
   // edit. Signed-out visitors get `null` and simply see the read-only version.
   const session = await getAuth().api.getSession({ headers: await headers() });
   const viewerId = session?.user.id ?? null;
+
+  // Private is a 404 to everyone but the author (and moderators, who must be
+  // able to open what gets reported) — not a 403, which would confirm the id.
+  if (!canView(pattern.visibility, pattern.userId, viewerId, isAdminSession(session))) {
+    notFound();
+  }
+
+  const initialKnobs = k
+    ? k.split(",").map(Number).filter((v) => Number.isFinite(v))
+    : undefined;
+
   const liked = viewerId ? await hasLiked(viewerId, pattern.id) : false;
 
   const parent = pattern.parentId ? await getPatternStub(pattern.parentId) : null;
@@ -73,6 +84,7 @@ export default async function CommunityPatternPage(props: RouteParams) {
         license: pattern.license,
         madeOn: pattern.madeOn,
         madeHow: pattern.madeHow,
+        visibility: pattern.visibility,
         createdAt: pattern.createdAt.toISOString(),
         username: pattern.username,
         displayUsername: pattern.displayUsername,
@@ -87,6 +99,10 @@ export default async function CommunityPatternPage(props: RouteParams) {
               handle: parent.displayUsername ?? parent.username ?? null,
               // Bounds what this fork may be relicensed to.
               license: parent.license,
+              // A parent that went private after being forked keeps its credit
+              // (it is baked into the source) but loses its link — the client
+              // renders plain text instead of a 404 for everyone.
+              visibility: parent.visibility,
             }
           : null,
         likeCount: pattern.likeCount,

--- a/web/src/app/community/u/[username]/page.tsx
+++ b/web/src/app/community/u/[username]/page.tsx
@@ -4,8 +4,9 @@ import { notFound } from "next/navigation";
 import type { Metadata } from "next";
 import { communityEnabled } from "@/lib/community/db";
 import { getAuth } from "@/lib/community/auth";
-import { getUserByUsername, listPatternsByUser } from "@/lib/community/queries";
-import { toCardItem } from "@/lib/community/serialize";
+import { getUserByUsername, listDecksByUser, listPatternsByUser } from "@/lib/community/queries";
+import { toCardItem, toDeckCardItem } from "@/lib/community/serialize";
+import DeckCard from "@/components/community/DeckCard";
 import PatternCard from "@/components/community/PatternCard";
 import styles from "@/components/community/Community.module.css";
 
@@ -36,10 +37,14 @@ export default async function CommunityUserPage(props: RouteParams) {
   const profile = await getUserByUsername(username.toLowerCase());
   if (!profile) notFound();
 
-  const items = (await listPatternsByUser(profile.id)).map(toCardItem);
-
   const session = await getAuth().api.getSession({ headers: await headers() });
-  const isSelf = session?.user.id === profile.id;
+  const viewerId = session?.user.id ?? null;
+  const isSelf = viewerId === profile.id;
+
+  // The owner sees their whole archive, badges marking what is not public;
+  // visitors see the public rows only. Same rule for patterns and decks.
+  const items = (await listPatternsByUser(profile.id, viewerId)).map(toCardItem);
+  const deckItems = (await listDecksByUser(profile.id, viewerId)).map(toDeckCardItem);
 
   const handle = profile.displayUsername ?? profile.username;
   const hardwareReady = items.filter((item) => item.hasCpp).length;
@@ -86,9 +91,21 @@ export default async function CommunityUserPage(props: RouteParams) {
         </div>
       )}
 
+      {deckItems.length > 0 && (
+        <>
+          <h2 className={styles.profileSectionTitle}>Decks</h2>
+          <div className={styles.deckGrid}>
+            {deckItems.map((deck) => (
+              <DeckCard key={deck.id} deck={deck} />
+            ))}
+          </div>
+        </>
+      )}
+
       {isSelf && items.length > 0 && (
         <p className={styles.profileFootNote}>
-          Open any pattern to edit its details, attach a firmware header, or delete it.
+          Open any pattern to edit its details, attach a firmware header, or delete it. Patterns
+          marked unlisted or private are visible only to you here.
         </p>
       )}
     </div>

--- a/web/src/app/terms/page.tsx
+++ b/web/src/app/terms/page.tsx
@@ -183,6 +183,11 @@ export default function TermsPage() {
               <strong>What you publish</strong> — patterns, decks, comments, posts, likes, and
               firmware build requests.
             </li>
+            <li>
+              <strong>Alerts</strong> — a note when someone comments on your work, forks a pattern
+              of yours, or puts one in a public deck. Shown only inside the site; nothing is ever
+              emailed.
+            </li>
           </ul>
 
           <h3>How long we keep it</h3>
@@ -194,6 +199,10 @@ export default function TermsPage() {
             <li>
               <strong>Firmware build artifacts</strong> — <strong>30 days</strong>. They can always
               be rebuilt.
+            </li>
+            <li>
+              <strong>Alerts</strong> — <strong>90 days</strong>, read or unread, and sooner when
+              what they point at is deleted.
             </li>
             <li>
               <strong>Account and published content</strong> — until you remove them, subject to

--- a/web/src/app/terms/page.tsx
+++ b/web/src/app/terms/page.tsx
@@ -134,7 +134,7 @@ export default function TermsPage() {
         <section>
           <h2>7. Reporting something</h2>
           <p>
-            Every pattern, post and comment has a <strong>Report</strong> control. If you are not a
+            Every pattern, deck, post and comment has a <strong>Report</strong> control. If you are not a
             member — a rights holder sending a takedown notice, for example — email{" "}
             <a href={`mailto:${CONTACT}`}>{CONTACT}</a>. Please include a link to the content, what
             is wrong with it, and for a copyright claim a link to the original and enough contact
@@ -154,7 +154,7 @@ export default function TermsPage() {
             reasonable to do so we will say why.
           </p>
           <p>
-            You can delete your own patterns, posts and comments at any time. To close your account,
+            You can delete your own patterns, decks, posts and comments at any time. To close your account,
             email <a href={`mailto:${CONTACT}`}>{CONTACT}</a>.
           </p>
           <p className={styles.callout}>
@@ -180,8 +180,8 @@ export default function TermsPage() {
               user-agent of the sign-in. This is for security and abuse handling, not analytics.
             </li>
             <li>
-              <strong>What you publish</strong> — patterns, comments, posts, likes, and firmware
-              build requests.
+              <strong>What you publish</strong> — patterns, decks, comments, posts, likes, and
+              firmware build requests.
             </li>
           </ul>
 

--- a/web/src/components/community/Community.module.css
+++ b/web/src/components/community/Community.module.css
@@ -2124,3 +2124,162 @@
   display: flex;
   gap: 8px;
 }
+
+/* ── Visibility ──
+   Same visual family as .frameChip (outlined mono micro-label), muted rather
+   than alarming: unlisted/private are states the owner chose, not warnings.
+   Only ever rendered when not public, so the feed never shows it. */
+.visChip {
+  flex: none;
+  font-family: var(--pf-mono, monospace);
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--pf-ink-muted);
+  border: 1px dashed rgba(20, 20, 20, 0.4);
+  border-radius: 0;
+  padding: 1px 7px;
+  white-space: nowrap;
+}
+
+/* ── Shared decks ── */
+
+.decksPage,
+.deckPage {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  padding-bottom: 80px;
+}
+
+/* Same rhythm as the profile grid; a deck card is wider than a pattern card
+   because it carries a strip, not a single screen. */
+.deckGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  gap: 18px;
+}
+
+.deckCard {
+  display: block;
+  border: 1px solid rgba(20, 20, 20, 0.18);
+  border-radius: 0;
+  background: #ffffff;
+  text-decoration: none;
+  color: inherit;
+  overflow: hidden;
+  box-sizing: border-box;
+}
+
+.deckCard:hover {
+  border-color: rgba(20, 20, 20, 0.55);
+}
+
+/* First patterns in running order, left to right — the card IS the order. */
+.deckStrip {
+  position: relative;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 2px;
+  background: #09090b;
+}
+
+.deckStripSlot {
+  aspect-ratio: 1 / 2;
+  position: relative;
+  background: #09090b;
+  overflow: hidden;
+}
+
+.deckStripEmpty {
+  grid-column: 1 / -1;
+  aspect-ratio: 3 / 2;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--pf-ink-faint);
+  font-family: var(--pf-mono, monospace);
+  font-size: 11px;
+}
+
+.deckStripMore {
+  position: absolute;
+  right: 6px;
+  bottom: 6px;
+  z-index: 2;
+  font-family: var(--pf-mono, monospace);
+  font-size: 10px;
+  color: #ffffff;
+  background: rgba(9, 9, 11, 0.85);
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  padding: 1px 6px;
+}
+
+/* The deck page's running order: numbered slots, wrapping like the profile
+   grid. The number sits above the card, not on it — it belongs to the deck,
+   not to the pattern. */
+.deckSlots {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  gap: 18px;
+}
+
+.deckSlot {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-width: 0;
+}
+
+.deckSlotIndex {
+  font-family: var(--pf-mono, monospace);
+  font-size: 11px;
+  color: var(--pf-ink-faint);
+}
+
+/* A slot whose pattern is gone. The deck keeps the position and the name —
+   the arrangement is the deck author's work; the pattern was its author's. */
+.deckGap {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  min-height: 200px;
+  border: 1px dashed rgba(20, 20, 20, 0.35);
+  padding: 16px;
+  text-align: center;
+}
+
+.deckGapTitle {
+  font-size: 14px;
+  color: var(--pf-ink-muted);
+  text-decoration: line-through;
+}
+
+.deckGapReason {
+  font-family: var(--pf-mono, monospace);
+  font-size: 10px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--pf-ink-faint);
+}
+
+.deckVisControl {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12.5px;
+  color: var(--pf-ink-muted);
+}
+
+.profileSectionTitle {
+  margin: 34px 0 0;
+  font-size: 18px;
+  font-weight: 500;
+  color: var(--pf-ink);
+}

--- a/web/src/components/community/Community.module.css
+++ b/web/src/components/community/Community.module.css
@@ -2283,3 +2283,79 @@
   font-weight: 500;
   color: var(--pf-ink);
 }
+
+/* ── Alerts ──
+   Delivery is the next page load — no polling, no sockets. The header link
+   turns LED-orange while anything is unread, and goes quiet again. */
+
+.notifyLink[data-unread="true"] {
+  color: var(--pf-led);
+}
+
+.notifyList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  max-width: 720px;
+}
+
+.notifyRow {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  padding: 12px 2px;
+  border-bottom: 1px solid var(--pf-rule-soft);
+  text-decoration: none;
+  color: var(--pf-ink);
+}
+
+.notifyRow:hover {
+  background: rgba(20, 20, 20, 0.03);
+}
+
+/* The unread marker keeps its place when read, so rows do not shift as the
+   visit marks them — it just empties. */
+.notifyMark {
+  flex: none;
+  width: 7px;
+  height: 7px;
+  align-self: center;
+  border: 1px solid transparent;
+}
+
+.notifyRow[data-unread="true"] .notifyMark {
+  background: var(--pf-led);
+  border-color: var(--pf-led);
+}
+
+.notifyBody {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  min-width: 0;
+}
+
+.notifySentence {
+  font-size: 14px;
+  line-height: 1.4;
+}
+
+.notifySentence strong {
+  font-weight: 500;
+}
+
+.notifySnippet {
+  font-size: 12.5px;
+  color: var(--pf-ink-muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.notifyDate {
+  margin-left: auto;
+  flex: none;
+  font-family: var(--pf-mono, monospace);
+  font-size: 10px;
+  color: var(--pf-ink-faint);
+}

--- a/web/src/components/community/CommunityNav.tsx
+++ b/web/src/components/community/CommunityNav.tsx
@@ -17,6 +17,12 @@ const SECTIONS = [
       path === "/community" || path.startsWith("/community/p/") || path.startsWith("/community/u/"),
   },
   {
+    href: "/community/decks",
+    label: "Decks",
+    match: (path: string) =>
+      path.startsWith("/community/decks") || path.startsWith("/community/d/"),
+  },
+  {
     href: "/community/discussions",
     label: "Discussions",
     match: (path: string) => path.startsWith("/community/discussions"),

--- a/web/src/components/community/DeckCard.tsx
+++ b/web/src/components/community/DeckCard.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useState } from "react";
+import { renderPatternThumb } from "@/lib/community/thumbs";
+import { knobSetupFromCode } from "@/lib/community/knobs";
+import { describeMatrixShape, matrixFromCode } from "@/lib/patternMatrix";
+import styles from "./Community.module.css";
+
+// One deck in a listing: a short strip of its first patterns, in running
+// order, because the order is the work. Static thumbnails only — a deck list
+// with live sandboxes per slot would be dozens of iframes for one page.
+
+export type DeckCardItem = {
+  id: string;
+  title: string;
+  description: string | null;
+  visibility: string;
+  createdAt: string; // ISO
+  username: string | null;
+  displayUsername: string | null;
+  patternCount: number;
+  /** First few patterns in running order. */
+  preview: { id: string; title: string; code: string }[];
+};
+
+function StripThumb({ code, title }: { code: string; title: string }) {
+  const [thumb, setThumb] = useState<string | null>(null);
+  const rotate = describeMatrixShape(matrixFromCode(code)) === "landscape";
+
+  useEffect(() => {
+    let alive = true;
+    renderPatternThumb(code, knobSetupFromCode(code).values).then((result) => {
+      if (alive && result.ok && result.dataUrl) setThumb(result.dataUrl);
+    });
+    return () => {
+      alive = false;
+    };
+  }, [code]);
+
+  return (
+    <div className={styles.deckStripSlot} title={title}>
+      <div className={rotate ? styles.screenRotator : styles.screenUpright}>
+        {thumb ? (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img src={thumb} alt={`${title} preview`} />
+        ) : (
+          <div className={styles.cardThumbNote}>…</div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default function DeckCard({ deck }: { deck: DeckCardItem }) {
+  const shown = deck.preview.slice(0, 3);
+  const more = deck.patternCount - shown.length;
+
+  return (
+    <Link href={`/community/d/${deck.id}`} className={styles.deckCard}>
+      <div className={styles.deckStrip}>
+        {shown.map((pattern) => (
+          <StripThumb key={pattern.id} code={pattern.code} title={pattern.title} />
+        ))}
+        {shown.length === 0 && <div className={styles.deckStripEmpty}>empty</div>}
+        {more > 0 && <span className={styles.deckStripMore}>+{more}</span>}
+      </div>
+      <div className={styles.cardMeta}>
+        <div className={styles.cardTitle}>
+          <span className={styles.cardTitleText}>{deck.title}</span>
+          {deck.visibility !== "public" && (
+            <span className={styles.visChip}>{deck.visibility}</span>
+          )}
+        </div>
+        <div className={styles.cardByline}>
+          <span className={styles.userLink}>
+            @{deck.displayUsername ?? deck.username ?? "unknown"}
+          </span>
+          <span className={styles.cardStats}>
+            <span>
+              {deck.patternCount} {deck.patternCount === 1 ? "pattern" : "patterns"}
+            </span>
+            <span className={styles.cardDate}>{deck.createdAt.slice(0, 10)}</span>
+          </span>
+        </div>
+      </div>
+    </Link>
+  );
+}

--- a/web/src/components/community/DeckPanel.tsx
+++ b/web/src/components/community/DeckPanel.tsx
@@ -21,6 +21,7 @@ import {
 import { useDeviceHost } from "@/lib/community/deviceHost";
 import { captureEvent } from "@/lib/posthogEvents";
 import AuthModal from "./AuthModal";
+import ShareDeckModal from "./ShareDeckModal";
 import styles from "./Community.module.css";
 
 // The deck and the saved list, in one panel.
@@ -57,6 +58,9 @@ export default function DeckPanel() {
   const [note, setNote] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
   const [confirmEmpty, setConfirmEmpty] = useState(false);
+  // Sharing gets its own modal, opened with the panel closed — two stacked
+  // dialogs would fight over the overlay click.
+  const [shareOpen, setShareOpen] = useState(false);
   // Sign-in is asked for at the moment it is needed — building — and never for
   // looking at your own lists. Saving is a local bookmark; gating the panel on
   // an account would mean a signed-out visitor cannot see what they saved.
@@ -374,6 +378,17 @@ export default function DeckPanel() {
                             ? "Queueing…"
                             : `Build ${deck.length} module${deck.length === 1 ? "" : "s"}`}
                         </button>
+                        <button
+                          type="button"
+                          className={styles.btn}
+                          title="Publish this deck — its patterns and their order — as a page others can open and copy"
+                          onClick={() => {
+                            setOpen(false);
+                            setShareOpen(true);
+                          }}
+                        >
+                          Share deck
+                        </button>
                         <span className={styles.headerSpacer} />
                         {/* Two presses: a deck is cheap to rebuild but an
                             arranged one is not, and this sits next to the button
@@ -439,6 +454,8 @@ export default function DeckPanel() {
           </div>
         </div>
       )}
+
+      {shareOpen && <ShareDeckModal deck={deck} onClose={() => setShareOpen(false)} />}
     </>
   );
 }

--- a/web/src/components/community/EditDetailsModal.tsx
+++ b/web/src/components/community/EditDetailsModal.tsx
@@ -12,6 +12,13 @@ import {
 import { LICENSE_OPTIONS, forkLicenseOptions, licenseBySpdx } from "@/lib/sharePattern";
 import { captureEvent } from "@/lib/posthogEvents";
 import { COMMUNITY_FETCH_INIT, communityApiUrl } from "@/lib/community/apiBase";
+import {
+  VISIBILITY_HINTS,
+  VISIBILITY_LABELS,
+  VISIBILITY_VALUES,
+  cleanVisibility,
+  type Visibility,
+} from "@/lib/community/visibility";
 import styles from "./Community.module.css";
 
 // Author-only: edit the pattern's title, description and licence. Saving
@@ -25,6 +32,7 @@ export default function EditDetailsModal({
   initialLicense,
   initialMadeOn,
   initialMadeHow,
+  initialVisibility,
   parentLicense,
   onClose,
 }: {
@@ -34,6 +42,7 @@ export default function EditDetailsModal({
   initialLicense: string; // SPDX
   initialMadeOn: string | null; // YYYY-MM-DD
   initialMadeHow: string | null;
+  initialVisibility: string;
   /** Parent's SPDX id when this pattern is a fork — narrows what it may become. */
   parentLicense?: string | null;
   onClose: () => void;
@@ -45,6 +54,9 @@ export default function EditDetailsModal({
   const [madeOn, setMadeOn] = useState(initialMadeOn ?? "");
   const [madeHow, setMadeHow] = useState<MadeHow | "">(
     (initialMadeHow as MadeHow | null) ?? "",
+  );
+  const [visibility, setVisibility] = useState<Visibility>(
+    cleanVisibility(initialVisibility) ?? "public",
   );
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
@@ -75,7 +87,7 @@ export default function EditDetailsModal({
         method: "PATCH",
         ...COMMUNITY_FETCH_INIT,
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ title: trimmed, description, license, madeOn, madeHow }),
+        body: JSON.stringify({ title: trimmed, description, license, madeOn, madeHow, visibility }),
       });
       const payload = (await response.json()) as { error?: string };
       if (!response.ok) {
@@ -153,6 +165,26 @@ export default function EditDetailsModal({
                 </option>
               ))}
             </select>
+          </label>
+
+          <label className={styles.field}>
+            <span className={styles.fieldLabel}>Who can see it?</span>
+            <select
+              value={visibility}
+              onChange={(event) => setVisibility(event.target.value as Visibility)}
+            >
+              {VISIBILITY_VALUES.map((value) => (
+                <option key={value} value={value}>
+                  {VISIBILITY_LABELS[value]}
+                </option>
+              ))}
+            </select>
+            <span className={styles.fieldHint}>
+              {VISIBILITY_HINTS[visibility]}
+              {visibility === "private" &&
+                initialVisibility !== "private" &&
+                " If this pattern sits in somebody's published deck, its slot shows as a gap while it is private."}
+            </span>
           </label>
 
           <label className={styles.field}>

--- a/web/src/components/community/FeedControls.tsx
+++ b/web/src/components/community/FeedControls.tsx
@@ -12,6 +12,9 @@ const SORTS = [
   { id: "new", label: "Newest" },
   { id: "top", label: "Most liked" },
   { id: "forks", label: "Most forked" },
+  // Counts distinct OTHER people whose published decks carry the pattern —
+  // harder to game than likes, since it costs a public deck slot.
+  { id: "decks", label: "In decks" },
 ] as const;
 
 export default function FeedControls({

--- a/web/src/components/community/NotificationsList.tsx
+++ b/web/src/components/community/NotificationsList.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect } from "react";
+import { COMMUNITY_FETCH_INIT, communityApiUrl } from "@/lib/community/apiBase";
+import styles from "./Community.module.css";
+
+// The alerts list. Unread rows keep their marker for this visit — the
+// mark-read call fires once after mount and nothing re-renders, so what you
+// came to see stays highlighted until you leave.
+
+export type NotificationView = {
+  id: string;
+  type: string;
+  targetType: string;
+  targetId: string;
+  targetTitle: string;
+  snippet: string | null;
+  unread: boolean;
+  createdAt: string; // ISO
+  actor: string;
+};
+
+function targetHref(item: NotificationView): string {
+  if (item.targetType === "post") return `/community/discussions/${item.targetId}`;
+  if (item.targetType === "deck") return `/community/d/${item.targetId}`;
+  return `/community/p/${item.targetId}`;
+}
+
+/** The sentence, minus the actor handle that leads every row. */
+function describe(item: NotificationView): string {
+  switch (item.type) {
+    case "comment":
+      return `commented on “${item.targetTitle}”`;
+    case "thread":
+      return `also commented on “${item.targetTitle}”`;
+    case "fork":
+      return `published a fork of “${item.targetTitle}”`;
+    case "deck":
+      return `put “${item.snippet ?? "your pattern"}” in their deck “${item.targetTitle}”`;
+    default:
+      return `did something with “${item.targetTitle}”`;
+  }
+}
+
+export default function NotificationsList({ items }: { items: NotificationView[] }) {
+  useEffect(() => {
+    // Fire-and-forget: the badge clears on the next server-rendered page.
+    void fetch(communityApiUrl("/api/community/notifications/read"), {
+      method: "POST",
+      ...COMMUNITY_FETCH_INIT,
+    }).catch(() => undefined);
+  }, []);
+
+  if (items.length === 0) {
+    return (
+      <div className={styles.empty}>
+        Nothing yet. When someone comments on your work, forks a pattern of yours, or puts one in
+        a public deck, it shows up here.
+      </div>
+    );
+  }
+
+  return (
+    <ul className={styles.notifyList}>
+      {items.map((item) => (
+        <li key={item.id}>
+          <Link
+            href={targetHref(item)}
+            className={styles.notifyRow}
+            data-unread={item.unread}
+          >
+            <span className={styles.notifyMark} aria-hidden="true" />
+            <span className={styles.notifyBody}>
+              <span className={styles.notifySentence}>
+                <strong>@{item.actor}</strong> {describe(item)}
+              </span>
+              {item.snippet && item.type !== "deck" && (
+                <span className={styles.notifySnippet}>{item.snippet}</span>
+              )}
+            </span>
+            <span className={styles.notifyDate}>{item.createdAt.slice(0, 10)}</span>
+          </Link>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/web/src/components/community/PatternCard.tsx
+++ b/web/src/components/community/PatternCard.tsx
@@ -38,6 +38,11 @@ export type PatternCardItem = {
   forkCount: number;
   /** Ships a verified firmware header — flashable as-is. */
   hasCpp: boolean;
+  /** "public" | "unlisted" | "private" — a chip appears when not public,
+   *  which only ever happens on the owner's own profile. */
+  visibility: string;
+  /** Distinct other people whose public decks carry this pattern. */
+  deckCount: number;
 };
 
 export function formatDate(iso: string): string {
@@ -330,6 +335,18 @@ export default function PatternCard({
               .h
             </span>
           )}
+          {item.visibility !== "public" && (
+            <span
+              className={styles.visChip}
+              title={
+                item.visibility === "private"
+                  ? "Private — only you can open it"
+                  : "Unlisted — off the feed, anyone with the link"
+              }
+            >
+              {item.visibility}
+            </span>
+          )}
           {item.parentId && <span className={styles.forkChip}>fork</span>}
           {/* Only worth the space when it isn't the stock panel — that is the
               assumption a reader already has. */}
@@ -358,6 +375,11 @@ export default function PatternCard({
             {item.forkCount > 0 && (
               <span title={`Forked ${item.forkCount} times`}>
                 FRK {String(item.forkCount).padStart(2, "0")}
+              </span>
+            )}
+            {item.deckCount > 0 && (
+              <span title={`In ${item.deckCount} ${item.deckCount === 1 ? "person's" : "people's"} published decks`}>
+                DCK {String(item.deckCount).padStart(2, "0")}
               </span>
             )}
             <span className={styles.cardDate}>{formatDate(item.createdAt)}</span>

--- a/web/src/components/community/PublishModal.tsx
+++ b/web/src/components/community/PublishModal.tsx
@@ -12,6 +12,12 @@ import {
   type MadeHow,
 } from "@/lib/community/validate";
 import {
+  VISIBILITY_HINTS,
+  VISIBILITY_LABELS,
+  VISIBILITY_VALUES,
+  type Visibility,
+} from "@/lib/community/visibility";
+import {
   DEFAULT_LICENSE_ID,
   LICENSE_OPTIONS,
   forkLicenseOptions,
@@ -57,6 +63,9 @@ export default function PublishModal({
   const [title, setTitle] = useState("");
   const [description, setDescription] = useState("");
   const [madeHow, setMadeHow] = useState<MadeHow>("ai-assisted");
+  // Public by default — the feed is the point. The quieter states are for
+  // work in progress (private) and "look before I post it" (unlisted).
+  const [visibility, setVisibility] = useState<Visibility>("public");
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
 
@@ -93,6 +102,7 @@ export default function PublishModal({
           codeCpp: codeCpp ?? undefined,
           license: licenseById(licenseId).spdx,
           madeHow,
+          visibility,
           parentId,
         }),
       });
@@ -204,6 +214,24 @@ export default function PublishModal({
               </span>
             </label>
 
+            <label className={styles.field}>
+              <span className={styles.fieldLabel}>Who can see it?</span>
+              <select
+                value={visibility}
+                onChange={(event) => setVisibility(event.target.value as Visibility)}
+              >
+                {VISIBILITY_VALUES.map((value) => (
+                  <option key={value} value={value}>
+                    {VISIBILITY_LABELS[value]}
+                  </option>
+                ))}
+              </select>
+              <span className={styles.fieldHint}>
+                {VISIBILITY_HINTS[visibility]}
+                {visibility !== "public" && " You can change this any time from the pattern's page."}
+              </span>
+            </label>
+
             {error && <div className={styles.formError}>{error}</div>}
 
             <button
@@ -212,7 +240,13 @@ export default function PublishModal({
               disabled={busy}
               onClick={() => void publish()}
             >
-              {busy ? "Publishing…" : "Publish to feed"}
+              {busy
+                ? "Publishing…"
+                : visibility === "public"
+                  ? "Publish to feed"
+                  : visibility === "unlisted"
+                    ? "Publish unlisted"
+                    : "Save privately"}
             </button>
           </div>
         )}

--- a/web/src/components/community/ReportQueue.tsx
+++ b/web/src/components/community/ReportQueue.tsx
@@ -23,6 +23,7 @@ export type ReportView = {
 function targetHref(type: string, id: string): string | null {
   if (type === "pattern") return `/community/p/${id}`;
   if (type === "post") return `/community/discussions/${id}`;
+  if (type === "deck") return `/community/d/${id}`;
   return null; // a comment has no page of its own
 }
 

--- a/web/src/components/community/ShareDeckModal.tsx
+++ b/web/src/components/community/ShareDeckModal.tsx
@@ -1,0 +1,161 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { authClient } from "@/lib/community/auth-client";
+import { COMMUNITY_FETCH_INIT, communityApiUrl } from "@/lib/community/apiBase";
+import { PUBLIC_DECKS_MAX, type CollectedPattern } from "@/lib/community/deck";
+import { DESCRIPTION_MAX, TITLE_MAX } from "@/lib/community/validate";
+import {
+  VISIBILITY_HINTS,
+  VISIBILITY_LABELS,
+  VISIBILITY_VALUES,
+  type Visibility,
+} from "@/lib/community/visibility";
+import { captureEvent } from "@/lib/posthogEvents";
+import AuthModal from "./AuthModal";
+import styles from "./Community.module.css";
+
+// "Share deck" — publish the working deck as a deck other people can open.
+// The working deck stays local and keeps being the scratch list; what is
+// shared is a titled snapshot of its ids and order.
+
+export default function ShareDeckModal({
+  deck,
+  onClose,
+}: {
+  deck: CollectedPattern[];
+  onClose: () => void;
+}) {
+  const router = useRouter();
+  const { data: session, isPending } = authClient.useSession();
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+  // Sharing is why this modal is open, so the shareable default. The private
+  // option is still here — a deck saved to the server survives a cleared
+  // browser, which localStorage does not.
+  const [visibility, setVisibility] = useState<Visibility>("public");
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  const share = async () => {
+    const trimmed = title.trim();
+    setError(null);
+    if (trimmed.length === 0 || trimmed.length > TITLE_MAX) {
+      setError(`Title is required (max ${TITLE_MAX} characters).`);
+      return;
+    }
+    setBusy(true);
+    try {
+      const response = await fetch(communityApiUrl("/api/community/decks"), {
+        method: "POST",
+        ...COMMUNITY_FETCH_INIT,
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          title: trimmed,
+          description,
+          visibility,
+          patternIds: deck.map((item) => item.patternId),
+        }),
+      });
+      const payload = (await response.json()) as { id?: string; error?: string };
+      if (!response.ok || !payload.id) {
+        setError(payload.error ?? "Sharing failed.");
+        return;
+      }
+      captureEvent("community_deck_shared", {
+        deck_id: payload.id,
+        patterns: deck.length,
+        visibility,
+      });
+      router.push(`/community/d/${payload.id}`);
+      onClose();
+    } catch {
+      setError("Network error — is the community server reachable?");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className={styles.modalOverlay} role="dialog" aria-modal="true" onClick={onClose}>
+      <div className={styles.modalCard} onClick={(event) => event.stopPropagation()}>
+        <div className={styles.modalHeader}>
+          <span>Share deck</span>
+          <button type="button" onClick={onClose} aria-label="Close">
+            ×
+          </button>
+        </div>
+
+        {isPending ? (
+          <div className={styles.modalBody}>
+            <span className={styles.formNote}>Checking session…</span>
+          </div>
+        ) : !session ? (
+          <AuthModal embedded onClose={() => undefined} />
+        ) : (
+          <div className={styles.modalBody}>
+            <p className={styles.formNote}>
+              Sharing {deck.length} pattern{deck.length === 1 ? "" : "s"} in their current order —
+              the order they cycle on the device. The shared deck keeps pointing at the community
+              patterns; your working deck here stays yours to rearrange.
+            </p>
+
+            <label className={styles.field}>
+              <span className={styles.fieldLabel}>Title</span>
+              <input
+                className={styles.textInput}
+                value={title}
+                maxLength={TITLE_MAX}
+                autoFocus
+                placeholder="What is this set — a mood, a place, a night?"
+                onChange={(event) => setTitle(event.target.value)}
+              />
+            </label>
+
+            <label className={styles.field}>
+              <span className={styles.fieldLabel}>Description (optional)</span>
+              <textarea
+                className={styles.textInput}
+                rows={3}
+                value={description}
+                maxLength={DESCRIPTION_MAX}
+                onChange={(event) => setDescription(event.target.value)}
+              />
+            </label>
+
+            <label className={styles.field}>
+              <span className={styles.fieldLabel}>Who can see it?</span>
+              <select
+                value={visibility}
+                onChange={(event) => setVisibility(event.target.value as Visibility)}
+              >
+                {VISIBILITY_VALUES.map((value) => (
+                  <option key={value} value={value}>
+                    {VISIBILITY_LABELS[value]}
+                  </option>
+                ))}
+              </select>
+              <span className={styles.fieldHint}>
+                {VISIBILITY_HINTS[visibility]}
+                {visibility === "public" &&
+                  ` Public decks are rationed: ${PUBLIC_DECKS_MAX} per account, so a published deck is one you stand behind.`}
+              </span>
+            </label>
+
+            {error && <div className={styles.formError}>{error}</div>}
+
+            <button
+              type="button"
+              className={styles.btnAccent}
+              disabled={busy}
+              onClick={() => void share()}
+            >
+              {busy ? "Sharing…" : visibility === "public" ? "Publish deck" : "Share deck"}
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/web/src/lib/community/deck.ts
+++ b/web/src/lib/community/deck.ts
@@ -29,6 +29,18 @@ export type CollectedPattern = {
 /** Mirrors MAX_MODULE_PATTERNS_PER_BUILD on the build API. */
 export const DECK_MAX = 10;
 
+/**
+ * How many PUBLIC decks one account may share at once.
+ *
+ * A curation policy, not a technical limit — the opposite of DECK_MAX, which
+ * is a fact about firmware. Publishing a deck spends one of two slots, so a
+ * published deck is staked reputation rather than overflow storage: a shelf
+ * you must ration is a shelf you curate. Private and unlisted decks are not
+ * rationed. Raising this is easy; lowering it would strand people over the
+ * limit, which is why it starts small.
+ */
+export const PUBLIC_DECKS_MAX = 2;
+
 export const COLLECTION_EVENT = "pf-collection-changed";
 
 const DECK_KEY = "pf-deck";
@@ -118,6 +130,16 @@ export function deckRemove(patternId: string): void {
 
 export function deckClear(): void {
   write(DECK_KEY, []);
+}
+
+/**
+ * Replace the whole working deck in one move — how a shared deck is copied in.
+ * Order is preserved (it is the point of a deck); anything over the cap is
+ * dropped from the end. The caller confirms before overwriting a non-empty
+ * deck — this function does not ask.
+ */
+export function deckReplace(items: CollectedPattern[]): void {
+  write(DECK_KEY, items.slice(0, DECK_MAX));
 }
 
 /**

--- a/web/src/lib/community/deckShare.ts
+++ b/web/src/lib/community/deckShare.ts
@@ -1,0 +1,52 @@
+// Rules for sharing a deck — pure functions, so the API routes and the smoke
+// test run the same code. Database access stays in queries.ts.
+
+import { DECK_MAX } from "./deck";
+import type { Visibility } from "./visibility";
+
+/**
+ * The submitted running order: 1 to DECK_MAX pattern ids, no duplicates.
+ * Returns null when the shape is wrong — the caller answers 400.
+ */
+export function cleanPatternIds(raw: unknown): string[] | null {
+  if (!Array.isArray(raw)) return null;
+  if (raw.length === 0 || raw.length > DECK_MAX) return null;
+  const ids: string[] = [];
+  for (const entry of raw) {
+    if (typeof entry !== "string" || entry.length === 0 || entry.length > 64) return null;
+    ids.push(entry);
+  }
+  if (new Set(ids).size !== ids.length) return null;
+  return ids;
+}
+
+export type DeckPatternCheck =
+  | { ok: true; title: string }
+  /** Missing — or somebody else's private pattern, which must answer exactly
+   *  like missing so a deck submission cannot probe ids. */
+  | { ok: false; reason: "unavailable" }
+  /** The owner's own private pattern in a deck that would be visible to others. */
+  | { ok: false; reason: "private"; title: string };
+
+/**
+ * May this pattern sit in a deck with this visibility?
+ *
+ * A shared deck (public or unlisted) may carry public and unlisted patterns —
+ * unlisted is exactly the state for "in a deck but not in the feed". It may
+ * not carry private ones, which would either leak them or render as holes the
+ * author never chose to publish.
+ */
+export function checkDeckPattern(
+  pattern: { title: string; userId: string; visibility: string } | undefined,
+  deckVisibility: Visibility,
+  ownerId: string,
+): DeckPatternCheck {
+  if (!pattern) return { ok: false, reason: "unavailable" };
+  if (pattern.visibility === "private") {
+    if (pattern.userId !== ownerId) return { ok: false, reason: "unavailable" };
+    if (deckVisibility !== "private") {
+      return { ok: false, reason: "private", title: pattern.title };
+    }
+  }
+  return { ok: true, title: pattern.title };
+}

--- a/web/src/lib/community/notify.ts
+++ b/web/src/lib/community/notify.ts
@@ -1,0 +1,216 @@
+import { and, eq, isNull } from "drizzle-orm";
+import { getDb } from "./db";
+import { newId } from "./queries";
+import { comments, notifications, postComments } from "./schema";
+
+// Fan-out on write: the mutation that causes a notification also records it,
+// one row per recipient. Nothing here is real-time — the rows sit until the
+// recipient's next page load reads the count.
+//
+// Two rules every writer follows:
+//   - never notify the actor about their own act
+//   - each recipient gets at most one row per event
+
+const SNIPPET_MAX = 120;
+
+/** One line of preview — the row has to read without opening anything. */
+function snippetOf(body: string): string {
+  const flat = body.replace(/\s+/g, " ").trim();
+  return flat.length > SNIPPET_MAX ? `${flat.slice(0, SNIPPET_MAX - 1)}…` : flat;
+}
+
+export type NotificationType = "comment" | "thread" | "fork" | "deck";
+
+type Seed = {
+  userId: string;
+  type: NotificationType;
+  actorId: string;
+  targetType: "pattern" | "post" | "deck";
+  targetId: string;
+  targetTitle: string;
+  sourceId?: string | null;
+  snippet?: string | null;
+};
+
+async function insertAll(seeds: Seed[]): Promise<void> {
+  if (seeds.length === 0) return;
+  const now = new Date();
+  await getDb()
+    .insert(notifications)
+    .values(
+      seeds.map((seed) => ({
+        id: newId(),
+        userId: seed.userId,
+        type: seed.type,
+        actorId: seed.actorId,
+        targetType: seed.targetType,
+        targetId: seed.targetId,
+        targetTitle: seed.targetTitle,
+        sourceId: seed.sourceId ?? null,
+        snippet: seed.snippet ?? null,
+        createdAt: now,
+      })),
+    );
+}
+
+/**
+ * A new comment notifies the owner ("comment") and everyone who commented on
+ * the same thing earlier ("thread") — which is what a reply means on a flat
+ * thread. The actor is excluded from both, and the owner never gets the
+ * weaker "thread" row on top of their "comment" one.
+ */
+export async function notifyCommentAdded(opts: {
+  on: "pattern" | "post";
+  targetId: string;
+  targetTitle: string;
+  ownerId: string;
+  actorId: string;
+  commentId: string;
+  body: string;
+}): Promise<void> {
+  const snippet = snippetOf(opts.body);
+  const seeds: Seed[] = [];
+
+  if (opts.ownerId !== opts.actorId) {
+    seeds.push({
+      userId: opts.ownerId,
+      type: "comment",
+      actorId: opts.actorId,
+      targetType: opts.on,
+      targetId: opts.targetId,
+      targetTitle: opts.targetTitle,
+      sourceId: opts.commentId,
+      snippet,
+    });
+  }
+
+  const db = getDb();
+  const earlier =
+    opts.on === "pattern"
+      ? await db
+          .selectDistinct({ userId: comments.userId })
+          .from(comments)
+          .where(eq(comments.patternId, opts.targetId))
+      : await db
+          .selectDistinct({ userId: postComments.userId })
+          .from(postComments)
+          .where(eq(postComments.postId, opts.targetId));
+
+  for (const row of earlier) {
+    if (row.userId === opts.actorId || row.userId === opts.ownerId) continue;
+    seeds.push({
+      userId: row.userId,
+      type: "thread",
+      actorId: opts.actorId,
+      targetType: opts.on,
+      targetId: opts.targetId,
+      targetTitle: opts.targetTitle,
+      sourceId: opts.commentId,
+      snippet,
+    });
+  }
+
+  await insertAll(seeds);
+}
+
+/**
+ * A fork notifies the parent's author. The row points at the FORK — that is
+ * the thing worth opening — while the title names what was forked. Private
+ * forks notify nobody: the page the row links to would be a 404.
+ */
+export async function notifyForkPublished(opts: {
+  parentOwnerId: string;
+  parentTitle: string;
+  forkId: string;
+  forkVisibility: string;
+  actorId: string;
+}): Promise<void> {
+  if (opts.parentOwnerId === opts.actorId) return;
+  if (opts.forkVisibility === "private") return;
+  await insertAll([
+    {
+      userId: opts.parentOwnerId,
+      type: "fork",
+      actorId: opts.actorId,
+      targetType: "pattern",
+      targetId: opts.forkId,
+      targetTitle: opts.parentTitle,
+      sourceId: opts.forkId,
+    },
+  ]);
+}
+
+/**
+ * A pattern entering someone's PUBLIC deck notifies the pattern's author —
+ * the same act the feed's "in decks" sort counts, told to the person it
+ * credits. Unlisted and private decks notify nobody: the deck author chose
+ * not to list them, and the notification would hand out the link.
+ *
+ * Guarded against repeats: flipping a deck's visibility back and forth, or
+ * re-publishing its contents, must not re-notify while the first row is
+ * still unread.
+ */
+export async function notifyDeckInclusion(opts: {
+  deckId: string;
+  deckTitle: string;
+  actorId: string;
+  patterns: { id: string; title: string; userId: string }[];
+}): Promise<void> {
+  const db = getDb();
+  const seeds: Seed[] = [];
+  for (const pattern of opts.patterns) {
+    if (pattern.userId === opts.actorId) continue;
+    const unread = await db
+      .select({ id: notifications.id })
+      .from(notifications)
+      .where(
+        and(
+          eq(notifications.userId, pattern.userId),
+          eq(notifications.type, "deck"),
+          eq(notifications.targetId, opts.deckId),
+          eq(notifications.sourceId, pattern.id),
+          isNull(notifications.readAt),
+        ),
+      )
+      .limit(1);
+    if (unread.length > 0) continue;
+    seeds.push({
+      userId: pattern.userId,
+      type: "deck",
+      actorId: opts.actorId,
+      targetType: "deck",
+      targetId: opts.deckId,
+      targetTitle: opts.deckTitle,
+      sourceId: pattern.id,
+      snippet: pattern.title,
+    });
+  }
+  await insertAll(seeds);
+}
+
+/**
+ * Cleanup for content deletion routes. A notification pointing at something
+ * gone is noise, so the route that removes a pattern, post, deck or comment
+ * calls this with the removed id — it clears rows that point AT the thing
+ * and rows triggered BY it.
+ */
+export async function clearNotificationsFor(opts: {
+  targetType?: "pattern" | "post" | "deck";
+  targetId?: string;
+  sourceId?: string;
+}): Promise<void> {
+  const db = getDb();
+  if (opts.targetType && opts.targetId) {
+    await db
+      .delete(notifications)
+      .where(
+        and(
+          eq(notifications.targetType, opts.targetType),
+          eq(notifications.targetId, opts.targetId),
+        ),
+      );
+  }
+  if (opts.sourceId) {
+    await db.delete(notifications).where(eq(notifications.sourceId, opts.sourceId));
+  }
+}

--- a/web/src/lib/community/queries.ts
+++ b/web/src/lib/community/queries.ts
@@ -1,6 +1,16 @@
-import { and, desc, eq, isNotNull, sql } from "drizzle-orm";
+import { and, desc, eq, inArray, isNotNull, ne, sql } from "drizzle-orm";
 import { getDb } from "./db";
-import { comments, likes, patterns, postComments, posts, reports, user } from "./schema";
+import {
+  comments,
+  deckPatterns,
+  decks,
+  likes,
+  patterns,
+  postComments,
+  posts,
+  reports,
+  user,
+} from "./schema";
 
 // Server-side read helpers for the community pages. Pages query the SQLite
 // file directly through these — no GET API layer for a single-process app.
@@ -20,9 +30,20 @@ const authorFields = {
 const likeCount = sql<number>`(SELECT COUNT(*) FROM ${likes} WHERE ${likes.patternId} = ${patterns.id})`;
 const forkCount = sql<number>`(SELECT COUNT(*) FROM ${patterns} AS child WHERE child.parent_id = ${patterns.id})`;
 const hasCpp = sql<number>`(${patterns.codeCpp} IS NOT NULL)`;
+// How many *other people* put this pattern in a public deck. Distinct owners,
+// not rows, and never the pattern's own author: a like costs a click, but this
+// costs one of somebody's two public deck slots spent on someone else's work —
+// which is why it ranks better than likes (#256).
+const deckCount = sql<number>`(
+  SELECT COUNT(DISTINCT d.user_id) FROM ${deckPatterns} AS dp
+  JOIN ${decks} AS d ON d.id = dp.deck_id
+  WHERE dp.pattern_id = ${patterns.id}
+    AND d.visibility = 'public'
+    AND d.user_id != ${patterns.userId}
+)`;
 
-/** Feed ordering. "top"/"forks" are all-time; add a time window once volume justifies it. */
-export const FEED_SORTS = ["new", "top", "forks"] as const;
+/** Feed ordering. "top"/"forks"/"decks" are all-time; add a time window once volume justifies it. */
+export const FEED_SORTS = ["new", "top", "forks", "decks"] as const;
 export type FeedSort = (typeof FEED_SORTS)[number];
 
 export function parseFeedSort(raw: string | undefined): FeedSort {
@@ -40,6 +61,10 @@ export type FeedItem = {
   likeCount: number;
   forkCount: number;
   hasCpp: boolean;
+  /** "public" | "unlisted" | "private" — always "public" in the feed itself. */
+  visibility: string;
+  /** Distinct other people whose public decks carry this pattern. */
+  deckCount: number;
 };
 
 const feedColumns = {
@@ -48,10 +73,12 @@ const feedColumns = {
   code: patterns.code,
   parentId: patterns.parentId,
   createdAt: patterns.createdAt,
+  visibility: patterns.visibility,
   ...authorFields,
   likeCount,
   forkCount,
   hasCpp,
+  deckCount,
 };
 
 type FeedRow = Omit<FeedItem, "hasCpp"> & { hasCpp: number | boolean };
@@ -61,12 +88,16 @@ function toFeedItems(rows: FeedRow[]): FeedItem[] {
   return rows.map((row) => ({ ...row, hasCpp: Boolean(row.hasCpp) }));
 }
 
+// The feed shows public patterns only. Unlisted and private rows exist in the
+// same table, so EVERY listing query needs this — a miss here is a leak (#255).
+const feedVisible = eq(patterns.visibility, "public");
+
 /** How many patterns match the current filter — drives the page count. */
 export async function countFeed(hardwareOnly = false): Promise<number> {
   const rows = await getDb()
     .select({ count: sql<number>`COUNT(*)` })
     .from(patterns)
-    .where(hardwareOnly ? isNotNull(patterns.codeCpp) : undefined);
+    .where(and(feedVisible, hardwareOnly ? isNotNull(patterns.codeCpp) : undefined));
   return rows[0]?.count ?? 0;
 }
 
@@ -89,13 +120,15 @@ export async function listFeed({
       ? [desc(likeCount), desc(patterns.createdAt)]
       : sort === "forks"
         ? [desc(forkCount), desc(patterns.createdAt)]
-        : [desc(patterns.createdAt)];
+        : sort === "decks"
+          ? [desc(deckCount), desc(patterns.createdAt)]
+          : [desc(patterns.createdAt)];
 
   const rows = await db
     .select(feedColumns)
     .from(patterns)
     .innerJoin(user, eq(patterns.userId, user.id))
-    .where(hardwareOnly ? isNotNull(patterns.codeCpp) : undefined)
+    .where(and(feedVisible, hardwareOnly ? isNotNull(patterns.codeCpp) : undefined))
     .orderBy(...order)
     .limit(limit)
     .offset(offset);
@@ -116,6 +149,7 @@ export async function getPattern(id: string) {
       madeOn: patterns.madeOn,
       madeHow: patterns.madeHow,
       parentId: patterns.parentId,
+      visibility: patterns.visibility,
       createdAt: patterns.createdAt,
       updatedAt: patterns.updatedAt,
       ...authorFields,
@@ -132,7 +166,9 @@ export async function getPattern(id: string) {
 /**
  * Parent info for the "forked from" link — and for the two things a fork owes
  * its parent: the upstream credit baked into the source, and the licence its
- * own choice has to stay compatible with.
+ * own choice has to stay compatible with. Carries visibility so interaction
+ * routes (like, comment, fork) can refuse private patterns without loading
+ * the whole row.
  */
 export async function getPatternStub(id: string) {
   const db = getDb();
@@ -142,6 +178,7 @@ export async function getPatternStub(id: string) {
       title: patterns.title,
       userId: patterns.userId,
       license: patterns.license,
+      visibility: patterns.visibility,
       ...authorFields,
     })
     .from(patterns)
@@ -234,7 +271,7 @@ export async function getCommentStub(on: "pattern" | "post", id: string) {
  * this is a label in a moderation list, not a copy of the content.
  */
 export async function reportTarget(
-  type: "pattern" | "post" | "comment",
+  type: "pattern" | "post" | "comment" | "deck",
   id: string,
 ): Promise<{ title: string; userId: string } | null> {
   const db = getDb();
@@ -243,6 +280,14 @@ export async function reportTarget(
       .select({ title: patterns.title, userId: patterns.userId })
       .from(patterns)
       .where(eq(patterns.id, id))
+      .limit(1);
+    return rows[0] ?? null;
+  }
+  if (type === "deck") {
+    const rows = await db
+      .select({ title: decks.title, userId: decks.userId })
+      .from(decks)
+      .where(eq(decks.id, id))
       .limit(1);
     return rows[0] ?? null;
   }
@@ -412,13 +457,272 @@ export async function getUserByUsername(usernameLower: string) {
   return rows[0] ?? null;
 }
 
-export async function listPatternsByUser(userId: string): Promise<FeedItem[]> {
+/**
+ * A profile is the complete archive only to its owner. Everyone else sees the
+ * public rows — unlisted stays reachable by link, not by browsing the author.
+ */
+export async function listPatternsByUser(
+  userId: string,
+  viewerId: string | null = null,
+): Promise<FeedItem[]> {
   const db = getDb();
   const rows = await db
     .select(feedColumns)
     .from(patterns)
     .innerJoin(user, eq(patterns.userId, user.id))
-    .where(eq(patterns.userId, userId))
+    .where(
+      viewerId === userId
+        ? eq(patterns.userId, userId)
+        : and(eq(patterns.userId, userId), feedVisible),
+    )
     .orderBy(desc(patterns.createdAt));
   return toFeedItems(rows);
+}
+
+// ── Decks ────────────────────────────────────────────────────────────────────
+// Shared decks: the ordered set someone published, distinct from the working
+// deck in localStorage (lib/community/deck.ts). Reads follow the same
+// visibility rules as patterns.
+
+const deckPatternCount = sql<number>`(SELECT COUNT(*) FROM ${deckPatterns} WHERE ${deckPatterns.deckId} = ${decks.id})`;
+
+export type DeckListItem = {
+  id: string;
+  title: string;
+  description: string | null;
+  visibility: string;
+  createdAt: Date;
+  updatedAt: Date;
+  username: string | null;
+  displayUsername: string | null;
+  patternCount: number;
+  /** First few patterns in running order — the card's thumbnail strip. */
+  preview: { id: string; title: string; code: string }[];
+};
+
+const deckListColumns = {
+  id: decks.id,
+  title: decks.title,
+  description: decks.description,
+  visibility: decks.visibility,
+  createdAt: decks.createdAt,
+  updatedAt: decks.updatedAt,
+  ...authorFields,
+  patternCount: deckPatternCount,
+};
+
+type DeckListRow = Omit<DeckListItem, "preview">;
+
+/**
+ * Attach each deck's first few visible patterns. One query per deck — at this
+ * scale (two public decks per account) a join-and-regroup would be more code
+ * than the problem.
+ */
+async function withPreviews(rows: DeckListRow[], perDeck = 3): Promise<DeckListItem[]> {
+  const db = getDb();
+  const result: DeckListItem[] = [];
+  for (const row of rows) {
+    const preview = await db
+      .select({ id: patterns.id, title: patterns.title, code: patterns.code })
+      .from(deckPatterns)
+      .innerJoin(patterns, eq(deckPatterns.patternId, patterns.id))
+      .where(
+        and(
+          eq(deckPatterns.deckId, row.id),
+          // A pattern that went private after the deck was published renders
+          // as a gap on the deck page, so it cannot headline the card either.
+          ne(patterns.visibility, "private"),
+        ),
+      )
+      .orderBy(deckPatterns.position)
+      .limit(perDeck);
+    result.push({ ...row, preview });
+  }
+  return result;
+}
+
+/** The deck feed: published decks, newest first. No pager yet — two public
+ *  decks per account keeps this list countable for a long while. */
+export async function listPublicDecks(limit = 60): Promise<DeckListItem[]> {
+  const rows = await getDb()
+    .select(deckListColumns)
+    .from(decks)
+    .innerJoin(user, eq(decks.userId, user.id))
+    .where(eq(decks.visibility, "public"))
+    .orderBy(desc(decks.createdAt))
+    .limit(limit);
+  return withPreviews(rows);
+}
+
+/** A profile's decks: all of them to the owner, public ones to everyone else. */
+export async function listDecksByUser(
+  userId: string,
+  viewerId: string | null = null,
+): Promise<DeckListItem[]> {
+  const rows = await getDb()
+    .select(deckListColumns)
+    .from(decks)
+    .innerJoin(user, eq(decks.userId, user.id))
+    .where(
+      viewerId === userId
+        ? eq(decks.userId, userId)
+        : and(eq(decks.userId, userId), eq(decks.visibility, "public")),
+    )
+    .orderBy(desc(decks.createdAt));
+  return withPreviews(rows);
+}
+
+export async function getDeck(id: string) {
+  const rows = await getDb()
+    .select({
+      id: decks.id,
+      userId: decks.userId,
+      title: decks.title,
+      description: decks.description,
+      visibility: decks.visibility,
+      createdAt: decks.createdAt,
+      updatedAt: decks.updatedAt,
+      ...authorFields,
+    })
+    .from(decks)
+    .innerJoin(user, eq(decks.userId, user.id))
+    .where(eq(decks.id, id))
+    .limit(1);
+  return rows[0] ?? null;
+}
+
+/** Ownership check for PATCH/DELETE, without loading the whole deck. */
+export async function getDeckStub(id: string) {
+  const rows = await getDb()
+    .select({ id: decks.id, userId: decks.userId, title: decks.title, visibility: decks.visibility })
+    .from(decks)
+    .where(eq(decks.id, id))
+    .limit(1);
+  return rows[0] ?? null;
+}
+
+export type DeckItem = {
+  position: number;
+  patternId: string;
+  titleSnapshot: string;
+  /** Null when the slot is a gap — see `gap`. */
+  pattern: FeedItem | null;
+  /** Why the slot is empty. A deck shows the gap rather than silently
+   *  shortening the set (#256): the running order is the author's work. */
+  gap: "deleted" | "private" | null;
+};
+
+/**
+ * A deck's contents in running order. `viewerId` decides whether a pattern
+ * that has since gone private still renders (its own author keeps seeing it).
+ */
+export async function listDeckItems(
+  deckId: string,
+  viewerId: string | null = null,
+): Promise<DeckItem[]> {
+  const rows = await getDb()
+    .select({
+      position: deckPatterns.position,
+      patternId: deckPatterns.patternId,
+      titleSnapshot: deckPatterns.titleSnapshot,
+      patternRow: {
+        id: patterns.id,
+        title: patterns.title,
+        code: patterns.code,
+        parentId: patterns.parentId,
+        createdAt: patterns.createdAt,
+        visibility: patterns.visibility,
+        userId: patterns.userId,
+      },
+      username: user.username,
+      displayUsername: user.displayUsername,
+      likeCount,
+      forkCount,
+      hasCpp,
+      deckCount,
+    })
+    .from(deckPatterns)
+    // LEFT joins: a deleted pattern's row is gone, and the whole point of the
+    // snapshot column is that the deck row survives it.
+    .leftJoin(patterns, eq(deckPatterns.patternId, patterns.id))
+    .leftJoin(user, eq(patterns.userId, user.id))
+    .where(eq(deckPatterns.deckId, deckId))
+    .orderBy(deckPatterns.position);
+
+  return rows.map((row) => {
+    if (!row.patternRow?.id) {
+      return {
+        position: row.position,
+        patternId: row.patternId,
+        titleSnapshot: row.titleSnapshot,
+        pattern: null,
+        gap: "deleted" as const,
+      };
+    }
+    const p = row.patternRow;
+    if (p.visibility === "private" && viewerId !== p.userId) {
+      return {
+        position: row.position,
+        patternId: row.patternId,
+        titleSnapshot: row.titleSnapshot,
+        pattern: null,
+        gap: "private" as const,
+      };
+    }
+    return {
+      position: row.position,
+      patternId: row.patternId,
+      titleSnapshot: row.titleSnapshot,
+      pattern: {
+        id: p.id,
+        title: p.title,
+        code: p.code,
+        parentId: p.parentId,
+        createdAt: p.createdAt,
+        visibility: p.visibility,
+        username: row.username,
+        displayUsername: row.displayUsername,
+        likeCount: row.likeCount,
+        forkCount: row.forkCount,
+        hasCpp: Boolean(row.hasCpp),
+        deckCount: row.deckCount,
+      },
+      gap: null,
+    };
+  });
+}
+
+/** How many public decks this account has — the two-slot cap's input. */
+export async function countPublicDecksByUser(
+  userId: string,
+  excludeDeckId?: string,
+): Promise<number> {
+  const rows = await getDb()
+    .select({ count: sql<number>`COUNT(*)` })
+    .from(decks)
+    .where(
+      and(
+        eq(decks.userId, userId),
+        eq(decks.visibility, "public"),
+        excludeDeckId ? ne(decks.id, excludeDeckId) : undefined,
+      ),
+    );
+  return rows[0]?.count ?? 0;
+}
+
+/**
+ * The rows a deck submission points at — existence and visibility checks
+ * happen against these, and the title snapshots are taken from them.
+ */
+export async function getPatternsForDeck(ids: string[]) {
+  if (ids.length === 0) return [];
+  return getDb()
+    .select({
+      id: patterns.id,
+      title: patterns.title,
+      userId: patterns.userId,
+      visibility: patterns.visibility,
+    })
+    .from(patterns)
+    .where(inArray(patterns.id, ids));
 }

--- a/web/src/lib/community/queries.ts
+++ b/web/src/lib/community/queries.ts
@@ -1,10 +1,11 @@
-import { and, desc, eq, inArray, isNotNull, ne, sql } from "drizzle-orm";
+import { and, desc, eq, inArray, isNotNull, isNull, ne, sql } from "drizzle-orm";
 import { getDb } from "./db";
 import {
   comments,
   deckPatterns,
   decks,
   likes,
+  notifications,
   patterns,
   postComments,
   posts,
@@ -416,10 +417,11 @@ export async function getPost(id: string) {
   return rows[0] ?? null;
 }
 
-/** Ownership check for edit/delete, without loading the body. */
+/** Ownership check for edit/delete, without loading the body. The title rides
+ *  along for notification rows, which snapshot it. */
 export async function getPostStub(id: string) {
   const rows = await getDb()
-    .select({ id: posts.id, userId: posts.userId })
+    .select({ id: posts.id, userId: posts.userId, title: posts.title })
     .from(posts)
     .where(eq(posts.id, id))
     .limit(1);
@@ -708,6 +710,113 @@ export async function countPublicDecksByUser(
       ),
     );
   return rows[0]?.count ?? 0;
+}
+
+// ── Notifications ────────────────────────────────────────────────────────────
+
+/** The header badge. Read on every page load, so it stays one indexed COUNT. */
+export async function countUnreadNotifications(userId: string): Promise<number> {
+  const rows = await getDb()
+    .select({ count: sql<number>`COUNT(*)` })
+    .from(notifications)
+    .where(and(eq(notifications.userId, userId), isNull(notifications.readAt)));
+  return rows[0]?.count ?? 0;
+}
+
+export type NotificationRow = {
+  id: string;
+  type: string;
+  targetType: string;
+  targetId: string;
+  targetTitle: string;
+  snippet: string | null;
+  readAt: Date | null;
+  createdAt: Date;
+  actorUsername: string | null;
+  actorDisplayUsername: string | null;
+};
+
+/**
+ * The recipient's notifications, newest first. Rows whose target has since
+ * gone private (and is not the recipient's own) are dropped at read time —
+ * the link would 404. Deleted targets are cleared by the delete routes; the
+ * join guard here is the belt to those braces, so the count and the list can
+ * disagree briefly. Opening the page marks everything read, which settles it.
+ */
+export async function listNotifications(
+  userId: string,
+  limit = 50,
+): Promise<NotificationRow[]> {
+  const rows = await getDb()
+    .select({
+      id: notifications.id,
+      type: notifications.type,
+      targetType: notifications.targetType,
+      targetId: notifications.targetId,
+      targetTitle: notifications.targetTitle,
+      snippet: notifications.snippet,
+      readAt: notifications.readAt,
+      createdAt: notifications.createdAt,
+      actorUsername: user.username,
+      actorDisplayUsername: user.displayUsername,
+      patternVisibility: patterns.visibility,
+      patternUserId: patterns.userId,
+      deckVisibility: decks.visibility,
+      deckUserId: decks.userId,
+      postId: posts.id,
+    })
+    .from(notifications)
+    .innerJoin(user, eq(notifications.actorId, user.id))
+    .leftJoin(
+      patterns,
+      and(eq(notifications.targetType, "pattern"), eq(notifications.targetId, patterns.id)),
+    )
+    .leftJoin(
+      decks,
+      and(eq(notifications.targetType, "deck"), eq(notifications.targetId, decks.id)),
+    )
+    .leftJoin(
+      posts,
+      and(eq(notifications.targetType, "post"), eq(notifications.targetId, posts.id)),
+    )
+    .where(eq(notifications.userId, userId))
+    .orderBy(desc(notifications.createdAt))
+    .limit(limit);
+
+  return rows
+    .filter((row) => {
+      if (row.targetType === "pattern") {
+        if (!row.patternUserId) return false;
+        return row.patternVisibility !== "private" || row.patternUserId === userId;
+      }
+      if (row.targetType === "deck") {
+        if (!row.deckUserId) return false;
+        return row.deckVisibility !== "private" || row.deckUserId === userId;
+      }
+      if (row.targetType === "post") return Boolean(row.postId);
+      return true;
+    })
+    .map((row) => ({
+      id: row.id,
+      type: row.type,
+      targetType: row.targetType,
+      targetId: row.targetId,
+      targetTitle: row.targetTitle,
+      snippet: row.snippet,
+      readAt: row.readAt,
+      createdAt: row.createdAt,
+      actorUsername: row.actorUsername,
+      actorDisplayUsername: row.actorDisplayUsername,
+    }));
+}
+
+/** Opening the notifications page reads everything — there is no per-row
+ *  unread state to manage at this scale. */
+export async function markNotificationsRead(userId: string): Promise<void> {
+  await getDb()
+    .update(notifications)
+    .set({ readAt: new Date() })
+    .where(and(eq(notifications.userId, userId), isNull(notifications.readAt)));
 }
 
 /**

--- a/web/src/lib/community/retention.ts
+++ b/web/src/lib/community/retention.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import { lt, isNotNull, sql } from "drizzle-orm";
 import { artifactDir } from "./builds";
 import { getDb } from "./db";
-import { builds, session, verification } from "./schema";
+import { builds, notifications, session, verification } from "./schema";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Retention sweep.
@@ -25,6 +25,10 @@ export const SESSION_MAX_AGE_DAYS = 90;
 /** /terms §9 — build artifacts last 30 days. They can always be rebuilt. */
 export const BUILD_MAX_AGE_DAYS = 30;
 
+/** /terms §9 — notifications last 90 days, read or not. After that an unread
+ *  one is not waiting, it is clutter. */
+export const NOTIFICATION_MAX_AGE_DAYS = 90;
+
 /**
  * A file on disk with no row pointing at it is only an orphan once the worker
  * has certainly finished with it. Inside this window it may simply be a build
@@ -37,6 +41,7 @@ export type SweepResult = {
   oldSessions: number;
   expiredVerifications: number;
   oldBuilds: number;
+  oldNotifications: number;
   artifactFilesDeleted: number;
   orphanFilesDeleted: number;
   artifactBytesFreed: number;
@@ -49,6 +54,7 @@ export function describeSweep(result: SweepResult): string {
     `sessions: ${result.expiredSessions} expired, ${result.oldSessions} over ${SESSION_MAX_AGE_DAYS}d`,
     `verifications: ${result.expiredVerifications} expired`,
     `builds: ${result.oldBuilds} over ${BUILD_MAX_AGE_DAYS}d`,
+    `notifications: ${result.oldNotifications} over ${NOTIFICATION_MAX_AGE_DAYS}d`,
     `files: ${result.artifactFilesDeleted} artifacts + ${result.orphanFilesDeleted} orphans (${mb} MB)`,
   ].join(" · ");
 }
@@ -69,6 +75,7 @@ export async function sweepRetention(now = new Date()): Promise<SweepResult> {
     oldSessions: 0,
     expiredVerifications: 0,
     oldBuilds: 0,
+    oldNotifications: 0,
     artifactFilesDeleted: 0,
     orphanFilesDeleted: 0,
     artifactBytesFreed: 0,
@@ -107,6 +114,21 @@ export async function sweepRetention(now = new Date()): Promise<SweepResult> {
     result.expiredVerifications = rows.length;
   } catch (error) {
     result.errors.push(`verifications: ${String(error)}`);
+  }
+
+  // ── Notifications ──────────────────────────────────────────────────────────
+  // Disposable by design (see schema.ts): read or unread, ninety days is the
+  // whole shelf life. The content deletion routes already cleared anything
+  // pointing at removed things; this ages out the rest.
+  try {
+    const cutoff = new Date(now.getTime() - NOTIFICATION_MAX_AGE_DAYS * DAY_MS);
+    const rows = await db
+      .delete(notifications)
+      .where(lt(notifications.createdAt, cutoff))
+      .returning({ id: notifications.id });
+    result.oldNotifications = rows.length;
+  } catch (error) {
+    result.errors.push(`notifications: ${String(error)}`);
   }
 
   // ── Builds ─────────────────────────────────────────────────────────────────
@@ -191,12 +213,17 @@ export async function previewRetention(now = new Date()): Promise<{
   oldSessions: number;
   expiredVerifications: number;
   oldBuilds: number;
+  oldNotifications: number;
 }> {
   const db = getDb();
   const sessionCutoff = new Date(now.getTime() - SESSION_MAX_AGE_DAYS * DAY_MS);
   const buildCutoff = new Date(now.getTime() - BUILD_MAX_AGE_DAYS * DAY_MS);
+  const notificationCutoff = new Date(now.getTime() - NOTIFICATION_MAX_AGE_DAYS * DAY_MS);
 
-  const count = async (table: typeof session | typeof verification | typeof builds, where: ReturnType<typeof lt>) => {
+  const count = async (
+    table: typeof session | typeof verification | typeof builds | typeof notifications,
+    where: ReturnType<typeof lt>,
+  ) => {
     const rows = await db.select({ n: sql<number>`COUNT(*)` }).from(table).where(where);
     return rows[0]?.n ?? 0;
   };
@@ -206,5 +233,6 @@ export async function previewRetention(now = new Date()): Promise<{
     oldSessions: await count(session, lt(session.createdAt, sessionCutoff)),
     expiredVerifications: await count(verification, lt(verification.expiresAt, now)),
     oldBuilds: await count(builds, lt(builds.createdAt, buildCutoff)),
+    oldNotifications: await count(notifications, lt(notifications.createdAt, notificationCutoff)),
   };
 }

--- a/web/src/lib/community/schema.ts
+++ b/web/src/lib/community/schema.ts
@@ -307,6 +307,65 @@ export const builds = sqliteTable(
   ],
 );
 
+// ── Notifications ────────────────────────────────────────────────────────────
+// In-app only, by policy: no email is ever sent (most accounts have none), and
+// nothing here is real-time — the badge is read on the next page load, which
+// is what a server-rendered site can promise honestly.
+//
+// A notification is DISPOSABLE — the deliberate opposite of a report. Reports
+// must outlive what they point at; a notification pointing at something gone
+// is pure noise, so content deletion routes clear these explicitly, and the
+// retention sweep ages the rest out (NOTIFICATION_MAX_AGE_DAYS).
+
+export const notifications = sqliteTable(
+  "notifications",
+  {
+    id: text("id").primaryKey(),
+    /** Recipient. */
+    userId: text("user_id")
+      .notNull()
+      .references(() => user.id, { onDelete: "cascade" }),
+    /**
+     * What happened:
+     *   "comment" — on something the recipient made
+     *   "thread"  — on something the recipient commented on earlier
+     *   "fork"    — their pattern was forked
+     *   "deck"    — their pattern entered someone's public deck
+     */
+    type: text("type").notNull(),
+    /** Who did it. Cascades: a deleted account takes its acts with it. */
+    actorId: text("actor_id")
+      .notNull()
+      .references(() => user.id, { onDelete: "cascade" }),
+    /**
+     * Where clicking goes: "pattern" | "post" | "deck". No foreign key — the
+     * types share one column — so the delete routes clear matching rows
+     * themselves, and the read path drops anything that slipped through.
+     */
+    targetType: text("target_type").notNull(),
+    targetId: text("target_id").notNull(),
+    /** Title at event time — the row reads without a join. */
+    targetTitle: text("target_title").notNull(),
+    /**
+     * The specific thing that triggered the row — a comment's id, or for
+     * "deck" the pattern that was included. The precise cleanup key: when
+     * that thing is deleted, rows carrying its id here go with it.
+     */
+    sourceId: text("source_id"),
+    /** Display extra: a comment's first line, or the pattern a deck took. */
+    snippet: text("snippet"),
+    readAt: integer("read_at", { mode: "timestamp" }),
+    createdAt: integer("created_at", { mode: "timestamp" }).notNull(),
+  },
+  (table) => [
+    // The badge (unread count) and the list both start from the recipient.
+    index("notifications_user_created_idx").on(table.userId, table.createdAt),
+    // Cleanup paths: by deleted content, and by deleted source.
+    index("notifications_target_idx").on(table.targetType, table.targetId),
+    index("notifications_source_idx").on(table.sourceId),
+  ],
+);
+
 // ── Moderation ───────────────────────────────────────────────────────────────
 // A report is a record, not a pointer. `targetId` and `targetUserId` carry NO
 // foreign key on purpose: the whole reason to keep reports is to see that the

--- a/web/src/lib/community/schema.ts
+++ b/web/src/lib/community/schema.ts
@@ -117,12 +117,23 @@ export const patterns = sqliteTable(
     parentId: text("parent_id").references((): AnySQLiteColumn => patterns.id, {
       onDelete: "set null",
     }),
+    /**
+     * "public" | "unlisted" | "private" — who can find it.
+     *
+     * Public is in the feed. Unlisted is reachable by link only — the "look at
+     * this before I post it" state, and what a shared deck can carry without
+     * flooding the feed. Private is the author alone (moderators keep sight of
+     * everything — visibility is not a shield from a report).
+     */
+    visibility: text("visibility").notNull().default("public"),
     createdAt: integer("created_at", { mode: "timestamp" }).notNull(),
     updatedAt: integer("updated_at", { mode: "timestamp" }).notNull(),
   },
   (table) => [
     index("patterns_created_at_idx").on(table.createdAt),
     index("patterns_user_id_idx").on(table.userId),
+    // The feed's exact shape: visible rows, newest first.
+    index("patterns_visibility_created_idx").on(table.visibility, table.createdAt),
   ],
 );
 
@@ -142,6 +153,60 @@ export const likes = sqliteTable(
   (table) => [
     primaryKey({ columns: [table.userId, table.patternId] }),
     index("likes_pattern_id_idx").on(table.patternId),
+  ],
+);
+
+// ── Shared decks ─────────────────────────────────────────────────────────────
+// A deck is an ordered set of patterns — a setlist, because the device cycles
+// them in sequence. The working deck stays in the browser's localStorage
+// (lib/community/deck.ts); a row here is the explicit act of sharing one.
+//
+// Publishing is deliberately scarce: two PUBLIC decks per account (see
+// PUBLIC_DECKS_MAX). That is a curation policy, not a technical limit — a
+// shelf you must ration is a shelf you curate. Private and unlisted decks are
+// not rationed.
+
+export const decks = sqliteTable(
+  "decks",
+  {
+    id: text("id").primaryKey(),
+    userId: text("user_id")
+      .notNull()
+      .references(() => user.id, { onDelete: "cascade" }),
+    title: text("title").notNull(),
+    description: text("description"),
+    /** "public" | "unlisted" | "private" — same three states as patterns. */
+    visibility: text("visibility").notNull().default("private"),
+    createdAt: integer("created_at", { mode: "timestamp" }).notNull(),
+    updatedAt: integer("updated_at", { mode: "timestamp" }).notNull(),
+  },
+  (table) => [
+    index("decks_user_id_idx").on(table.userId),
+    index("decks_visibility_created_idx").on(table.visibility, table.createdAt),
+  ],
+);
+
+export const deckPatterns = sqliteTable(
+  "deck_patterns",
+  {
+    deckId: text("deck_id")
+      .notNull()
+      .references(() => decks.id, { onDelete: "cascade" }),
+    /**
+     * NO foreign key on purpose (same reasoning as reports): deleting a pattern
+     * must leave a visible gap in the running order, not silently shorten
+     * somebody's arranged set. The title below is what the gap shows.
+     */
+    patternId: text("pattern_id").notNull(),
+    /** 0-based running order — the order the device cycles them. */
+    position: integer("position").notNull(),
+    /** What the pattern was called when the deck was published. */
+    titleSnapshot: text("title_snapshot").notNull(),
+  },
+  (table) => [
+    primaryKey({ columns: [table.deckId, table.patternId] }),
+    // The feed's "in decks" ranking signal counts through this.
+    index("deck_patterns_pattern_id_idx").on(table.patternId),
   ],
 );
 

--- a/web/src/lib/community/serialize.ts
+++ b/web/src/lib/community/serialize.ts
@@ -1,5 +1,6 @@
+import type { DeckCardItem } from "@/components/community/DeckCard";
 import type { PatternCardItem } from "@/components/community/PatternCard";
-import type { FeedItem } from "./queries";
+import type { DeckItem, DeckListItem, FeedItem } from "./queries";
 
 /** Server → client boundary: Dates become ISO strings. */
 export function toCardItem(item: FeedItem): PatternCardItem {
@@ -14,5 +15,40 @@ export function toCardItem(item: FeedItem): PatternCardItem {
     likeCount: item.likeCount,
     forkCount: item.forkCount,
     hasCpp: item.hasCpp,
+    visibility: item.visibility,
+    deckCount: item.deckCount,
+  };
+}
+
+export function toDeckCardItem(item: DeckListItem): DeckCardItem {
+  return {
+    id: item.id,
+    title: item.title,
+    description: item.description,
+    visibility: item.visibility,
+    createdAt: item.createdAt.toISOString(),
+    username: item.username,
+    displayUsername: item.displayUsername,
+    patternCount: item.patternCount,
+    preview: item.preview,
+  };
+}
+
+/** One slot of a deck page: a pattern card, or a named gap. */
+export type DeckPageItem = {
+  position: number;
+  patternId: string;
+  titleSnapshot: string;
+  pattern: PatternCardItem | null;
+  gap: "deleted" | "private" | null;
+};
+
+export function toDeckPageItem(item: DeckItem): DeckPageItem {
+  return {
+    position: item.position,
+    patternId: item.patternId,
+    titleSnapshot: item.titleSnapshot,
+    pattern: item.pattern ? toCardItem(item.pattern) : null,
+    gap: item.gap,
   };
 }

--- a/web/src/lib/community/validate.ts
+++ b/web/src/lib/community/validate.ts
@@ -128,7 +128,7 @@ export function cleanMadeHow(raw: unknown): string | null | undefined {
 
 // ── Reports ──────────────────────────────────────────────────────────────────
 
-export const REPORT_TARGET_TYPES = ["pattern", "post", "comment"] as const;
+export const REPORT_TARGET_TYPES = ["pattern", "post", "comment", "deck"] as const;
 export type ReportTargetType = (typeof REPORT_TARGET_TYPES)[number];
 
 export function isReportTargetType(raw: unknown): raw is ReportTargetType {

--- a/web/src/lib/community/visibility.ts
+++ b/web/src/lib/community/visibility.ts
@@ -1,0 +1,62 @@
+// Visibility — three states, not two, shared by patterns and decks.
+//
+// Public is in the feed. Private is the author alone. Unlisted is the one that
+// earns its keep: reachable by link but off the feed — "look at this before I
+// post it", and the state that lets a deck carry a pattern without that pattern
+// flooding the feed. Publishing still defaults to public: the community works
+// because things are shared, and the flood is handled by curation (decks as a
+// ranking signal), not by suppressing supply.
+//
+// Importable from client and server — no database access here.
+
+export const VISIBILITY_VALUES = ["public", "unlisted", "private"] as const;
+export type Visibility = (typeof VISIBILITY_VALUES)[number];
+
+export const VISIBILITY_LABELS: Record<Visibility, string> = {
+  public: "Public",
+  unlisted: "Unlisted",
+  private: "Private",
+};
+
+/** Shown under the picker — has to say what actually happens. */
+export const VISIBILITY_HINTS: Record<Visibility, string> = {
+  public: "In the community feed, for everyone.",
+  unlisted: "Off the feed — anyone with the link can open it.",
+  private: "Only you can open it.",
+};
+
+export function isVisibility(raw: unknown): raw is Visibility {
+  return typeof raw === "string" && VISIBILITY_VALUES.includes(raw as Visibility);
+}
+
+/** The value, or `undefined` when invalid. Callers pick their own default. */
+export function cleanVisibility(raw: unknown): Visibility | undefined {
+  return isVisibility(raw) ? raw : undefined;
+}
+
+/**
+ * Whether a viewer may open something with this visibility. Moderators pass:
+ * visibility is not a shield from a report, and a moderation queue that cannot
+ * open what it moderates would be theatre.
+ */
+export function canView(
+  visibility: string,
+  ownerId: string,
+  viewerId: string | null,
+  isAdmin = false,
+): boolean {
+  if (visibility !== "private") return true;
+  return viewerId === ownerId || isAdmin;
+}
+
+/**
+ * A fork bakes a `Based on:` credit link into its source. If the parent is
+ * private that link 404s for everyone (#255), so only the author may fork
+ * their own private work. Unlisted parents are forkable — the link resolves.
+ */
+export function forkBlocked(
+  parent: { visibility: string; userId: string },
+  viewerId: string,
+): boolean {
+  return parent.visibility === "private" && parent.userId !== viewerId;
+}


### PR DESCRIPTION
Two features the junk-feed problem asked for, and the notification rail on top of them.

## Pattern visibility (#255)

Three states — public (default) / unlisted / private — chosen at publish time, changeable from the pattern page. Every listing query filters on it; private is a 404 to everyone but the author (moderators keep sight of everything), cannot be forked by others, and takes no drive-by likes or comments. Unlisted is the load-bearing state: off the feed, reachable by link, welcome in shared decks.

## Shared decks (#256)

"Share deck" publishes a titled snapshot of the working deck's ids and order at `/community/d/[id]`, listed under a new **Decks** tab. **Two public decks per account** — a curation policy, deliberately unlike the build cap; unlisted/private decks are unrationed. A slot whose pattern was deleted or made private renders as a named gap, never a silently shorter set. Every slot credits the pattern's own author; "Copy to my deck" loads a shared deck back into the working one. The feed gains an **"In decks"** sort: distinct other people whose public decks carry the pattern — costs a slot, games worse than likes.

## In-app alerts

Comments on your work, comments on threads you joined (what a reply means on a flat thread), forks of your patterns, and your pattern entering someone's public deck. Delivery is the next page load — header shows "Alerts (n)", opening `/community/notifications` marks everything read. No email, no push. Notifications are disposable: content deletion clears them, targets gone private are hidden at read time, and the sweep ages everything out at 90 days (terms §9 updated).

## Verification

- New smoke suites: `check:sharing` (43 checks), `check:notify` (28 checks); all six existing suites green; tsc/lint clean.
- Live walkthrough on a community-enabled dev server: publish in all three states, feed filtering, slot cap (third public deck refused), private-in-deck refused, gap rendering for anonymous vs owner, copy-to-mine, all three alert types landing and the badge clearing on visit.
- Migrations `0009`/`0010` apply automatically on first DB open; existing rows default to public, so nothing visible changes on deploy until people use the new states.

Closes #255. Closes #256.

🤖 Generated with [Claude Code](https://claude.com/claude-code)