### PR TITLE
Community: infinite scroll feed, firmware ports, and the notice board

### DIFF
--- a/docs/COMMUNITY.md
+++ b/docs/COMMUNITY.md
@@ -42,11 +42,39 @@ database row on every save, never trusted from user input. Most people copy
 code out of the page rather than downloading a file, and a licence that only
 exists in the download is a licence most readers never see.
 
-**The firmware header (`.h`) is separate and optional.** It is the author's
-hand-verified C++ port, attached after the fact; a pattern that has one is
-"hardware ready" and can be flashed or built into a module directly. It is
-never auto-generated and never carried across a fork — the JavaScript may have
-changed, which would make the port a lie.
+**The firmware header (`.h`) is separate and optional.** It is a hand-verified
+C++ port, attached after the fact; a pattern that has one is "hardware ready"
+and can be flashed or built into a module directly. It is never auto-generated
+and never carried across a fork — the JavaScript may have changed, which would
+make the port a lie.
+
+### Community ports
+
+Some people make patterns without owning a board; some people own boards. A
+**port** is the second group finishing the first group's work: anyone can
+propose a verified `.h` for a pattern whose author has not attached their own
+("Port this pattern" on the pattern page).
+
+- **Live immediately** — no acceptance queue; a queue would rot on authors who
+  moved on. The author is notified instead, and moderation stays after the
+  fact, as everywhere else.
+- **Several can coexist** (the first may be wrong). Which one the pattern
+  ships: the **author's own header first**, else the **author's pinned pick**,
+  else the **oldest live port** — arrival order, because "latest wins" would
+  be hijackable.
+- **Credited, always**: the page says `port by @who`, and every port row names
+  its porter. The port is a derivative of the pattern, so it lives under the
+  pattern's licence — the work stays the author's; the porter's payment is
+  the credit.
+- **Version-bound**: when the pattern's JS changes, every port goes stale
+  ("for an older version") and stops resolving — the same rule that detaches
+  the author's own header on edit. Stale ports stay listed; a fresh
+  verification is a new port.
+- Porters can withdraw their own ports; moderators can remove any. The author
+  does not delete other people's ports — they out-rank them with a pin or
+  with their own header, same spirit as comments on their pattern.
+- The feed's `.h` chip and hardware filter mean "an effective header exists" —
+  the author's own or a live port, no distinction at that distance.
 
 **Untrusted code only ever runs inside a sandboxed iframe**
 (`web/public/pattern-sandbox.html`, `sandbox="allow-scripts"`, opaque origin,
@@ -268,7 +296,7 @@ first).
 | Unreferenced artifact files | Swept after a 24-hour grace window |
 | Notifications | **90 days**, read or not — and gone sooner if their subject is deleted |
 | Reports | Kept after the reported content is gone |
-| Patterns, decks, posts, comments | Until removed |
+| Patterns, decks, ports, posts, comments | Until removed |
 
 Changing a retention period means changing the constant in
 `web/src/lib/community/retention.ts` **and** the terms. Both, or the terms stop
@@ -288,6 +316,7 @@ npm run check:retention    # the sweep, against a throwaway database
 npm run check:deck         # deck cap, ordering, legacy migration
 npm run check:sharing      # visibility read paths, shared-deck rules, gaps
 npm run check:notify       # notification fan-out, cleanup, age-out
+npm run check:ports        # effective-header resolution, staleness, feed chip
 ```
 
 They exist for the failures that are silent. A sweep that deletes too little

--- a/docs/COMMUNITY.md
+++ b/docs/COMMUNITY.md
@@ -162,6 +162,20 @@ anything.
 
 ---
 
+## Discussions
+
+Plain-text threads for everything that isn't a pattern. Bodies and comments
+are stored exactly as typed and escaped on output; the only markup in the
+whole board is a ``` fence, which renders as a code block — the long posts
+here are build logs and compiler output, and a log squashed into a paragraph
+is unreadable. The fence changes the font, never the trust model.
+
+One post can be **the notice**: moderator-pinned, always first in the list,
+marked as such. One slot — pinning a post un-pins the previous one, because
+two notices are a noticeboard and this is a welcome mat.
+
+---
+
 ## Moderation
 
 | Capability | Who |

--- a/docs/COMMUNITY.md
+++ b/docs/COMMUNITY.md
@@ -213,9 +213,11 @@ What follows from a deck being somebody's arrangement:
   is the arrangement; the patterns stay their authors'.
 - "Copy to my deck" loads a shared deck into the working deck, order intact, so
   a shared deck is a starting point rather than a read-only artifact.
-- **"In decks" is a feed sort**: it counts how many *other* people put a
-  pattern in a public deck (distinct people, own decks excluded). It ranks
-  better than likes because it costs one of somebody's two slots.
+- **Deck membership shows on every card** (`DCK n`): distinct *other* people
+  whose public decks carry the pattern — own decks excluded, so it costs one
+  of somebody's two slots and games worse than likes. It is deliberately not
+  a feed sort yet; with a handful of decks it would reorder the feed on
+  almost no signal.
 - Decks are reportable and moderator-deletable like everything else, and the
   build path is untouched: a copied deck builds exactly as the working deck
   always has.
@@ -300,7 +302,7 @@ Listed because "is this missing or am I holding it wrong" deserves an answer.
 
 | | Status |
 | :--- | :--- |
-| **Tags and search** | Not built. The feed sorts by new / most liked / most forked / in decks, and filters for hardware-ready. |
+| **Tags and search** | Not built. The feed sorts by new / most liked / most forked, and filters for hardware-ready. |
 | **Self-serve account deletion** | Not built. Requests go to the address in the terms and are handled by hand. Published patterns are anonymised rather than removed — the licence granted is irrevocable and others may have built on them. |
 | **Email of any kind** | Not sent, ever. No verification, no notification, no password-reset mail — alerts exist only inside the site. |
 | **Approval queue for new patterns** | Not built, and not currently wanted — moderation is after the fact. |

--- a/docs/COMMUNITY.md
+++ b/docs/COMMUNITY.md
@@ -164,11 +164,12 @@ anything.
 
 ## Discussions
 
-Plain-text threads for everything that isn't a pattern. Bodies and comments
-are stored exactly as typed and escaped on output; the only markup in the
-whole board is a ``` fence, which renders as a code block — the long posts
-here are build logs and compiler output, and a log squashed into a paragraph
-is unreadable. The fence changes the font, never the trust model.
+The community's free board — ideas, questions, anything that isn't a
+pattern. Bodies and comments are stored exactly as typed and escaped on
+output. The one render-time nicety is the ``` fence, which shows its
+contents as a code block: most posts will never use it, but a pasted error
+log squashed into a paragraph is unreadable, and the fence costs nothing
+when unused. It changes the font, never the trust model.
 
 One post can be **the notice**: moderator-pinned, always first in the list,
 marked as such. One slot — pinning a post un-pins the previous one, because

--- a/web/drizzle/0011_add-pattern-ports.sql
+++ b/web/drizzle/0011_add-pattern-ports.sql
@@ -1,0 +1,14 @@
+CREATE TABLE `pattern_headers` (
+	`id` text PRIMARY KEY NOT NULL,
+	`pattern_id` text NOT NULL,
+	`user_id` text NOT NULL,
+	`code_cpp` text NOT NULL,
+	`note` text,
+	`stale` integer DEFAULT false NOT NULL,
+	`created_at` integer NOT NULL,
+	FOREIGN KEY (`pattern_id`) REFERENCES `patterns`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`user_id`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `pattern_headers_pattern_created_idx` ON `pattern_headers` (`pattern_id`,`created_at`);--> statement-breakpoint
+ALTER TABLE `patterns` ADD `pinned_header_id` text;

--- a/web/drizzle/0012_add-post-notice.sql
+++ b/web/drizzle/0012_add-post-notice.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `posts` ADD `pinned_at` integer;

--- a/web/drizzle/meta/0011_snapshot.json
+++ b/web/drizzle/meta/0011_snapshot.json
@@ -1,0 +1,1494 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "464ad064-03cf-4c81-a67a-14c533caa7d6",
+  "prevId": "b3a70742-e4d3-4514-a5d0-4a0b1d638bb7",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "builds": {
+      "name": "builds",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'queued'"
+        },
+        "format": {
+          "name": "format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'bin'"
+        },
+        "patterns": {
+          "name": "patterns",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "namespaces": {
+          "name": "namespaces",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "artifact": {
+          "name": "artifact",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "artifact_bytes": {
+          "name": "artifact_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "worker": {
+          "name": "worker",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "builds_status_created_idx": {
+          "name": "builds_status_created_idx",
+          "columns": [
+            "status",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "builds_user_id_idx": {
+          "name": "builds_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "builds_user_id_user_id_fk": {
+          "name": "builds_user_id_user_id_fk",
+          "tableFrom": "builds",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "comments": {
+      "name": "comments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pattern_id": {
+          "name": "pattern_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "edited_at": {
+          "name": "edited_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "comments_pattern_id_idx": {
+          "name": "comments_pattern_id_idx",
+          "columns": [
+            "pattern_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "comments_pattern_id_patterns_id_fk": {
+          "name": "comments_pattern_id_patterns_id_fk",
+          "tableFrom": "comments",
+          "tableTo": "patterns",
+          "columnsFrom": [
+            "pattern_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "comments_user_id_user_id_fk": {
+          "name": "comments_user_id_user_id_fk",
+          "tableFrom": "comments",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "deck_patterns": {
+      "name": "deck_patterns",
+      "columns": {
+        "deck_id": {
+          "name": "deck_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pattern_id": {
+          "name": "pattern_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title_snapshot": {
+          "name": "title_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "deck_patterns_pattern_id_idx": {
+          "name": "deck_patterns_pattern_id_idx",
+          "columns": [
+            "pattern_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "deck_patterns_deck_id_decks_id_fk": {
+          "name": "deck_patterns_deck_id_decks_id_fk",
+          "tableFrom": "deck_patterns",
+          "tableTo": "decks",
+          "columnsFrom": [
+            "deck_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "deck_patterns_deck_id_pattern_id_pk": {
+          "columns": [
+            "deck_id",
+            "pattern_id"
+          ],
+          "name": "deck_patterns_deck_id_pattern_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "decks": {
+      "name": "decks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'private'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "decks_user_id_idx": {
+          "name": "decks_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "decks_visibility_created_idx": {
+          "name": "decks_visibility_created_idx",
+          "columns": [
+            "visibility",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "decks_user_id_user_id_fk": {
+          "name": "decks_user_id_user_id_fk",
+          "tableFrom": "decks",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "likes": {
+      "name": "likes",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pattern_id": {
+          "name": "pattern_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "likes_pattern_id_idx": {
+          "name": "likes_pattern_id_idx",
+          "columns": [
+            "pattern_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "likes_user_id_user_id_fk": {
+          "name": "likes_user_id_user_id_fk",
+          "tableFrom": "likes",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "likes_pattern_id_patterns_id_fk": {
+          "name": "likes_pattern_id_patterns_id_fk",
+          "tableFrom": "likes",
+          "tableTo": "patterns",
+          "columnsFrom": [
+            "pattern_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "likes_user_id_pattern_id_pk": {
+          "columns": [
+            "user_id",
+            "pattern_id"
+          ],
+          "name": "likes_user_id_pattern_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "notifications": {
+      "name": "notifications",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_title": {
+          "name": "target_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "snippet": {
+          "name": "snippet",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "notifications_user_created_idx": {
+          "name": "notifications_user_created_idx",
+          "columns": [
+            "user_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "notifications_target_idx": {
+          "name": "notifications_target_idx",
+          "columns": [
+            "target_type",
+            "target_id"
+          ],
+          "isUnique": false
+        },
+        "notifications_source_idx": {
+          "name": "notifications_source_idx",
+          "columns": [
+            "source_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "notifications_user_id_user_id_fk": {
+          "name": "notifications_user_id_user_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notifications_actor_id_user_id_fk": {
+          "name": "notifications_actor_id_user_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "user",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "pattern_headers": {
+      "name": "pattern_headers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pattern_id": {
+          "name": "pattern_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code_cpp": {
+          "name": "code_cpp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stale": {
+          "name": "stale",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "pattern_headers_pattern_created_idx": {
+          "name": "pattern_headers_pattern_created_idx",
+          "columns": [
+            "pattern_id",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "pattern_headers_pattern_id_patterns_id_fk": {
+          "name": "pattern_headers_pattern_id_patterns_id_fk",
+          "tableFrom": "pattern_headers",
+          "tableTo": "patterns",
+          "columnsFrom": [
+            "pattern_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pattern_headers_user_id_user_id_fk": {
+          "name": "pattern_headers_user_id_user_id_fk",
+          "tableFrom": "pattern_headers",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "patterns": {
+      "name": "patterns",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code_cpp": {
+          "name": "code_cpp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "license": {
+          "name": "license",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'CC-BY-SA-4.0'"
+        },
+        "made_on": {
+          "name": "made_on",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "made_how": {
+          "name": "made_how",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'public'"
+        },
+        "pinned_header_id": {
+          "name": "pinned_header_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "patterns_created_at_idx": {
+          "name": "patterns_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "patterns_user_id_idx": {
+          "name": "patterns_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "patterns_visibility_created_idx": {
+          "name": "patterns_visibility_created_idx",
+          "columns": [
+            "visibility",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "patterns_user_id_user_id_fk": {
+          "name": "patterns_user_id_user_id_fk",
+          "tableFrom": "patterns",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "patterns_parent_id_patterns_id_fk": {
+          "name": "patterns_parent_id_patterns_id_fk",
+          "tableFrom": "patterns",
+          "tableTo": "patterns",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "post_comments": {
+      "name": "post_comments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "edited_at": {
+          "name": "edited_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "post_comments_post_id_idx": {
+          "name": "post_comments_post_id_idx",
+          "columns": [
+            "post_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "post_comments_post_id_posts_id_fk": {
+          "name": "post_comments_post_id_posts_id_fk",
+          "tableFrom": "post_comments",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_comments_user_id_user_id_fk": {
+          "name": "post_comments_user_id_user_id_fk",
+          "tableFrom": "post_comments",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "posts": {
+      "name": "posts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "posts_created_at_idx": {
+          "name": "posts_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "posts_user_id_idx": {
+          "name": "posts_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "posts_user_id_user_id_fk": {
+          "name": "posts_user_id_user_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "reports": {
+      "name": "reports",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_title": {
+          "name": "target_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "target_user_id": {
+          "name": "target_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reporter_id": {
+          "name": "reporter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'open'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "reports_status_created_idx": {
+          "name": "reports_status_created_idx",
+          "columns": [
+            "status",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "reports_target_user_idx": {
+          "name": "reports_target_user_idx",
+          "columns": [
+            "target_user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "reports_reporter_id_user_id_fk": {
+          "name": "reports_reporter_id_user_id_fk",
+          "tableFrom": "reports",
+          "tableTo": "user",
+          "columnsFrom": [
+            "reporter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "display_username": {
+          "name": "display_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        },
+        "user_username_unique": {
+          "name": "user_username_unique",
+          "columns": [
+            "username"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/web/drizzle/meta/0012_snapshot.json
+++ b/web/drizzle/meta/0012_snapshot.json
@@ -1,0 +1,1501 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "142bf9be-cdba-468f-9f66-b3906905d2d4",
+  "prevId": "464ad064-03cf-4c81-a67a-14c533caa7d6",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "builds": {
+      "name": "builds",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'queued'"
+        },
+        "format": {
+          "name": "format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'bin'"
+        },
+        "patterns": {
+          "name": "patterns",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "namespaces": {
+          "name": "namespaces",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "artifact": {
+          "name": "artifact",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "artifact_bytes": {
+          "name": "artifact_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "worker": {
+          "name": "worker",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "builds_status_created_idx": {
+          "name": "builds_status_created_idx",
+          "columns": [
+            "status",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "builds_user_id_idx": {
+          "name": "builds_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "builds_user_id_user_id_fk": {
+          "name": "builds_user_id_user_id_fk",
+          "tableFrom": "builds",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "comments": {
+      "name": "comments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pattern_id": {
+          "name": "pattern_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "edited_at": {
+          "name": "edited_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "comments_pattern_id_idx": {
+          "name": "comments_pattern_id_idx",
+          "columns": [
+            "pattern_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "comments_pattern_id_patterns_id_fk": {
+          "name": "comments_pattern_id_patterns_id_fk",
+          "tableFrom": "comments",
+          "tableTo": "patterns",
+          "columnsFrom": [
+            "pattern_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "comments_user_id_user_id_fk": {
+          "name": "comments_user_id_user_id_fk",
+          "tableFrom": "comments",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "deck_patterns": {
+      "name": "deck_patterns",
+      "columns": {
+        "deck_id": {
+          "name": "deck_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pattern_id": {
+          "name": "pattern_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title_snapshot": {
+          "name": "title_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "deck_patterns_pattern_id_idx": {
+          "name": "deck_patterns_pattern_id_idx",
+          "columns": [
+            "pattern_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "deck_patterns_deck_id_decks_id_fk": {
+          "name": "deck_patterns_deck_id_decks_id_fk",
+          "tableFrom": "deck_patterns",
+          "tableTo": "decks",
+          "columnsFrom": [
+            "deck_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "deck_patterns_deck_id_pattern_id_pk": {
+          "columns": [
+            "deck_id",
+            "pattern_id"
+          ],
+          "name": "deck_patterns_deck_id_pattern_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "decks": {
+      "name": "decks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'private'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "decks_user_id_idx": {
+          "name": "decks_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "decks_visibility_created_idx": {
+          "name": "decks_visibility_created_idx",
+          "columns": [
+            "visibility",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "decks_user_id_user_id_fk": {
+          "name": "decks_user_id_user_id_fk",
+          "tableFrom": "decks",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "likes": {
+      "name": "likes",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pattern_id": {
+          "name": "pattern_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "likes_pattern_id_idx": {
+          "name": "likes_pattern_id_idx",
+          "columns": [
+            "pattern_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "likes_user_id_user_id_fk": {
+          "name": "likes_user_id_user_id_fk",
+          "tableFrom": "likes",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "likes_pattern_id_patterns_id_fk": {
+          "name": "likes_pattern_id_patterns_id_fk",
+          "tableFrom": "likes",
+          "tableTo": "patterns",
+          "columnsFrom": [
+            "pattern_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "likes_user_id_pattern_id_pk": {
+          "columns": [
+            "user_id",
+            "pattern_id"
+          ],
+          "name": "likes_user_id_pattern_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "notifications": {
+      "name": "notifications",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_title": {
+          "name": "target_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "snippet": {
+          "name": "snippet",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "notifications_user_created_idx": {
+          "name": "notifications_user_created_idx",
+          "columns": [
+            "user_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "notifications_target_idx": {
+          "name": "notifications_target_idx",
+          "columns": [
+            "target_type",
+            "target_id"
+          ],
+          "isUnique": false
+        },
+        "notifications_source_idx": {
+          "name": "notifications_source_idx",
+          "columns": [
+            "source_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "notifications_user_id_user_id_fk": {
+          "name": "notifications_user_id_user_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notifications_actor_id_user_id_fk": {
+          "name": "notifications_actor_id_user_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "user",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "pattern_headers": {
+      "name": "pattern_headers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pattern_id": {
+          "name": "pattern_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code_cpp": {
+          "name": "code_cpp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stale": {
+          "name": "stale",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "pattern_headers_pattern_created_idx": {
+          "name": "pattern_headers_pattern_created_idx",
+          "columns": [
+            "pattern_id",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "pattern_headers_pattern_id_patterns_id_fk": {
+          "name": "pattern_headers_pattern_id_patterns_id_fk",
+          "tableFrom": "pattern_headers",
+          "tableTo": "patterns",
+          "columnsFrom": [
+            "pattern_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pattern_headers_user_id_user_id_fk": {
+          "name": "pattern_headers_user_id_user_id_fk",
+          "tableFrom": "pattern_headers",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "patterns": {
+      "name": "patterns",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code_cpp": {
+          "name": "code_cpp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "license": {
+          "name": "license",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'CC-BY-SA-4.0'"
+        },
+        "made_on": {
+          "name": "made_on",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "made_how": {
+          "name": "made_how",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'public'"
+        },
+        "pinned_header_id": {
+          "name": "pinned_header_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "patterns_created_at_idx": {
+          "name": "patterns_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "patterns_user_id_idx": {
+          "name": "patterns_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "patterns_visibility_created_idx": {
+          "name": "patterns_visibility_created_idx",
+          "columns": [
+            "visibility",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "patterns_user_id_user_id_fk": {
+          "name": "patterns_user_id_user_id_fk",
+          "tableFrom": "patterns",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "patterns_parent_id_patterns_id_fk": {
+          "name": "patterns_parent_id_patterns_id_fk",
+          "tableFrom": "patterns",
+          "tableTo": "patterns",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "post_comments": {
+      "name": "post_comments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "edited_at": {
+          "name": "edited_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "post_comments_post_id_idx": {
+          "name": "post_comments_post_id_idx",
+          "columns": [
+            "post_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "post_comments_post_id_posts_id_fk": {
+          "name": "post_comments_post_id_posts_id_fk",
+          "tableFrom": "post_comments",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_comments_user_id_user_id_fk": {
+          "name": "post_comments_user_id_user_id_fk",
+          "tableFrom": "post_comments",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "posts": {
+      "name": "posts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pinned_at": {
+          "name": "pinned_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "posts_created_at_idx": {
+          "name": "posts_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "posts_user_id_idx": {
+          "name": "posts_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "posts_user_id_user_id_fk": {
+          "name": "posts_user_id_user_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "reports": {
+      "name": "reports",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_title": {
+          "name": "target_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "target_user_id": {
+          "name": "target_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reporter_id": {
+          "name": "reporter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'open'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "reports_status_created_idx": {
+          "name": "reports_status_created_idx",
+          "columns": [
+            "status",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "reports_target_user_idx": {
+          "name": "reports_target_user_idx",
+          "columns": [
+            "target_user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "reports_reporter_id_user_id_fk": {
+          "name": "reports_reporter_id_user_id_fk",
+          "tableFrom": "reports",
+          "tableTo": "user",
+          "columnsFrom": [
+            "reporter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "display_username": {
+          "name": "display_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        },
+        "user_username_unique": {
+          "name": "user_username_unique",
+          "columns": [
+            "username"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/web/drizzle/meta/_journal.json
+++ b/web/drizzle/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1785537782506,
       "tag": "0010_add-notifications",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "6",
+      "when": 1785648191733,
+      "tag": "0011_add-pattern-ports",
+      "breakpoints": true
     }
   ]
 }

--- a/web/drizzle/meta/_journal.json
+++ b/web/drizzle/meta/_journal.json
@@ -85,6 +85,13 @@
       "when": 1785648191733,
       "tag": "0011_add-pattern-ports",
       "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "6",
+      "when": 1785649158014,
+      "tag": "0012_add-post-notice",
+      "breakpoints": true
     }
   ]
 }

--- a/web/package.json
+++ b/web/package.json
@@ -18,7 +18,8 @@
     "sweep": "tsx scripts/retention-sweep.ts",
     "check:deck": "tsx scripts/deck-smoke.ts",
     "check:sharing": "tsx scripts/sharing-smoke.ts",
-    "check:notify": "tsx scripts/notify-smoke.ts"
+    "check:notify": "tsx scripts/notify-smoke.ts",
+    "check:ports": "tsx scripts/ports-smoke.ts"
   },
   "dependencies": {
     "@chenglou/pretext": "^0.0.6",

--- a/web/scripts/ports-smoke.ts
+++ b/web/scripts/ports-smoke.ts
@@ -1,0 +1,192 @@
+/**
+ * Community-port smoke test — `npm run check:ports`.
+ *
+ * What this guards: which .h a pattern ships is a three-step resolution
+ * (author's own > author's pin > oldest live port), the feed's "hardware
+ * ready" chip and filter follow it, and a port of code that has since changed
+ * stops resolving. Any of these failing silently ships the wrong C++ to
+ * somebody's board.
+ */
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+// The database is a lazy singleton keyed off this variable, so it has to be set
+// before anything imports it — hence the dynamic imports below.
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "pf-ports-"));
+process.env.COMMUNITY_DB_PATH = path.join(tmp, "test.db");
+process.env.COMMUNITY_ENABLED = "1";
+
+const at = (day: number) => new Date(Date.UTC(2026, 6, day, 12, 0, 0));
+
+let failures = 0;
+
+function check(label: string, actual: unknown, expected: unknown) {
+  const ok = JSON.stringify(actual) === JSON.stringify(expected);
+  if (!ok) failures += 1;
+  console.log(
+    `${ok ? "  ok  " : "FAIL  "}${label}${ok ? "" : `\n        got ${JSON.stringify(actual)}\n        want ${JSON.stringify(expected)}`}`,
+  );
+}
+
+async function main() {
+  const { eq } = await import("drizzle-orm");
+  const { getDb } = await import("../src/lib/community/db");
+  const schema = await import("../src/lib/community/schema");
+  const queries = await import("../src/lib/community/queries");
+  const { resolveHeader } = await import("../src/lib/community/ports");
+
+  const db = getDb();
+
+  // ── The pure resolution order ──────────────────────────────────────────────
+  const port = (id: string, day: number, stale = false) => ({
+    id,
+    userId: `u-${id}`,
+    codeCpp: `#pragma once // ${id}`,
+    note: null,
+    stale,
+    createdAt: at(day),
+    username: id,
+    displayUsername: id,
+  });
+
+  console.log("\n── which header ships ──");
+  check("no header, no ports → nothing", resolveHeader({ codeCpp: null, pinnedHeaderId: null }, []), null);
+  check(
+    "the author's own header always wins",
+    resolveHeader({ codeCpp: "#pragma once // own", pinnedHeaderId: "b" }, [port("a", 1), port("b", 2)])?.source,
+    "author",
+  );
+  check(
+    "without a pin, first come first served",
+    (() => {
+      const r = resolveHeader({ codeCpp: null, pinnedHeaderId: null }, [port("a", 1), port("b", 2)]);
+      return r?.source === "port" ? r.portId : null;
+    })(),
+    "a",
+  );
+  check(
+    "the author's pin overrides arrival order",
+    (() => {
+      const r = resolveHeader({ codeCpp: null, pinnedHeaderId: "b" }, [port("a", 1), port("b", 2)]);
+      return r?.source === "port" ? r.portId : null;
+    })(),
+    "b",
+  );
+  check(
+    "a stale port never resolves, even pinned",
+    (() => {
+      const r = resolveHeader({ codeCpp: null, pinnedHeaderId: "b" }, [port("a", 1), port("b", 2, true)]);
+      return r?.source === "port" ? r.portId : null;
+    })(),
+    "a",
+  );
+  check(
+    "a pin pointing at nothing falls back",
+    (() => {
+      const r = resolveHeader({ codeCpp: null, pinnedHeaderId: "gone" }, [port("a", 1)]);
+      return r?.source === "port" ? r.portId : null;
+    })(),
+    "a",
+  );
+  check(
+    "only stale ports → nothing ships",
+    resolveHeader({ codeCpp: null, pinnedHeaderId: null }, [port("a", 1, true)]),
+    null,
+  );
+  check(
+    "the porter's handle rides along",
+    (() => {
+      const r = resolveHeader({ codeCpp: null, pinnedHeaderId: null }, [port("a", 1)]);
+      return r?.source === "port" ? r.handle : null;
+    })(),
+    "a",
+  );
+
+  // ── The feed follows the same answer ───────────────────────────────────────
+  const person = (id: string) => ({
+    id,
+    name: id,
+    email: `${id}@patternflow.local`,
+    emailVerified: false,
+    createdAt: at(1),
+    updatedAt: at(1),
+    username: id,
+    displayUsername: id,
+  });
+  await db.insert(schema.user).values([person("author"), person("porter")]);
+  await db.insert(schema.patterns).values([
+    {
+      id: "p-ported",
+      userId: "author",
+      title: "Ported",
+      code: "// js",
+      license: "CC-BY-SA-4.0",
+      visibility: "public",
+      createdAt: at(2),
+      updatedAt: at(2),
+    },
+    {
+      id: "p-bare",
+      userId: "author",
+      title: "Bare",
+      code: "// js",
+      license: "CC-BY-SA-4.0",
+      visibility: "public",
+      createdAt: at(3),
+      updatedAt: at(3),
+    },
+  ]);
+  await db.insert(schema.patternHeaders).values({
+    id: "port-1",
+    patternId: "p-ported",
+    userId: "porter",
+    codeCpp: "#pragma once // port-1",
+    createdAt: at(4),
+  });
+
+  console.log("\n── the feed's chip and filter follow it ──");
+  const feed = await queries.listFeed();
+  check(
+    "a live port makes the pattern hardware ready",
+    feed.find((item) => item.id === "p-ported")?.hasCpp,
+    true,
+  );
+  check("a bare pattern stays bare", feed.find((item) => item.id === "p-bare")?.hasCpp, false);
+  check(
+    "the hardware filter agrees",
+    (await queries.listFeed({ hardwareOnly: true })).map((item) => item.id),
+    ["p-ported"],
+  );
+  check("and so does its count", await queries.countFeed(true), 1);
+
+  console.log("\n── going stale takes it back out ──");
+  await db
+    .update(schema.patternHeaders)
+    .set({ stale: true })
+    .where(eq(schema.patternHeaders.id, "port-1"));
+  check(
+    "a stale-only pattern is no longer hardware ready",
+    (await queries.listFeed()).find((item) => item.id === "p-ported")?.hasCpp,
+    false,
+  );
+  check("the filter shows nothing", await queries.countFeed(true), 0);
+  check(
+    "but the port stays listed, marked",
+    (await queries.listPatternPorts("p-ported")).map((row) => row.stale),
+    [true],
+  );
+}
+
+main()
+  .then(() => {
+    console.log(failures === 0 ? "\nAll port checks passed.\n" : `\n${failures} check(s) FAILED.\n`);
+    process.exit(failures === 0 ? 0 : 1);
+  })
+  .catch((error: unknown) => {
+    console.error(error);
+    process.exit(1);
+  })
+  .finally(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });

--- a/web/scripts/sharing-smoke.ts
+++ b/web/scripts/sharing-smoke.ts
@@ -244,16 +244,16 @@ async function main() {
   check("its snapshot title survives the row", afterDelete[0]?.titleSnapshot, "Pattern p-g1");
   check("the set is still two slots long", afterDelete.length, 2);
 
-  console.log("\n── the feed's deck signal ──");
+  console.log("\n── the deck signal on feed cards ──");
   // p-pub sits in alice's own deck (does not count), two decks by bob (one
-  // person), and cara's unlisted deck (not public, does not count) → 1.
-  const ranked = await queries.listFeed({ sort: "decks" });
-  const pPub = ranked.find((item) => item.id === "p-pub");
-  check("own decks and unlisted decks do not count", pPub?.deckCount, 1);
-  check("two decks by one person count once", ranked[0]?.id, "p-pub");
+  // person, counts once), and cara's unlisted deck (not public, does not
+  // count) → 1. Shown on the card as DCK; not a sort while decks are few.
+  const feedNow = await queries.listFeed();
+  const pPub = feedNow.find((item) => item.id === "p-pub");
+  check("own decks and unlisted decks do not count, one person counts once", pPub?.deckCount, 1);
   check(
     "everything else sits at zero",
-    ranked.filter((i) => i.id !== "p-pub").map((i) => i.deckCount),
+    feedNow.filter((i) => i.id !== "p-pub").map((i) => i.deckCount),
     [0],
   );
 }

--- a/web/src/app/api/community/patterns/[id]/header/route.ts
+++ b/web/src/app/api/community/patterns/[id]/header/route.ts
@@ -4,19 +4,23 @@ import { isAdminSession } from "@/lib/community/admin";
 import { getAuth } from "@/lib/community/auth";
 import { originBlocked, preflight, withCors } from "@/lib/community/cors";
 import { communityEnabled, getDb } from "@/lib/community/db";
-import { patterns } from "@/lib/community/schema";
+import { notifyPortAdded } from "@/lib/community/notify";
+import { resolveHeader } from "@/lib/community/ports";
+import { listPatternPorts, newId } from "@/lib/community/queries";
+import { rateLimit } from "@/lib/community/ratelimit";
+import { patternHeaders, patterns } from "@/lib/community/schema";
+import { cleanCpp, cleanDescription } from "@/lib/community/validate";
 import { canView } from "@/lib/community/visibility";
 
-// GET /api/community/patterns/[id]/header — the pattern's firmware header.
+// GET  /api/community/patterns/[id]/header — the pattern's EFFECTIVE firmware
+// header: the author's own, or the winning community port (see
+// lib/community/ports.ts). Feed cards and deck copies read this, so they get
+// exactly what the pattern page shows.
 //
-// Feed cards can add a pattern to the deck, and the deck holds the .h,
-// not the JavaScript. Shipping every header in the feed payload would mean
-// carrying up to 200 KB per card for something most visitors never click, so
-// the card fetches just this one when the button is pressed.
-//
-// Auth only when the pattern is private (the owner adding their own private
-// pattern to their deck). Public and unlisted stay session-free — the header
-// is rendered in full on any page the visitor can already open.
+// POST — propose a port: a hand-verified .h for somebody else's pattern. Live
+// immediately; an acceptance queue would rot on authors who moved on. The
+// author hears about it (notification) and can pin or out-rank it with their
+// own header at any time.
 
 export async function OPTIONS(request: Request) {
   return preflight(request);
@@ -28,25 +32,35 @@ export async function GET(request: Request, context: { params: Promise<{ id: str
   return withCors(request, await handleGet(request, context));
 }
 
-async function handleGet(request: Request, context: { params: Promise<{ id: string }> }) {
-  if (!communityEnabled()) {
-    return Response.json({ error: "Community is not configured." }, { status: 503 });
-  }
-  const { id } = await context.params;
+export async function POST(request: Request, context: { params: Promise<{ id: string }> }) {
+  const blocked = originBlocked(request);
+  if (blocked) return blocked;
+  return withCors(request, await handlePost(request, context));
+}
 
+async function loadPattern(id: string) {
   const rows = await getDb()
     .select({
       id: patterns.id,
       title: patterns.title,
       codeCpp: patterns.codeCpp,
+      pinnedHeaderId: patterns.pinnedHeaderId,
       userId: patterns.userId,
       visibility: patterns.visibility,
     })
     .from(patterns)
     .where(eq(patterns.id, id))
     .limit(1);
+  return rows[0] ?? null;
+}
 
-  const pattern = rows[0];
+async function handleGet(request: Request, context: { params: Promise<{ id: string }> }) {
+  if (!communityEnabled()) {
+    return Response.json({ error: "Community is not configured." }, { status: 503 });
+  }
+  const { id } = await context.params;
+
+  const pattern = await loadPattern(id);
   if (!pattern) return Response.json({ error: "No such pattern." }, { status: 404 });
 
   if (pattern.visibility === "private") {
@@ -57,9 +71,78 @@ async function handleGet(request: Request, context: { params: Promise<{ id: stri
     }
   }
 
-  if (!pattern.codeCpp) {
+  const effective = resolveHeader(pattern, await listPatternPorts(id));
+  if (!effective) {
     return Response.json({ error: "This pattern has no firmware header." }, { status: 404 });
   }
 
-  return Response.json({ id: pattern.id, title: pattern.title, codeCpp: pattern.codeCpp });
+  return Response.json({
+    id: pattern.id,
+    title: pattern.title,
+    codeCpp: effective.codeCpp,
+    portedBy: effective.source === "port" ? effective.handle : null,
+  });
+}
+
+async function handlePost(request: Request, context: { params: Promise<{ id: string }> }) {
+  if (!communityEnabled()) {
+    return Response.json({ error: "Community is not enabled on this deployment." }, { status: 503 });
+  }
+
+  const session = await getAuth().api.getSession({ headers: request.headers });
+  if (!session) {
+    return Response.json({ error: "Sign in to propose a port." }, { status: 401 });
+  }
+
+  if (!rateLimit(`port:${session.user.id}`, 5, 60_000)) {
+    return Response.json({ error: "Too many ports — wait a minute and try again." }, { status: 429 });
+  }
+
+  const { id } = await context.params;
+  const pattern = await loadPattern(id);
+  // Private patterns take no ports from strangers — same 404 as a missing row.
+  if (!pattern || !canView(pattern.visibility, pattern.userId, session.user.id)) {
+    return Response.json({ error: "No such pattern." }, { status: 404 });
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return Response.json({ error: "Invalid JSON body." }, { status: 400 });
+  }
+  const raw = body as Record<string, unknown>;
+
+  const codeCpp = cleanCpp(raw.codeCpp);
+  if (!codeCpp) {
+    return Response.json(
+      { error: "That does not look like a Patternflow header — it must start with `#pragma once` and be under 200KB." },
+      { status: 400 },
+    );
+  }
+
+  const note = cleanDescription(raw.note);
+  if (note === undefined) {
+    return Response.json({ error: "Note is too long (max 2000 chars)." }, { status: 400 });
+  }
+
+  const portId = newId();
+  await getDb().insert(patternHeaders).values({
+    id: portId,
+    patternId: pattern.id,
+    userId: session.user.id,
+    codeCpp,
+    note,
+    createdAt: new Date(),
+  });
+
+  await notifyPortAdded({
+    patternOwnerId: pattern.userId,
+    patternId: pattern.id,
+    patternTitle: pattern.title,
+    portId,
+    actorId: session.user.id,
+  });
+
+  return Response.json({ id: portId }, { status: 201 });
 }

--- a/web/src/app/api/community/patterns/[id]/route.ts
+++ b/web/src/app/api/community/patterns/[id]/route.ts
@@ -3,10 +3,10 @@ import { isAdminSession } from "@/lib/community/admin";
 import { getAuth } from "@/lib/community/auth";
 import { originBlocked, preflight, withCors } from "@/lib/community/cors";
 import { communityEnabled, getDb } from "@/lib/community/db";
-import { clearNotificationsFor } from "@/lib/community/notify";
-import { getPattern, getPatternStub } from "@/lib/community/queries";
+import { clearNotificationsFor, notifyPortPinned } from "@/lib/community/notify";
+import { getPattern, getPatternStub, getPortStub } from "@/lib/community/queries";
 import { rateLimit } from "@/lib/community/ratelimit";
-import { patterns } from "@/lib/community/schema";
+import { patternHeaders, patterns } from "@/lib/community/schema";
 import { buildStoredPatternCode, lineageFrom } from "@/lib/community/license";
 import {
   cleanCode,
@@ -174,6 +174,32 @@ async function handlePatch(request: Request, context: { params: Promise<{ id: st
     visibility = next;
   }
 
+  // The author's pick among community ports. Owner-only by virtue of being in
+  // this handler — picking the header that ships under the pattern's name is
+  // exactly the author's call and nobody else's.
+  let pinnedHeaderId = pattern.pinnedHeaderId;
+  let newlyPinnedPort: Awaited<ReturnType<typeof getPortStub>> = null;
+  if (raw.pinnedHeaderId !== undefined) {
+    if (raw.pinnedHeaderId === null || raw.pinnedHeaderId === "") {
+      pinnedHeaderId = null;
+    } else if (typeof raw.pinnedHeaderId === "string") {
+      const port = await getPortStub(raw.pinnedHeaderId);
+      if (!port || port.patternId !== id) {
+        return Response.json({ error: "No such port on this pattern." }, { status: 400 });
+      }
+      if (port.stale) {
+        return Response.json(
+          { error: "That port was made for an older version of the code — it cannot be pinned." },
+          { status: 400 },
+        );
+      }
+      if (port.id !== pattern.pinnedHeaderId) newlyPinnedPort = port;
+      pinnedHeaderId = port.id;
+    } else {
+      return Response.json({ error: "Unknown pinned port." }, { status: 400 });
+    }
+  }
+
   // Compare the bodies with any licence wrapping removed, so re-saving without
   // touching the code isn't mistaken for a code change.
   let bareCode = stripShareWrapping(pattern.code);
@@ -234,9 +260,30 @@ async function handlePatch(request: Request, context: { params: Promise<{ id: st
       }),
       codeCpp,
       visibility,
+      pinnedHeaderId,
       updatedAt: new Date(),
     })
     .where(eq(patterns.id, id));
+
+  // A port is of a SPECIFIC version of the JS. Once the source moves, every
+  // community port goes stale — same guarantee-expiry that just cleared the
+  // author's own header above, applied to everyone else's.
+  if (codeChanged) {
+    await getDb()
+      .update(patternHeaders)
+      .set({ stale: true })
+      .where(eq(patternHeaders.patternId, id));
+  }
+
+  if (newlyPinnedPort) {
+    await notifyPortPinned({
+      porterId: newlyPinnedPort.userId,
+      patternId: id,
+      patternTitle: title,
+      portId: newlyPinnedPort.id,
+      actorId: session.user.id,
+    });
+  }
 
   return Response.json({
     ok: true,

--- a/web/src/app/api/community/patterns/route.ts
+++ b/web/src/app/api/community/patterns/route.ts
@@ -1,10 +1,18 @@
 import { getAuth } from "@/lib/community/auth";
 import { originBlocked, preflight, withCors } from "@/lib/community/cors";
 import { communityEnabled, getDb } from "@/lib/community/db";
+import { MAX_FEED_PAGE_SIZE } from "@/lib/community/feedView";
 import { notifyForkPublished } from "@/lib/community/notify";
-import { getPatternStub, newId } from "@/lib/community/queries";
+import {
+  countFeed,
+  getPatternStub,
+  listFeed,
+  newId,
+  parseFeedSort,
+} from "@/lib/community/queries";
 import { rateLimit } from "@/lib/community/ratelimit";
 import { patterns } from "@/lib/community/schema";
+import { toCardItem } from "@/lib/community/serialize";
 import {
   cleanCode,
   cleanCpp,
@@ -17,7 +25,12 @@ import { buildStoredPatternCode, lineageFrom } from "@/lib/community/license";
 import { LICENSE_OPTIONS, forkLicenseAllowed, stripShareWrapping } from "@/lib/sharePattern";
 
 // POST /api/community/patterns — publish (or fork-publish) a pattern.
-// Reads happen in server components; only mutations go through the API.
+// GET  /api/community/patterns — one batch of the feed, for infinite scroll.
+//
+// Reads otherwise happen in server components; this GET is the one exception,
+// because "load more as you scroll" is a client act by nature. Same filters
+// and ordering as the server-rendered first paint — it reads through the very
+// same listFeed, so the visibility rules cannot drift apart.
 //
 // Callable from the main site's Pattern Lab, which is a different origin, so
 // every response carries CORS headers and OPTIONS answers the preflight.
@@ -28,7 +41,38 @@ export async function POST(request: Request) {
   return withCors(request, await handlePost(request));
 }
 
+export async function GET(request: Request) {
+  const blocked = originBlocked(request);
+  if (blocked) return blocked;
+  return withCors(request, await handleGet(request));
+}
+
 export const OPTIONS = preflight;
+
+function clampInt(raw: string | null, fallback: number, min: number, max: number) {
+  const value = Number(raw);
+  if (!Number.isFinite(value)) return fallback;
+  return Math.max(min, Math.min(max, Math.floor(value)));
+}
+
+async function handleGet(request: Request) {
+  if (!communityEnabled()) {
+    return Response.json({ error: "Community is not enabled on this deployment." }, { status: 503 });
+  }
+
+  const params = new URL(request.url).searchParams;
+  const sort = parseFeedSort(params.get("sort") ?? undefined);
+  const hardwareOnly = params.get("hw") === "1";
+  const offset = clampInt(params.get("offset"), 0, 0, 1_000_000);
+  const size = clampInt(params.get("size"), 12, 1, MAX_FEED_PAGE_SIZE);
+
+  const [items, total] = await Promise.all([
+    listFeed({ sort, hardwareOnly, limit: size, offset }),
+    countFeed(hardwareOnly),
+  ]);
+
+  return Response.json({ items: items.map(toCardItem), total });
+}
 
 async function handlePost(request: Request) {
   if (!communityEnabled()) {

--- a/web/src/app/api/community/ports/[id]/route.ts
+++ b/web/src/app/api/community/ports/[id]/route.ts
@@ -1,0 +1,51 @@
+import { eq } from "drizzle-orm";
+import { isAdminSession } from "@/lib/community/admin";
+import { getAuth } from "@/lib/community/auth";
+import { originBlocked, preflight, withCors } from "@/lib/community/cors";
+import { communityEnabled, getDb } from "@/lib/community/db";
+import { clearNotificationsFor } from "@/lib/community/notify";
+import { getPortStub } from "@/lib/community/queries";
+import { patternHeaders, patterns } from "@/lib/community/schema";
+
+// DELETE /api/community/ports/[id] — the porter withdraws their port, or a
+// moderator removes it. The pattern's author does not delete other people's
+// ports (same rule as comments on their pattern) — they out-rank them with a
+// pin or with their own header instead.
+
+export async function DELETE(request: Request, context: { params: Promise<{ id: string }> }) {
+  const blocked = originBlocked(request);
+  if (blocked) return blocked;
+  return withCors(request, await handleDelete(request, context));
+}
+
+export const OPTIONS = preflight;
+
+async function handleDelete(request: Request, context: { params: Promise<{ id: string }> }) {
+  if (!communityEnabled()) {
+    return Response.json({ error: "Community is not enabled on this deployment." }, { status: 503 });
+  }
+
+  const session = await getAuth().api.getSession({ headers: request.headers });
+  if (!session) {
+    return Response.json({ error: "Sign in to remove your port." }, { status: 401 });
+  }
+
+  const { id } = await context.params;
+  const port = await getPortStub(id);
+  if (!port) return Response.json({ error: "Port not found." }, { status: 404 });
+  if (port.userId !== session.user.id && !isAdminSession(session)) {
+    return Response.json({ error: "You can only remove your own ports." }, { status: 403 });
+  }
+
+  const db = getDb();
+  await db.delete(patternHeaders).where(eq(patternHeaders.id, id));
+  // A pin pointing at a deleted port must not dangle — resolution would cope,
+  // but the author's stored choice should reflect reality.
+  await db
+    .update(patterns)
+    .set({ pinnedHeaderId: null })
+    .where(eq(patterns.pinnedHeaderId, id));
+  await clearNotificationsFor({ sourceId: id });
+
+  return Response.json({ ok: true });
+}

--- a/web/src/app/api/community/posts/[id]/pin/route.ts
+++ b/web/src/app/api/community/posts/[id]/pin/route.ts
@@ -1,0 +1,59 @@
+import { eq, isNotNull } from "drizzle-orm";
+import { isAdminSession } from "@/lib/community/admin";
+import { getAuth } from "@/lib/community/auth";
+import { originBlocked, preflight, withCors } from "@/lib/community/cors";
+import { communityEnabled, getDb } from "@/lib/community/db";
+import { getPostStub } from "@/lib/community/queries";
+import { posts } from "@/lib/community/schema";
+
+// POST /api/community/posts/[id]/pin — moderators set (or clear) THE notice.
+//
+// Not part of the post PATCH on purpose: pinning is curation, not editing, and
+// the edit route is author-only by a rule worth keeping intact. One slot:
+// pinning a post un-pins whatever held the spot before.
+
+export async function POST(request: Request, context: { params: Promise<{ id: string }> }) {
+  const blocked = originBlocked(request);
+  if (blocked) return blocked;
+  return withCors(request, await handlePost(request, context));
+}
+
+export const OPTIONS = preflight;
+
+async function handlePost(request: Request, context: { params: Promise<{ id: string }> }) {
+  if (!communityEnabled()) {
+    return Response.json({ error: "Community is not enabled on this deployment." }, { status: 503 });
+  }
+
+  const session = await getAuth().api.getSession({ headers: request.headers });
+  if (!session || !isAdminSession(session)) {
+    // 404, not 403 — the pin control is moderator furniture; everyone else
+    // has no reason to learn the endpoint exists.
+    return Response.json({ error: "Not found." }, { status: 404 });
+  }
+
+  const { id } = await context.params;
+  const post = await getPostStub(id);
+  if (!post) return Response.json({ error: "Post not found." }, { status: 404 });
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return Response.json({ error: "Invalid JSON body." }, { status: 400 });
+  }
+  const pinned = (body as Record<string, unknown>).pinned;
+  if (typeof pinned !== "boolean") {
+    return Response.json({ error: "Expected { pinned: true | false }." }, { status: 400 });
+  }
+
+  const db = getDb();
+  if (pinned) {
+    await db.update(posts).set({ pinnedAt: null }).where(isNotNull(posts.pinnedAt));
+    await db.update(posts).set({ pinnedAt: new Date() }).where(eq(posts.id, id));
+  } else {
+    await db.update(posts).set({ pinnedAt: null }).where(eq(posts.id, id));
+  }
+
+  return Response.json({ ok: true });
+}

--- a/web/src/app/community/discussions/[id]/page.tsx
+++ b/web/src/app/community/discussions/[id]/page.tsx
@@ -1,6 +1,7 @@
 import { headers } from "next/headers";
 import { notFound } from "next/navigation";
 import type { Metadata } from "next";
+import { isAdminSession } from "@/lib/community/admin";
 import { communityEnabled } from "@/lib/community/db";
 import { getAuth } from "@/lib/community/auth";
 import { getPost, listPostComments } from "@/lib/community/queries";
@@ -50,6 +51,7 @@ export default async function CommunityPostPage(props: RouteParams) {
         id: post.id,
         title: post.title,
         body: post.body,
+        pinned: post.pinnedAt !== null,
         createdAt: post.createdAt.toISOString(),
         updatedAt: post.updatedAt.toISOString(),
         username: post.username,
@@ -57,6 +59,7 @@ export default async function CommunityPostPage(props: RouteParams) {
       }}
       comments={comments}
       isOwner={session?.user.id === post.userId}
+      isAdmin={isAdminSession(session)}
     />
   );
 }

--- a/web/src/app/community/discussions/page.tsx
+++ b/web/src/app/community/discussions/page.tsx
@@ -38,6 +38,7 @@ export default async function CommunityDiscussionsPage(props: {
         id: post.id,
         title: post.title,
         body: post.body,
+        pinned: post.pinned,
         createdAt: post.createdAt.toISOString(),
         username: post.username,
         displayUsername: post.displayUsername,

--- a/web/src/app/community/discussions/page.tsx
+++ b/web/src/app/community/discussions/page.tsx
@@ -3,9 +3,8 @@ import { communityEnabled } from "@/lib/community/db";
 import { countPosts, listPosts } from "@/lib/community/queries";
 import DiscussionsClient from "@/components/community/DiscussionsClient";
 
-// Discussions: plain-text threads that aren't attached to a pattern.
-//
-// Deliberately the boring half of the community. No previews, no sandboxes,
+// Discussions: the community's free board — ideas, questions, anything that
+// isn't a pattern. Deliberately the plain half: no previews, no sandboxes,
 // no thumbnails — a title, a body, and replies. That is why it can page in
 // twenty rows where the pattern feed can only afford a handful.
 
@@ -13,7 +12,7 @@ export const dynamic = "force-dynamic";
 
 export const metadata: Metadata = {
   title: "Discussions / Patternflow Community",
-  description: "Questions, build logs and discussion from the Patternflow community.",
+  description: "Ideas, questions and open discussion from the Patternflow community.",
 };
 
 const PAGE_SIZE = 20;

--- a/web/src/app/community/p/[id]/PatternDetailClient.tsx
+++ b/web/src/app/community/p/[id]/PatternDetailClient.tsx
@@ -39,13 +39,31 @@ import styles from "@/components/community/Community.module.css";
 // boundary that makes that safe. Saving (fork-publishing) happens in Pattern
 // Lab via the sessionStorage handoff.
 
+export type PortView = {
+  id: string;
+  handle: string | null;
+  note: string | null;
+  stale: boolean;
+  createdAt: string; // ISO
+  mine: boolean;
+  pinned: boolean;
+  effective: boolean;
+};
+
 export type PatternView = {
   id: string;
   title: string;
   description: string | null;
   code: string;
-  /** Author-attached firmware port, if any. Read-only here. */
+  /** The EFFECTIVE header — the author's own, or the winning community port.
+   *  Everything that builds, downloads or collects reads this one. */
   codeCpp: string | null;
+  /** The author's own header only — what their Update/Remove modal edits. */
+  ownCpp: string | null;
+  /** Porter handle when the effective header is a community port. */
+  portedBy: string | null;
+  /** Every port on this pattern, oldest first. */
+  ports: PortView[];
   license: string;
   /** Author-stated creation date (YYYY-MM-DD), when it differs from the upload. */
   madeOn: string | null;
@@ -87,6 +105,7 @@ export default function PatternDetailClient({
   const [runtimeError, setRuntimeError] = useState<string | null>(null);
   const [codeTab, setCodeTab] = useState<"js" | "h">("js");
   const [headerModalOpen, setHeaderModalOpen] = useState(false);
+  const [portModalOpen, setPortModalOpen] = useState(false);
   const [detailsModalOpen, setDetailsModalOpen] = useState(false);
   const [reportOpen, setReportOpen] = useState(false);
   const [buildOpen, setBuildOpen] = useState(false);
@@ -482,8 +501,16 @@ export default function PatternDetailClient({
             </span>
           )}
           {pattern.codeCpp && (
-            <span className={styles.hwNote} title="Ships a .h firmware header">
+            <span
+              className={styles.hwNote}
+              title={
+                pattern.portedBy
+                  ? `Ships a .h firmware header, ported by @${pattern.portedBy}`
+                  : "Ships a .h firmware header"
+              }
+            >
               <span className={styles.hwChip}>.h</span> hardware ready
+              {pattern.portedBy && <> · port by @{pattern.portedBy}</>}
             </span>
           )}
           {pattern.visibility !== "public" && (
@@ -544,9 +571,11 @@ export default function PatternDetailClient({
         {isOwner && (
           <div className={styles.ownerBar}>
             <span className={styles.formNote}>
-              {pattern.codeCpp
-                ? "Your pattern ships a firmware header."
-                : "Ported this to the board? Attach the .h so others can flash it."}
+              {pattern.ownCpp
+                ? "Your pattern ships your own firmware header."
+                : pattern.portedBy
+                  ? `Running on @${pattern.portedBy}'s port — pin your pick below, or attach your own to out-rank it.`
+                  : "Ported this to the board? Attach the .h so others can flash it."}
             </span>
             <button type="button" className={styles.btn} onClick={() => setDetailsModalOpen(true)}>
               Edit details
@@ -556,12 +585,14 @@ export default function PatternDetailClient({
               className={styles.btn}
               onClick={() => setHeaderModalOpen(true)}
             >
-              {pattern.codeCpp ? "Update .h" : "Add firmware header"}
+              {pattern.ownCpp ? "Update .h" : "Add firmware header"}
             </button>
             <span className={styles.ownerBarSpacer} />
             <DeletePatternButton patternId={pattern.id} forkCount={pattern.forkCount} />
           </div>
         )}
+
+        <PortsSection pattern={pattern} isOwner={isOwner} onPropose={() => setPortModalOpen(true)} />
       </div>
 
       <CommentSection target={{ kind: "pattern", id: pattern.id }} comments={comments} />
@@ -569,8 +600,17 @@ export default function PatternDetailClient({
       {headerModalOpen && (
         <AddHeaderModal
           patternId={pattern.id}
-          initialCpp={pattern.codeCpp}
+          initialCpp={pattern.ownCpp}
           onClose={() => setHeaderModalOpen(false)}
+        />
+      )}
+
+      {portModalOpen && (
+        <AddHeaderModal
+          patternId={pattern.id}
+          initialCpp={null}
+          mode="port"
+          onClose={() => setPortModalOpen(false)}
         />
       )}
 
@@ -612,6 +652,137 @@ export default function PatternDetailClient({
           onClose={() => setReportOpen(false)}
         />
       )}
+    </div>
+  );
+}
+
+// Community ports: who finished the hardware half, in arrival order. Visible
+// to everyone — a porter's credit is the whole payment. The author's pick
+// (pin) decides which one ships when they have no header of their own.
+function PortsSection({
+  pattern,
+  isOwner,
+  onPropose,
+}: {
+  pattern: PatternView;
+  isOwner: boolean;
+  onPropose: () => void;
+}) {
+  const router = useRouter();
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const canPropose = !isOwner && !pattern.ownCpp;
+  if (pattern.ports.length === 0 && !canPropose) return null;
+
+  const pin = async (portId: string | null) => {
+    setBusy(true);
+    setError(null);
+    try {
+      const response = await fetch(communityApiUrl(`/api/community/patterns/${pattern.id}`), {
+        method: "PATCH",
+        ...COMMUNITY_FETCH_INIT,
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ pinnedHeaderId: portId }),
+      });
+      const payload = (await response.json()) as { error?: string };
+      if (!response.ok) {
+        setError(payload.error ?? "Could not save.");
+        return;
+      }
+      router.refresh();
+    } catch {
+      setError("Network error.");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const remove = async (portId: string) => {
+    setBusy(true);
+    setError(null);
+    try {
+      const response = await fetch(communityApiUrl(`/api/community/ports/${portId}`), {
+        method: "DELETE",
+        ...COMMUNITY_FETCH_INIT,
+      });
+      const payload = (await response.json()) as { error?: string };
+      if (!response.ok) {
+        setError(payload.error ?? "Could not remove the port.");
+        return;
+      }
+      router.refresh();
+    } catch {
+      setError("Network error.");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className={styles.portsSection}>
+      <div className={styles.portsHead}>
+        <span className={styles.portsTitle}>
+          Firmware ports{pattern.ports.length > 0 ? ` (${pattern.ports.length})` : ""}
+        </span>
+        {canPropose && (
+          <button type="button" className={styles.btnSmall} onClick={onPropose}>
+            {pattern.ports.length === 0 ? "Port this pattern (.h)" : "Propose another"}
+          </button>
+        )}
+      </div>
+
+      {pattern.ports.length === 0 ? (
+        <p className={styles.formNote}>
+          No firmware header yet. If you ran this on your own board, propose the .h — it goes
+          live immediately, credited to you.
+        </p>
+      ) : (
+        <ul className={styles.portsList}>
+          {pattern.ports.map((port) => (
+            <li key={port.id} className={styles.portRow} data-stale={port.stale}>
+              <span className={styles.portHandle}>@{port.handle ?? "unknown"}</span>
+              <span className={styles.portDate}>{port.createdAt.slice(0, 10)}</span>
+              {port.effective && <span className={styles.portChip}>in use</span>}
+              {port.pinned && <span className={styles.portChip}>pinned</span>}
+              {port.stale && (
+                <span className={styles.portStale} title="The pattern's code changed after this port was made">
+                  for an older version
+                </span>
+              )}
+              {port.note && <span className={styles.portNote}>{port.note}</span>}
+              <span className={styles.ownerBarSpacer} />
+              {isOwner && !port.stale && !pattern.ownCpp && (
+                <button
+                  type="button"
+                  className={styles.btnSmall}
+                  disabled={busy}
+                  title={
+                    port.pinned
+                      ? "Stop pinning this port (arrival order decides again)"
+                      : "Make this the port your pattern ships"
+                  }
+                  onClick={() => void pin(port.pinned ? null : port.id)}
+                >
+                  {port.pinned ? "Unpin" : "Pin"}
+                </button>
+              )}
+              {port.mine && (
+                <button
+                  type="button"
+                  className={styles.btnSmall}
+                  disabled={busy}
+                  onClick={() => void remove(port.id)}
+                >
+                  remove
+                </button>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {error && <div className={styles.formError}>{error}</div>}
     </div>
   );
 }

--- a/web/src/app/community/p/[id]/page.tsx
+++ b/web/src/app/community/p/[id]/page.tsx
@@ -4,7 +4,8 @@ import type { Metadata } from "next";
 import { isAdminSession } from "@/lib/community/admin";
 import { communityEnabled } from "@/lib/community/db";
 import { getAuth } from "@/lib/community/auth";
-import { getPattern, getPatternStub, hasLiked, listComments } from "@/lib/community/queries";
+import { getPattern, getPatternStub, hasLiked, listComments, listPatternPorts } from "@/lib/community/queries";
+import { resolveHeader } from "@/lib/community/ports";
 import { provenanceFor } from "@/lib/community/provenance";
 import { canView } from "@/lib/community/visibility";
 import type { CommentView } from "@/components/community/CommentSection";
@@ -59,6 +60,12 @@ export default async function CommunityPatternPage(props: RouteParams) {
 
   const liked = viewerId ? await hasLiked(viewerId, pattern.id) : false;
 
+  // Which .h this pattern actually ships: the author's own, or the winning
+  // community port (author's pin first, then arrival order).
+  const ports = await listPatternPorts(pattern.id);
+  const effective = resolveHeader(pattern, ports);
+  const effectivePortId = effective?.source === "port" ? effective.portId : null;
+
   const parent = pattern.parentId ? await getPatternStub(pattern.parentId) : null;
   const comments: CommentView[] = (await listComments(pattern.id)).map((comment) => ({
     id: comment.id,
@@ -80,7 +87,19 @@ export default async function CommunityPatternPage(props: RouteParams) {
         title: pattern.title,
         description: pattern.description,
         code: pattern.code,
-        codeCpp: pattern.codeCpp,
+        codeCpp: effective?.codeCpp ?? null,
+        ownCpp: pattern.codeCpp,
+        portedBy: effective?.source === "port" ? effective.handle : null,
+        ports: ports.map((port) => ({
+          id: port.id,
+          handle: port.displayUsername ?? port.username ?? null,
+          note: port.note,
+          stale: port.stale,
+          createdAt: port.createdAt.toISOString(),
+          mine: viewerId === port.userId,
+          pinned: pattern.pinnedHeaderId === port.id,
+          effective: effectivePortId === port.id,
+        })),
         license: pattern.license,
         madeOn: pattern.madeOn,
         madeHow: pattern.madeHow,
@@ -90,7 +109,7 @@ export default async function CommunityPatternPage(props: RouteParams) {
         displayUsername: pattern.displayUsername,
         // Read out of the stored source, not stored separately — the source is
         // where Pattern Lab wrote these while the author worked.
-        provenance: provenanceFor(pattern.code, pattern.codeCpp !== null, pattern.madeHow),
+        provenance: provenanceFor(pattern.code, effective !== null, pattern.madeHow),
         parent: parent
           ? {
               id: parent.id,

--- a/web/src/app/community/page.tsx
+++ b/web/src/app/community/page.tsx
@@ -1,59 +1,44 @@
 import { communityEnabled } from "@/lib/community/db";
 import { countFeed, listFeed, parseFeedSort } from "@/lib/community/queries";
 import { toCardItem } from "@/lib/community/serialize";
-import { FEED_VIEWS, MAX_FEED_PAGE_SIZE, parseFeedView } from "@/lib/community/feedView";
+import { FEED_FIRST_PAINT } from "@/lib/community/feedView";
 import CommunityFeedClient from "@/components/community/CommunityFeedClient";
 
-// The feed. Sort, hardware filter, card size and paging all live in the URL
-// (?sort=, ?hw=, ?view=, ?page=, ?size=) so a view is shareable and the back
-// button works.
+// The feed. Sort and the hardware filter live in the URL (?sort=, ?hw=) so a
+// view is shareable and the back button works. Card size does not — that is
+// the Ctrl+scroll zoom, remembered per browser.
 //
-// Only about one row of patterns is fetched per request. Every feed row ships
-// its full source (the cards render and hover-play it client-side), so sending
-// the whole feed would mean shipping code for patterns nobody can see.
+// Only the first batch is rendered here; scrolling loads the rest through
+// GET /api/community/patterns. Every card ships its full source (they render
+// and hover-play it client-side), so the feed pays for patterns as they come
+// into reach rather than all at once.
 
 export const dynamic = "force-dynamic";
-
-function clampInt(raw: string | undefined, fallback: number, min: number, max: number) {
-  const value = Number(raw);
-  if (!Number.isFinite(value)) return fallback;
-  return Math.max(min, Math.min(max, Math.floor(value)));
-}
 
 export default async function CommunityFeedPage(props: {
   searchParams: Promise<{
     sort?: string;
     hw?: string;
-    view?: string;
-    page?: string;
-    size?: string;
   }>;
 }) {
   if (!communityEnabled()) return null; // layout already rendered notice
 
-  const { sort: rawSort, hw, view: rawView, page: rawPage, size: rawSize } = await props.searchParams;
+  const { sort: rawSort, hw } = await props.searchParams;
   const sort = parseFeedSort(rawSort);
   const hardwareOnly = hw === "1";
-  const view = parseFeedView(rawView);
-  // Generous enough to fill the widest screen in this view; the client trims to
-  // what actually fits and asks for its exact size from the next page onwards.
-  const size = clampInt(rawSize, FEED_VIEWS[view].defaultSize, 1, MAX_FEED_PAGE_SIZE);
-  const page = clampInt(rawPage, 0, 0, 100_000);
 
   const [items, total] = await Promise.all([
-    listFeed({ sort, hardwareOnly, limit: size, offset: page * size }),
+    listFeed({ sort, hardwareOnly, limit: FEED_FIRST_PAINT }),
     countFeed(hardwareOnly),
   ]);
 
   return (
     <CommunityFeedClient
-      // Remount on a view change so the layout re-measures from scratch.
-      key={`${sort}-${hardwareOnly}-${view}`}
+      // Remount on a sort/filter change so the accumulated list restarts.
+      key={`${sort}-${hardwareOnly}`}
       items={items.map(toCardItem)}
       sort={sort}
       hardwareOnly={hardwareOnly}
-      view={view}
-      page={page}
       total={total}
     />
   );

--- a/web/src/app/terms/page.tsx
+++ b/web/src/app/terms/page.tsx
@@ -154,7 +154,8 @@ export default function TermsPage() {
             reasonable to do so we will say why.
           </p>
           <p>
-            You can delete your own patterns, decks, posts and comments at any time. To close your account,
+            You can delete your own patterns, decks, firmware ports, posts and comments at any
+            time. To close your account,
             email <a href={`mailto:${CONTACT}`}>{CONTACT}</a>.
           </p>
           <p className={styles.callout}>
@@ -180,8 +181,8 @@ export default function TermsPage() {
               user-agent of the sign-in. This is for security and abuse handling, not analytics.
             </li>
             <li>
-              <strong>What you publish</strong> — patterns, decks, comments, posts, likes, and
-              firmware build requests.
+              <strong>What you publish</strong> — patterns, decks, firmware ports, comments,
+              posts, likes, and build requests.
             </li>
             <li>
               <strong>Alerts</strong> — a note when someone comments on your work, forks a pattern

--- a/web/src/components/community/AddHeaderModal.tsx
+++ b/web/src/components/community/AddHeaderModal.tsx
@@ -4,25 +4,39 @@ import { useState } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { captureEvent } from "@/lib/posthogEvents";
+import { authClient } from "@/lib/community/auth-client";
 import { COMMUNITY_FETCH_INIT, communityApiUrl } from "@/lib/community/apiBase";
+import AuthModal from "./AuthModal";
 import styles from "./Community.module.css";
 
-// Author-only: attach the hand-verified firmware header to an already published
-// pattern. This is the "publish the JS now, port it later" half of the flow —
-// generation and hardware testing happen in Pattern Lab and on the board, and
-// only the finished, working .h comes back here.
+// Two ways a .h reaches a pattern, one modal:
+//
+//   owner — the author attaches (or replaces) their own header. PATCHes the
+//   pattern row; this is the "publish the JS now, port it later" half of the
+//   original flow.
+//
+//   port — somebody ELSE verified it on their board and proposes it. POSTs a
+//   community port, live immediately (see the header route) — the author
+//   hears about it and can pin or out-rank it.
+//
+// Generation and hardware testing happen in Pattern Lab and on the board;
+// only the finished, working .h comes here.
 
 export default function AddHeaderModal({
   patternId,
   initialCpp,
+  mode = "owner",
   onClose,
 }: {
   patternId: string;
   initialCpp: string | null;
+  mode?: "owner" | "port";
   onClose: () => void;
 }) {
   const router = useRouter();
+  const { data: session, isPending } = authClient.useSession();
   const [cpp, setCpp] = useState(initialCpp ?? "");
+  const [note, setNote] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
 
@@ -30,20 +44,27 @@ export default function AddHeaderModal({
     setBusy(true);
     setError(null);
     try {
-      const response = await fetch(communityApiUrl(`/api/community/patterns/${patternId}`), {
-        method: "PATCH",
-        ...COMMUNITY_FETCH_INIT,
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ codeCpp: next }),
-      });
+      const response =
+        mode === "port"
+          ? await fetch(communityApiUrl(`/api/community/patterns/${patternId}/header`), {
+              method: "POST",
+              ...COMMUNITY_FETCH_INIT,
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({ codeCpp: next, note }),
+            })
+          : await fetch(communityApiUrl(`/api/community/patterns/${patternId}`), {
+              method: "PATCH",
+              ...COMMUNITY_FETCH_INIT,
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({ codeCpp: next }),
+            });
       const payload = (await response.json()) as { error?: string; hasCpp?: boolean };
       if (!response.ok) {
         setError(payload.error ?? "Could not save the header.");
         return;
       }
-      captureEvent("community_attach_header", {
+      captureEvent(mode === "port" ? "community_propose_port" : "community_attach_header", {
         pattern_id: patternId,
-        attached: Boolean(payload.hasCpp),
       });
       router.refresh();
       onClose();
@@ -61,59 +82,102 @@ export default function AddHeaderModal({
         onClick={(event) => event.stopPropagation()}
       >
         <div className={styles.modalHeader}>
-          <span>{initialCpp ? "Update firmware header" : "Add firmware header (.h)"}</span>
+          <span>
+            {mode === "port"
+              ? "Propose a firmware port (.h)"
+              : initialCpp
+                ? "Update firmware header"
+                : "Add firmware header (.h)"}
+          </span>
           <button type="button" onClick={onClose} aria-label="Close">
             ×
           </button>
         </div>
 
-        <div className={styles.modalBody}>
-          <p className={styles.formNote}>
-            The board runs C++, so a pattern needs a <code>.h</code> port before anyone can flash
-            it. Generate one with <strong>Copy C++ prompt</strong> in{" "}
-            <Link href="/pattern-lab">Pattern Lab</Link>, build it on your own board, and paste the
-            working header here. Your pattern then shows as{" "}
-            <strong>hardware ready</strong> and can be filtered for in the feed.
-          </p>
+        {mode === "port" && isPending ? (
+          <div className={styles.modalBody}>
+            <span className={styles.formNote}>Checking session…</span>
+          </div>
+        ) : mode === "port" && !session ? (
+          <AuthModal embedded onClose={() => undefined} />
+        ) : (
+          <div className={styles.modalBody}>
+            {mode === "port" ? (
+              <p className={styles.formNote}>
+                The author has no header for this pattern yet — if you ran it on your own board,
+                finish the job for them. Generate the port with <strong>Copy C++ prompt</strong> in{" "}
+                <Link href="/pattern-lab">Pattern Lab</Link>, verify it on hardware, and paste it
+                here. It goes live immediately, credited to you; the author can pin or replace it,
+                and the port carries the pattern&apos;s own licence — the work stays theirs.
+              </p>
+            ) : (
+              <p className={styles.formNote}>
+                The board runs C++, so a pattern needs a <code>.h</code> port before anyone can
+                flash it. Generate one with <strong>Copy C++ prompt</strong> in{" "}
+                <Link href="/pattern-lab">Pattern Lab</Link>, build it on your own board, and paste
+                the working header here. Your pattern then shows as <strong>hardware ready</strong>{" "}
+                and can be filtered for in the feed.
+              </p>
+            )}
 
-          <label className={styles.field}>
-            <span className={styles.fieldLabel}>Header source</span>
-            <textarea
-              className={`${styles.textInput} ${styles.cppInput}`}
-              placeholder="#pragma once&#10;…"
-              spellCheck={false}
-              value={cpp}
-              onChange={(event) => setCpp(event.target.value)}
-            />
-            <span className={styles.fieldHint}>
-              Must start with <code>#pragma once</code>. It is stored as you paste it — we can&apos;t
-              compile it here, so only attach a header you have actually run.
-            </span>
-          </label>
+            <label className={styles.field}>
+              <span className={styles.fieldLabel}>Header source</span>
+              <textarea
+                className={`${styles.textInput} ${styles.cppInput}`}
+                placeholder="#pragma once&#10;…"
+                spellCheck={false}
+                value={cpp}
+                onChange={(event) => setCpp(event.target.value)}
+              />
+              <span className={styles.fieldHint}>
+                Must start with <code>#pragma once</code>. It is stored as you paste it — we
+                can&apos;t compile it here, so only submit a header you have actually run.
+              </span>
+            </label>
 
-          {error && <div className={styles.formError}>{error}</div>}
+            {mode === "port" && (
+              <label className={styles.field}>
+                <span className={styles.fieldLabel}>Note (optional)</span>
+                <input
+                  className={styles.textInput}
+                  placeholder="How you verified it — board, firmware version…"
+                  value={note}
+                  maxLength={200}
+                  onChange={(event) => setNote(event.target.value)}
+                />
+              </label>
+            )}
 
-          <div className={styles.actionRow}>
-            <button
-              type="button"
-              className={styles.btnAccent}
-              disabled={busy || cpp.trim().length === 0}
-              onClick={() => void save(cpp)}
-            >
-              {busy ? "Saving…" : initialCpp ? "Update header" : "Attach header"}
-            </button>
-            {initialCpp && (
+            {error && <div className={styles.formError}>{error}</div>}
+
+            <div className={styles.actionRow}>
               <button
                 type="button"
-                className={styles.btn}
-                disabled={busy}
-                onClick={() => void save("")}
+                className={styles.btnAccent}
+                disabled={busy || cpp.trim().length === 0}
+                onClick={() => void save(cpp)}
               >
-                Remove header
+                {busy
+                  ? "Saving…"
+                  : mode === "port"
+                    ? "Propose port"
+                    : initialCpp
+                      ? "Update header"
+                      : "Attach header"}
               </button>
-            )}
+              {mode === "owner" && initialCpp && (
+                <button
+                  type="button"
+                  className={styles.btn}
+                  disabled={busy}
+                  onClick={() => void save("")}
+                >
+                  Remove header
+                </button>
+              )}
+            </div>
           </div>
-        </div>
+        )}
       </div>
     </div>
   );

--- a/web/src/components/community/CommentSection.tsx
+++ b/web/src/components/community/CommentSection.tsx
@@ -7,7 +7,7 @@ import { authClient } from "@/lib/community/auth-client";
 import { COMMUNITY_FETCH_INIT, communityApiUrl } from "@/lib/community/apiBase";
 import { COMMENT_MAX } from "@/lib/community/validate";
 import AuthModal from "./AuthModal";
-import LinkedText from "./LinkedText";
+import FencedText from "./FencedText";
 import { formatDate } from "./PatternCard";
 import styles from "./Community.module.css";
 
@@ -218,7 +218,7 @@ export default function CommentSection({
               </div>
             ) : (
               <div className={styles.commentBody}>
-                <LinkedText text={comment.body} />
+                <FencedText text={comment.body} />
               </div>
             )}
             {!editing && rowError && rowBusy === null && confirmDelete === comment.id && (

--- a/web/src/components/community/Community.module.css
+++ b/web/src/components/community/Community.module.css
@@ -2173,6 +2173,99 @@
   color: var(--pf-ink);
 }
 
+/* ── Discussions pagination ──
+   (The pattern feed scrolls forever; this list still pages — twenty text rows
+   at a time is plenty, and a pager is honest furniture for an archive.) */
+
+.paginationBar {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 16px;
+  font-family: var(--pf-mono, monospace);
+  font-size: 13px;
+  margin-top: 8px;
+}
+
+.pageBtn {
+  border: 1px solid rgba(20, 20, 20, 0.3);
+  border-radius: 0;
+  background: #ffffff;
+  color: var(--pf-ink);
+  font-size: 12px;
+  font-family: inherit;
+  font-weight: 500;
+  padding: 6px 14px;
+  cursor: pointer;
+  text-decoration: none;
+  transition: all 120ms ease;
+}
+
+.pageBtn:hover:not([data-disabled="true"]) {
+  background: var(--pf-ink);
+  border-color: var(--pf-ink);
+  color: var(--pf-cream);
+}
+
+.pageBtn[data-disabled="true"] {
+  opacity: 0.4;
+  pointer-events: none;
+}
+
+.pageIndicator {
+  color: var(--pf-ink-muted);
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.pageIndicator strong {
+  color: var(--pf-ink);
+}
+
+.pageMetaTotal {
+  font-size: 11px;
+  opacity: 0.7;
+}
+
+/* ── Notice ──
+   One moderator-pinned post at the top of Discussions. Solid, like .hwChip —
+   the strongest chip in the family, because it is the one the site itself is
+   saying rather than reporting. */
+.noticeChip {
+  display: inline-block;
+  font-family: var(--pf-mono, monospace);
+  font-size: 10px;
+  font-weight: 500;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #ffffff;
+  background: var(--pf-ink);
+  border: 1px solid var(--pf-ink);
+  border-radius: 0;
+  padding: 1px 7px;
+  margin-right: 8px;
+  vertical-align: 2px;
+  white-space: nowrap;
+}
+
+/* ── Code fences ──
+   The one piece of markup the board has. Same dark ground as the code panel,
+   so pasted logs read as what they are. */
+.codeFence {
+  margin: 10px 0;
+  padding: 10px 12px;
+  background: #09090b;
+  color: #e6e2d8;
+  font-family: var(--pf-mono, monospace);
+  font-size: 12px;
+  line-height: 1.55;
+  white-space: pre-wrap;
+  word-break: break-word;
+  overflow-x: auto;
+  border-radius: 0;
+}
+
 /* ── Firmware ports ──
    Somebody else's board finishing the author's pattern. A quiet ledger, not a
    leaderboard: handle, date, state — and the author's Pin as the only verb. */

--- a/web/src/components/community/Community.module.css
+++ b/web/src/components/community/Community.module.css
@@ -82,21 +82,20 @@
   flex: none;
 }
 
+/* The feed flows with the document and grows as batches append — ONE
+   scrollbar, the page's own. (Its ancestor once locked itself to the viewport
+   for the paginated layout; that clipped the controls on short screens.) */
 .feedWrapper {
   flex: 1;
   display: flex;
   flex-direction: column;
-  height: calc(100vh - 100px);
-  max-height: calc(100vh - 100px);
-  overflow: hidden;
+  padding-bottom: 60px;
 }
 
 .centeredFeedBody {
-  flex: 1;
   display: flex;
   flex-direction: column;
   align-items: center;
-  justify-content: center;
   gap: 20px;
 }
 
@@ -112,83 +111,19 @@
   justify-content: center;
 }
 
-.paginationBar {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 16px;
+/* The infinite-scroll loader's target: a sliver under the grid whose
+   approach triggers the next batch. Height, not emptiness — a 0px element
+   never intersects. */
+.feedSentinel {
+  width: 100%;
+  height: 1px;
+}
+
+.feedEndNote {
+  margin: 4px 0 0;
   font-family: var(--pf-mono, monospace);
-  font-size: 13px;
-  margin-top: 8px;
-}
-
-.pageBtn {
-  appearance: none;
-  border: 1px solid rgba(20, 20, 20, 0.3);
-  border-radius: 0;
-  background: #FFFFFF;
-  color: var(--pf-ink);
-  font-size: 12px;
-  font-family: inherit;
-  font-weight: 500;
-  padding: 6px 14px;
-  cursor: pointer;
-  transition: all 120ms ease;
-}
-
-.pageBtn:hover:not(:disabled) {
-  background: var(--pf-ink);
-  border-color: var(--pf-ink);
-  color: var(--pf-cream);
-}
-
-.pageBtn:disabled {
-  opacity: 0.4;
-  cursor: default;
-}
-
-.pageIndicator {
-  color: var(--pf-ink-muted);
-  display: flex;
-  align-items: center;
-  gap: 6px;
-}
-
-.pageIndicator strong {
-  color: var(--pf-ink);
-}
-
-.pageMetaTotal {
   font-size: 11px;
-  opacity: 0.7;
-}
-
-/* Type a page number instead of stepping to it. Sized for four digits, since
-   the spinner arrows are hidden and the value has to fit unaided. */
-.pageInput {
-  width: 52px;
-  padding: 3px 6px;
-  border: 1px solid rgba(20, 20, 20, 0.3);
-  border-radius: 0;
-  background: #FFFFFF;
-  color: var(--pf-ink);
-  font-family: inherit;
-  font-size: 12px;
-  font-weight: 500;
-  text-align: center;
-  -moz-appearance: textfield;
-  appearance: textfield;
-}
-
-.pageInput::-webkit-outer-spin-button,
-.pageInput::-webkit-inner-spin-button {
-  -webkit-appearance: none;
-  margin: 0;
-}
-
-.pageInput:focus {
-  outline: none;
-  border-color: var(--pf-ink);
+  color: var(--pf-ink-faint);
 }
 
 /* ── Small view ──
@@ -1012,32 +947,14 @@
   color: var(--pf-cream);
 }
 
-/* Card-size switch. Same pill as the sort tabs — it's the same kind of choice,
-   so it should not look like a different kind of control. */
-.viewTabs {
-  display: flex;
-  gap: 2px;
-  border: 1px solid rgba(20, 20, 20, 0.2);
-  border-radius: 0;
-  padding: 2px;
-}
-
-.viewTabs a {
-  padding: 5px 12px;
-  border-radius: 0;
-  color: var(--pf-ink-muted);
-  font-size: 12.5px;
-  text-decoration: none;
+/* Card size has no widget — Ctrl+scroll (or pinch) IS the control, so this
+   hint is its entire discoverability. Quiet on purpose. */
+.zoomHint {
+  margin-left: auto;
+  font-family: var(--pf-mono, monospace);
+  font-size: 11px;
+  color: var(--pf-ink-faint);
   white-space: nowrap;
-}
-
-.viewTabs a:hover {
-  color: var(--pf-ink);
-}
-
-.viewTabs a[data-active="true"] {
-  background: var(--pf-ink);
-  color: var(--pf-cream);
 }
 
 .filterChip {
@@ -1690,16 +1607,7 @@
     min-height: auto;
   }
 
-  /* The desktop feed locks itself to the viewport and never scrolls; on
-     mobile the wall of thumbnails IS the page, so let it flow. */
-  .feedWrapper {
-    height: auto;
-    max-height: none;
-    overflow: visible;
-  }
-
   .centeredFeedBody {
-    justify-content: flex-start;
     gap: 14px;
   }
 
@@ -1708,29 +1616,10 @@
     margin-bottom: 14px;
   }
 
-  /* Card size is fixed by the mobile view config — a Large/Small toggle
-     would be a lie here. */
-  .viewTabs {
+  /* Card size is fixed by the mobile view config, and there is no Ctrl+wheel
+     on a phone — the hint would advertise a gesture that does not exist. */
+  .zoomHint {
     display: none;
-  }
-
-  /* Touch-sized pagination. */
-  .paginationBar {
-    flex-wrap: wrap;
-    justify-content: center;
-    row-gap: 10px;
-    margin-top: 14px;
-    padding-bottom: 28px;
-  }
-
-  .pageBtn {
-    padding: 10px 14px;
-    font-size: 13px;
-  }
-
-  .pageInput {
-    padding: 8px 6px;
-    font-size: 13px;
   }
 }
 

--- a/web/src/components/community/Community.module.css
+++ b/web/src/components/community/Community.module.css
@@ -2173,6 +2173,95 @@
   color: var(--pf-ink);
 }
 
+/* ── Firmware ports ──
+   Somebody else's board finishing the author's pattern. A quiet ledger, not a
+   leaderboard: handle, date, state — and the author's Pin as the only verb. */
+
+.portsSection {
+  margin-top: 18px;
+  border-top: 1px solid var(--pf-rule-soft);
+  padding-top: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.portsHead {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.portsTitle {
+  font-family: var(--pf-mono, monospace);
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--pf-ink-muted);
+}
+
+.portsList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.portRow {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 6px 0;
+  border-bottom: 1px solid var(--pf-rule-soft);
+  font-size: 13px;
+  min-width: 0;
+}
+
+.portRow[data-stale="true"] .portHandle {
+  color: var(--pf-ink-faint);
+}
+
+.portHandle {
+  font-weight: 500;
+  color: var(--pf-ink);
+  white-space: nowrap;
+}
+
+.portDate {
+  font-family: var(--pf-mono, monospace);
+  font-size: 10px;
+  color: var(--pf-ink-faint);
+  flex: none;
+}
+
+.portChip {
+  flex: none;
+  font-family: var(--pf-mono, monospace);
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--pf-led);
+  border: 1px solid rgba(232, 85, 46, 0.5);
+  padding: 0 6px;
+}
+
+.portStale {
+  flex: none;
+  font-family: var(--pf-mono, monospace);
+  font-size: 10px;
+  letter-spacing: 0.04em;
+  color: var(--pf-ink-faint);
+  border: 1px dashed rgba(20, 20, 20, 0.3);
+  padding: 0 6px;
+}
+
+.portNote {
+  color: var(--pf-ink-muted);
+  font-size: 12px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 /* ── Alerts ──
    Delivery is the next page load — no polling, no sockets. The header link
    turns LED-orange while anything is unread, and goes quiet again. */

--- a/web/src/components/community/CommunityFeedClient.tsx
+++ b/web/src/components/community/CommunityFeedClient.tsx
@@ -1,25 +1,35 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
-import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import PatternCard, { PatternCardItem } from "./PatternCard";
 import FeedControls from "./FeedControls";
+import { COMMUNITY_FETCH_INIT, communityApiUrl } from "@/lib/community/apiBase";
 import {
-  DEFAULT_FEED_VIEW,
-  FEED_VIEWS,
+  FEED_SLOT_KEY,
   MAX_FEED_PAGE_SIZE,
   MOBILE_FEED_VIEW,
-  type FeedView,
+  SLOT_COMPACT,
+  SLOT_DEFAULT,
+  SLOT_MAX,
+  SLOT_MIN,
+  batchRowsForSlot,
+  gapForSlot,
 } from "@/lib/community/feedView";
 import { useIsMobile } from "@/lib/useMediaQuery";
 import styles from "./Community.module.css";
 
-// Responsive grid sized to whichever view is active (see lib/community/feedView).
+// Infinite scroll, one scrollbar: the page itself. The grid grows downward as
+// the sentinel under it comes into view — no pager, no inner scroll region to
+// fight the document over the wheel.
 //
-// Paging is server-side: a request returns about a screenful of patterns rather
-// than the whole feed. Every row ships its full source — the cards compile and
-// play it client-side — so sending patterns nobody can see would be paying for
-// them twice, in transfer and in sandboxes.
+// Card size is a continuous zoom (Ctrl + scroll, or trackpad pinch),
+// Pinterest-style, remembered per browser. Plain scrolling feeds the page;
+// Ctrl distinguishes "resize the wall" from "walk along it" — and from the
+// knob overlay, whose wheel only acts without Ctrl.
+//
+// Batches stay small because every card ships its full source. Appends are
+// de-duplicated by id: the feed is newest-first, so anything published while
+// you scroll shifts the offsets and would otherwise repeat a card.
 
 function useResponsiveCardsPerRow(
   containerRef: React.RefObject<HTMLDivElement | null>,
@@ -48,103 +58,152 @@ function useResponsiveCardsPerRow(
 }
 
 export default function CommunityFeedClient({
-  items,
+  items: initialItems,
   sort = "new",
   hardwareOnly = false,
-  view = DEFAULT_FEED_VIEW,
-  page = 0,
-  total = 0,
+  total: initialTotal = 0,
 }: {
   items: PatternCardItem[];
   sort?: string;
   hardwareOnly?: boolean;
-  view?: FeedView;
-  page?: number;
   total?: number;
 }) {
-  const router = useRouter();
-  const pathname = usePathname();
-  const params = useSearchParams();
+  const wrapperRef = useRef<HTMLDivElement | null>(null);
   const containerRef = useRef<HTMLDivElement | null>(null);
+  const sentinelRef = useRef<HTMLDivElement | null>(null);
 
-  // Mobile swaps in its own view config: dense static thumbnails, several rows
-  // per page, the whole page scrollable. Desktop keeps the Large/Small toggle.
   const isMobile = useIsMobile();
-  const config = isMobile ? MOBILE_FEED_VIEW : FEED_VIEWS[view];
-  const cardsPerRow = useResponsiveCardsPerRow(containerRef, config.slot, config.gap);
-  const pageSize = Math.min(MAX_FEED_PAGE_SIZE, Math.max(1, cardsPerRow * config.rows));
 
-  // The server sends a slightly generous first page (it can't know the
-  // viewport), so trim to what actually fits. Page 0 of any size shares the
-  // same prefix, so the following pages line up exactly.
-  const visibleItems = items.slice(0, pageSize);
-  const totalPages = Math.max(1, Math.ceil(total / pageSize));
-  const currentPage = Math.min(page, totalPages - 1);
-
-  const hrefForPage = useCallback(
-    (nextPage: number) => {
-      const next = new URLSearchParams(params.toString());
-      if (nextPage <= 0) next.delete("page");
-      else next.set("page", String(nextPage));
-      // Ask for exactly what this viewport shows from here on.
-      next.set("size", String(pageSize));
-      const query = next.toString();
-      return query ? `${pathname}?${query}` : pathname;
-    },
-    [params, pathname, pageSize],
-  );
-
-  const goTo = useCallback(
-    (nextPage: number) => {
-      if (nextPage < 0 || nextPage > totalPages - 1) return;
-      router.push(hrefForPage(nextPage), { scroll: false });
-    },
-    [router, hrefForPage, totalPages],
-  );
-
-  // Self-correcting page size: when this viewport shows more cards than the
-  // server guessed (a first load on mobile, where six dense rows outrun the
-  // desktop-sized default), re-request the page at the real size. hrefForPage
-  // pins ?size= to the measured value, so this settles after one replace.
-  const expectedCount = Math.min(pageSize, Math.max(0, total - currentPage * pageSize));
+  // The zoom. Starts at the default for a hydration-stable first paint, then
+  // adopts whatever this browser chose last time — a frame later, so the
+  // stored value never fights the server-rendered markup.
+  const [slot, setSlot] = useState<number>(SLOT_DEFAULT);
   useEffect(() => {
-    if (items.length >= expectedCount) return;
-    router.replace(hrefForPage(currentPage), { scroll: false });
-  }, [items.length, expectedCount, router, hrefForPage, currentPage]);
-
-  const pageInputRef = useRef<HTMLInputElement | null>(null);
-
-  const commitPageInput = useCallback(() => {
-    const input = pageInputRef.current;
-    if (!input) return;
-    const typed = Number(input.value);
-    if (!Number.isFinite(typed)) {
-      input.value = String(currentPage + 1);
-      return;
-    }
-    // Clamp rather than reject: "999" on a 7-page feed means the end.
-    const target = Math.max(0, Math.min(totalPages - 1, Math.round(typed) - 1));
-    if (target === currentPage) {
-      input.value = String(currentPage + 1);
-      return;
-    }
-    goTo(target);
-  }, [currentPage, totalPages, goTo]);
-
-  // Arrow keys flip pages, as before.
+    const id = window.requestAnimationFrame(() => {
+      try {
+        const saved = Number(window.localStorage.getItem(FEED_SLOT_KEY));
+        if (Number.isFinite(saved) && saved >= SLOT_MIN && saved <= SLOT_MAX) setSlot(saved);
+      } catch {
+        // Private mode: the default is fine.
+      }
+    });
+    return () => window.cancelAnimationFrame(id);
+  }, []);
   useEffect(() => {
-    const handleKeyDown = (event: KeyboardEvent) => {
-      const target = event.target as HTMLElement | null;
-      if (target && /^(INPUT|TEXTAREA|SELECT)$/.test(target.tagName)) return;
-      if (event.key === "ArrowLeft") goTo(currentPage - 1);
-      if (event.key === "ArrowRight") goTo(currentPage + 1);
+    try {
+      window.localStorage.setItem(FEED_SLOT_KEY, String(slot));
+    } catch {
+      // Private mode: the size lasts for this page, which is still something.
+    }
+  }, [slot]);
+
+  // Ctrl+wheel (and pinch, which reports as ctrlKey wheel) resizes the wall.
+  // A native non-passive listener, because preventDefault here is the whole
+  // point — without it the browser zooms the page instead.
+  useEffect(() => {
+    const el = wrapperRef.current;
+    if (!el || isMobile) return;
+    const onWheel = (event: WheelEvent) => {
+      if (!event.ctrlKey) return;
+      event.preventDefault();
+      setSlot((prev) =>
+        Math.round(
+          Math.min(SLOT_MAX, Math.max(SLOT_MIN, prev * Math.exp(-event.deltaY * 0.0015))),
+        ),
+      );
     };
-    window.addEventListener("keydown", handleKeyDown);
-    return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [goTo, currentPage]);
+    el.addEventListener("wheel", onWheel, { passive: false });
+    return () => el.removeEventListener("wheel", onWheel);
+  }, [isMobile]);
+
+  const gap = isMobile ? MOBILE_FEED_VIEW.gap : gapForSlot(slot);
+  const effectiveSlot = isMobile ? MOBILE_FEED_VIEW.slot : slot;
+  const compact = isMobile || slot <= SLOT_COMPACT;
+  const cardsPerRow = useResponsiveCardsPerRow(containerRef, effectiveSlot, gap);
+
+  const [items, setItems] = useState<PatternCardItem[]>(initialItems);
+  const [total, setTotal] = useState(initialTotal);
+  const [failed, setFailed] = useState(false);
+  // Everything the loader itself needs lives in refs: loads are triggered by
+  // an IntersectionObserver, and stale closures over state would double-fetch.
+  const itemsRef = useRef(initialItems);
+  const busyRef = useRef(false);
+  const doneRef = useRef(initialItems.length >= initialTotal);
+  const [done, setDone] = useState(initialItems.length >= initialTotal);
+
+  const batchRows = isMobile ? MOBILE_FEED_VIEW.batchRows : batchRowsForSlot(slot);
+
+  const loadMore = useCallback(async () => {
+    if (busyRef.current || doneRef.current) return;
+    busyRef.current = true;
+    setFailed(false);
+    try {
+      const have = itemsRef.current.length;
+      const size = Math.min(MAX_FEED_PAGE_SIZE, Math.max(cardsPerRow * batchRows, cardsPerRow));
+      const params = new URLSearchParams({ offset: String(have), size: String(size) });
+      if (sort !== "new") params.set("sort", sort);
+      if (hardwareOnly) params.set("hw", "1");
+      const response = await fetch(
+        communityApiUrl(`/api/community/patterns?${params.toString()}`),
+        COMMUNITY_FETCH_INIT,
+      );
+      if (!response.ok) throw new Error(String(response.status));
+      const payload = (await response.json()) as { items: PatternCardItem[]; total: number };
+
+      const seen = new Set(itemsRef.current.map((item) => item.id));
+      const fresh = payload.items.filter((item) => !seen.has(item.id));
+      const next = [...itemsRef.current, ...fresh];
+      itemsRef.current = next;
+      setItems(next);
+      setTotal(payload.total);
+      if (payload.items.length < size || next.length >= payload.total) {
+        doneRef.current = true;
+        setDone(true);
+      }
+    } catch {
+      // Note it and stand down until the next intersection — a flaky network
+      // must not become a fetch loop.
+      setFailed(true);
+    } finally {
+      busyRef.current = false;
+    }
+  }, [cardsPerRow, batchRows, sort, hardwareOnly]);
+
+  // The sentinel drives loading. One subtlety: after an append the sentinel
+  // can STILL be inside the viewport (short feed, tall screen), and an
+  // observer only fires on crossings — so keep loading while it shows.
+  useEffect(() => {
+    const sentinel = sentinelRef.current;
+    if (!sentinel) return;
+
+    let cancelled = false;
+    const fillViewport = async () => {
+      while (!cancelled && !doneRef.current && !busyRef.current) {
+        const rect = sentinel.getBoundingClientRect();
+        if (rect.top > window.innerHeight + 600) break;
+        await loadMore();
+        if (busyRef.current) break;
+      }
+    };
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((entry) => entry.isIntersecting)) void fillViewport();
+      },
+      // Start fetching a comfortable distance before the gap becomes visible.
+      { rootMargin: "600px 0px" },
+    );
+    observer.observe(sentinel);
+    void fillViewport();
+
+    return () => {
+      cancelled = true;
+      observer.disconnect();
+    };
+  }, [loadMore]);
 
   return (
-    <div className={styles.feedWrapper}>
+    <div ref={wrapperRef} className={styles.feedWrapper}>
       <div className={styles.introRow}>
         <span>
           {isMobile
@@ -153,7 +212,7 @@ export default function CommunityFeedClient({
         </span>
       </div>
 
-      <FeedControls sort={sort} hardwareOnly={hardwareOnly} view={view} />
+      <FeedControls sort={sort} hardwareOnly={hardwareOnly} />
 
       {total === 0 ? (
         <div className={styles.empty}>
@@ -165,92 +224,34 @@ export default function CommunityFeedClient({
         <div ref={containerRef} className={styles.centeredFeedBody}>
           <div
             className={styles.feedGrid}
-            // Mobile borrows the small view's compact card furniture.
-            data-view={isMobile ? "small" : view}
+            // Compact cards borrow the small view's furniture.
+            data-view={compact ? "small" : "large"}
             style={{
               gridTemplateColumns: `repeat(${cardsPerRow}, minmax(0, 1fr))`,
-              gap: `${config.gap}px`,
+              gap: `${gap}px`,
             }}
           >
-            {visibleItems.map((item) => (
+            {items.map((item) => (
               // Static thumbnails on mobile: no hover means the live sandbox
               // iframes and knob overlay are pure cost there.
               <PatternCard key={item.id} item={item} interactive={!isMobile} />
             ))}
           </div>
 
-          {/* Pagination. Stepping is fine for a handful of pages, but a feed of
-              any size needs a way in that doesn't cost one page load per step —
-              hence First/Last and a page box you can type into. */}
-          {totalPages > 1 && (
-            <div className={styles.paginationBar}>
-              <button
-                type="button"
-                className={styles.pageBtn}
-                onClick={() => goTo(0)}
-                disabled={currentPage === 0}
-                title="First page"
-                aria-label="First page"
-              >
-                ⏮
-              </button>
-              <button
-                type="button"
-                className={styles.pageBtn}
-                onClick={() => goTo(currentPage - 1)}
-                disabled={currentPage === 0}
-              >
-                ◀ Prev
-              </button>
+          {/* The loader's target. Kept in the tree even when done, so a feed
+              that grows while you read can resume. */}
+          <div ref={sentinelRef} className={styles.feedSentinel} aria-hidden="true" />
 
-              <span className={styles.pageIndicator}>
-                Page{" "}
-                <input
-                  // Remount on page change so the box always shows the page
-                  // actually being displayed, never a half-typed number left
-                  // over from a jump that got clamped or cancelled.
-                  key={currentPage}
-                  ref={pageInputRef}
-                  className={styles.pageInput}
-                  type="number"
-                  inputMode="numeric"
-                  min={1}
-                  max={totalPages}
-                  defaultValue={currentPage + 1}
-                  aria-label={`Page number, 1 to ${totalPages}`}
-                  onFocus={(event) => event.currentTarget.select()}
-                  onBlur={commitPageInput}
-                  onKeyDown={(event) => {
-                    if (event.key === "Enter") event.currentTarget.blur();
-                    if (event.key === "Escape") {
-                      event.currentTarget.value = String(currentPage + 1);
-                      event.currentTarget.blur();
-                    }
-                  }}
-                />{" "}
-                of {totalPages}
-                <span className={styles.pageMetaTotal}>({total} patterns)</span>
-              </span>
+          {failed && (
+            <button type="button" className={styles.btn} onClick={() => void loadMore()}>
+              Loading failed — try again
+            </button>
+          )}
 
-              <button
-                type="button"
-                className={styles.pageBtn}
-                onClick={() => goTo(currentPage + 1)}
-                disabled={currentPage >= totalPages - 1}
-              >
-                Next ▶
-              </button>
-              <button
-                type="button"
-                className={styles.pageBtn}
-                onClick={() => goTo(totalPages - 1)}
-                disabled={currentPage >= totalPages - 1}
-                title="Last page"
-                aria-label="Last page"
-              >
-                ⏭
-              </button>
-            </div>
+          {done && (
+            <p className={styles.feedEndNote}>
+              That is the whole feed — {total} pattern{total === 1 ? "" : "s"}.
+            </p>
           )}
         </div>
       )}

--- a/web/src/components/community/DiscussionsClient.tsx
+++ b/web/src/components/community/DiscussionsClient.tsx
@@ -20,6 +20,8 @@ export type PostListView = {
   id: string;
   title: string;
   body: string;
+  /** The notice — moderator-pinned, always first in the list. */
+  pinned: boolean;
   createdAt: string; // ISO
   username: string | null;
   displayUsername: string | null;
@@ -119,7 +121,7 @@ export default function DiscussionsClient({
             className={styles.postBodyInput}
             value={body}
             maxLength={POST_BODY_MAX}
-            placeholder="Write your post. Plain text — links become clickable on their own."
+            placeholder={"Write your post. Plain text — links become clickable on their own, and anything between ``` lines renders as code."}
             aria-label="Post body"
             onChange={(event) => setBody(event.target.value)}
           />
@@ -150,6 +152,7 @@ export default function DiscussionsClient({
             <li key={post.id} className={styles.postRow}>
               <Link href={`/community/discussions/${post.id}`} className={styles.postRowLink}>
                 <span className={styles.postRowTitle}>
+                  {post.pinned && <span className={styles.noticeChip}>Notice</span>}
                   {post.title}
                   {post.commentCount > 0 && (
                     <span className={styles.postRowCount}>{post.commentCount}</span>

--- a/web/src/components/community/DiscussionsClient.tsx
+++ b/web/src/components/community/DiscussionsClient.tsx
@@ -90,7 +90,7 @@ export default function DiscussionsClient({
   return (
     <div className={styles.discussionWrap}>
       <div className={styles.introRow}>
-        <span>Questions, build logs and anything else that isn&apos;t a pattern.</span>
+        <span>Ideas, questions, and anything else on your mind — the free half of the community.</span>
         <span className={styles.headerSpacer} />
         {session ? (
           <button
@@ -121,7 +121,7 @@ export default function DiscussionsClient({
             className={styles.postBodyInput}
             value={body}
             maxLength={POST_BODY_MAX}
-            placeholder={"Write your post. Plain text — links become clickable on their own, and anything between ``` lines renders as code."}
+            placeholder="Write your post. Plain text — links become clickable on their own."
             aria-label="Post body"
             onChange={(event) => setBody(event.target.value)}
           />

--- a/web/src/components/community/FeedControls.tsx
+++ b/web/src/components/community/FeedControls.tsx
@@ -2,41 +2,36 @@
 
 import Link from "next/link";
 import { usePathname, useSearchParams } from "next/navigation";
-import { DEFAULT_FEED_VIEW, FEED_VIEWS, type FeedView } from "@/lib/community/feedView";
 import styles from "./Community.module.css";
 
 // Sort + filter bar. Plain links carrying query params, so the feed stays a
-// server-rendered, shareable, back-button-friendly URL.
+// server-rendered, shareable, back-button-friendly URL. Card size is not
+// here: that is the Ctrl+scroll zoom, a per-browser preference, and the hint
+// on the right is its only UI.
 
 const SORTS = [
   { id: "new", label: "Newest" },
   { id: "top", label: "Most liked" },
   { id: "forks", label: "Most forked" },
-  // Counts distinct OTHER people whose published decks carry the pattern —
-  // harder to game than likes, since it costs a public deck slot.
-  { id: "decks", label: "In decks" },
 ] as const;
 
 export default function FeedControls({
   sort,
   hardwareOnly,
-  view,
 }: {
   sort: string;
   hardwareOnly: boolean;
-  view: FeedView;
 }) {
   const pathname = usePathname();
   const params = useSearchParams();
 
   const hrefWith = (patch: Record<string, string | null>) => {
     const next = new URLSearchParams(params.toString());
-    // Changing the view always restarts at the first page — page 3 of "newest"
-    // means nothing in "most liked", and may not even exist once filtered.
+    // Parameters from the paginated era — scrub them off any link followed
+    // from an old bookmark.
     next.delete("page");
-    // The row size is measured for the old view; let the server pick its
-    // default and the client re-measure rather than carrying a stale one.
     next.delete("size");
+    next.delete("view");
     for (const [key, value] of Object.entries(patch)) {
       if (value === null) next.delete(key);
       else next.set(key, value);
@@ -60,24 +55,6 @@ export default function FeedControls({
         ))}
       </div>
 
-      <div className={styles.viewTabs} role="group" aria-label="Card size">
-        {(Object.keys(FEED_VIEWS) as FeedView[]).map((option) => (
-          <Link
-            key={option}
-            href={hrefWith({ view: option === DEFAULT_FEED_VIEW ? null : option })}
-            data-active={view === option}
-            scroll={false}
-            title={
-              FEED_VIEWS[option].rows === 1
-                ? "One row of large cards"
-                : `${FEED_VIEWS[option].rows} rows of smaller cards`
-            }
-          >
-            {FEED_VIEWS[option].label}
-          </Link>
-        ))}
-      </div>
-
       <Link
         className={styles.filterChip}
         href={hrefWith({ hw: hardwareOnly ? null : "1" })}
@@ -88,6 +65,10 @@ export default function FeedControls({
         {/* Same chip as the one on the cards, so the filter names its own badge. */}
         <span className={styles.hwChip}>.h</span> Hardware ready
       </Link>
+
+      {/* Desktop only (hidden with the rest of the pointer furniture on
+          mobile): the zoom has no widget, so the hint IS the discoverability. */}
+      <span className={styles.zoomHint}>Ctrl + scroll to resize</span>
     </div>
   );
 }

--- a/web/src/components/community/FencedText.tsx
+++ b/web/src/components/community/FencedText.tsx
@@ -1,11 +1,12 @@
 import LinkedText from "./LinkedText";
 import styles from "./Community.module.css";
 
-// Plain text plus exactly ONE piece of markup: ``` fences render as code
-// blocks. This board's long posts are build logs, compiler output and JS
-// fragments — prose markup would be ceremony, but a log squashed into a
-// paragraph is unreadable. Everything stays escaped-by-React, same as ever;
-// a fence changes the font, never the trust model.
+// Plain text plus exactly ONE render-time nicety: ``` fences render as code
+// blocks. The board is a free board — most posts are just ideas and talk —
+// but the odd pasted error log squashed into a paragraph is unreadable, and
+// this fixes that at zero cost to everyone who never types a fence.
+// Everything stays escaped-by-React, same as ever; a fence changes the font,
+// never the trust model.
 
 type Segment = { fence: boolean; text: string };
 

--- a/web/src/components/community/FencedText.tsx
+++ b/web/src/components/community/FencedText.tsx
@@ -1,0 +1,60 @@
+import LinkedText from "./LinkedText";
+import styles from "./Community.module.css";
+
+// Plain text plus exactly ONE piece of markup: ``` fences render as code
+// blocks. This board's long posts are build logs, compiler output and JS
+// fragments — prose markup would be ceremony, but a log squashed into a
+// paragraph is unreadable. Everything stays escaped-by-React, same as ever;
+// a fence changes the font, never the trust model.
+
+type Segment = { fence: boolean; text: string };
+
+/**
+ * Split on lines that are exactly a fence marker (``` plus an optional
+ * language tag, which is dropped). An unclosed fence runs to the end — people
+ * forget the closing marker, and rendering their log as the code they meant
+ * beats punishing the omission.
+ */
+export function splitFences(text: string): Segment[] {
+  const lines = text.split("\n");
+  const segments: Segment[] = [];
+  let current: string[] = [];
+  let inFence = false;
+
+  const flush = () => {
+    if (current.length === 0) return;
+    const joined = current.join("\n");
+    // Whitespace-only prose between fences is layout residue, not content.
+    if (inFence || joined.trim().length > 0) segments.push({ fence: inFence, text: joined });
+    current = [];
+  };
+
+  for (const line of lines) {
+    if (/^```[\w+-]*\s*$/.test(line)) {
+      flush();
+      inFence = !inFence;
+      continue;
+    }
+    current.push(line);
+  }
+  flush();
+
+  return segments;
+}
+
+export default function FencedText({ text }: { text: string }) {
+  const segments = splitFences(text);
+  return (
+    <>
+      {segments.map((segment, index) =>
+        segment.fence ? (
+          <pre key={index} className={styles.codeFence}>
+            {segment.text}
+          </pre>
+        ) : (
+          <LinkedText key={index} text={segment.text} />
+        ),
+      )}
+    </>
+  );
+}

--- a/web/src/components/community/NotificationsList.tsx
+++ b/web/src/components/community/NotificationsList.tsx
@@ -38,6 +38,10 @@ function describe(item: NotificationView): string {
       return `published a fork of “${item.targetTitle}”`;
     case "deck":
       return `put “${item.snippet ?? "your pattern"}” in their deck “${item.targetTitle}”`;
+    case "port":
+      return `added a firmware port to “${item.targetTitle}” — open it to pick or replace`;
+    case "pin":
+      return `pinned your port of “${item.targetTitle}”`;
     default:
       return `did something with “${item.targetTitle}”`;
   }

--- a/web/src/components/community/PatternCard.tsx
+++ b/web/src/components/community/PatternCard.tsx
@@ -127,10 +127,46 @@ export default function PatternCard({
   };
 
   const thumbRef = useRef<HTMLDivElement | null>(null);
+  const rootRef = useRef<HTMLAnchorElement | null>(null);
   // Mirrors `thumb` so the effect can ask "do we already have one?" without
   // depending on it — depending on the state would restart the render whenever
   // a thumbnail arrives, and reading it from the closure would read a stale one.
   const lastThumbRef = useRef<string | null>(null);
+
+  // A card is a dead zone for page scroll: the wheel belongs to the knobs
+  // there, and a feed that lurches while you are mid-turn is unusable. Scroll
+  // the page from the gaps between cards. Native and non-passive, because
+  // preventDefault is the whole point; Ctrl+wheel still passes through — that
+  // is the wall's resize gesture, handled above the card.
+  useEffect(() => {
+    if (!interactive) return;
+    const el = rootRef.current;
+    if (!el) return;
+    const onWheel = (event: WheelEvent) => {
+      if (event.ctrlKey) return;
+      event.preventDefault();
+    };
+    el.addEventListener("wheel", onWheel, { passive: false });
+    return () => el.removeEventListener("wheel", onWheel);
+  }, [interactive]);
+
+  // The live sandbox iframe mounts only once the card has been near the
+  // viewport, and stays mounted after. An infinite feed accumulates hundreds
+  // of cards; pre-warming every one of them would be hundreds of iframes.
+  const [nearViewport, setNearViewport] = useState(false);
+  useEffect(() => {
+    if (!interactive || nearViewport) return;
+    const el = thumbRef.current;
+    if (!el) return;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((entry) => entry.isIntersecting)) setNearViewport(true);
+      },
+      { rootMargin: "300px 0px" },
+    );
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [interactive, nearViewport]);
 
   // Initial static thumbnail
   useEffect(() => {
@@ -189,8 +225,10 @@ export default function PatternCard({
     }
   };
 
-  // Mouse wheel adjusts active knob value
+  // Mouse wheel adjusts active knob value. With Ctrl held it is the feed's
+  // zoom gesture instead — let it bubble to the wall.
   const handleWheel = (e: React.WheelEvent<HTMLDivElement>) => {
+    if (e.ctrlKey) return;
     e.preventDefault();
 
     const [min, max] = knobSetup.ranges[activeKnobIdx] ?? [0, 1];
@@ -217,6 +255,7 @@ export default function PatternCard({
 
   return (
     <Link
+      ref={rootRef}
       href={detailUrl}
       className={styles.card}
       onMouseEnter={interactive ? handleCardMouseEnter : undefined}
@@ -239,8 +278,9 @@ export default function PatternCard({
             <div className={styles.cardThumbNote}>{failed ? "render error" : "rendering…"}</div>
           )}
 
-          {/* Pre-warmed Live Sandbox Preview (0ms instant playback while hovering on card) */}
-          {interactive && (
+          {/* Live sandbox, pre-warmed once the card nears the viewport so the
+              first hover still plays instantly. */}
+          {interactive && nearViewport && (
             <SandboxPreview
               code={item.code}
               knobValues={knobValues}

--- a/web/src/components/community/PostDetailClient.tsx
+++ b/web/src/components/community/PostDetailClient.tsx
@@ -6,7 +6,7 @@ import { useRouter } from "next/navigation";
 import { COMMUNITY_FETCH_INIT, communityApiUrl } from "@/lib/community/apiBase";
 import { POST_BODY_MAX, TITLE_MAX } from "@/lib/community/validate";
 import CommentSection, { type CommentView } from "./CommentSection";
-import LinkedText from "./LinkedText";
+import FencedText from "./FencedText";
 import { formatDate } from "./PatternCard";
 import styles from "./Community.module.css";
 
@@ -16,6 +16,8 @@ export type PostView = {
   id: string;
   title: string;
   body: string;
+  /** Whether this post is THE notice. */
+  pinned: boolean;
   createdAt: string; // ISO
   updatedAt: string; // ISO
   username: string | null;
@@ -26,10 +28,12 @@ export default function PostDetailClient({
   post,
   comments,
   isOwner,
+  isAdmin = false,
 }: {
   post: PostView;
   comments: CommentView[];
   isOwner: boolean;
+  isAdmin?: boolean;
 }) {
   const router = useRouter();
   const [editing, setEditing] = useState(false);
@@ -40,6 +44,31 @@ export default function PostDetailClient({
   const [confirmingDelete, setConfirmingDelete] = useState(false);
 
   const edited = post.updatedAt !== post.createdAt;
+
+  // Moderator-only: make this post the notice (one slot — pinning it bumps
+  // whatever held the spot), or clear it.
+  const setPinned = async (pinned: boolean) => {
+    setBusy(true);
+    setError(null);
+    try {
+      const response = await fetch(communityApiUrl(`/api/community/posts/${post.id}/pin`), {
+        method: "POST",
+        ...COMMUNITY_FETCH_INIT,
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ pinned }),
+      });
+      if (!response.ok) {
+        const payload = (await response.json()) as { error?: string };
+        setError(payload.error ?? "Could not save.");
+        return;
+      }
+      router.refresh();
+    } catch {
+      setError("Network error.");
+    } finally {
+      setBusy(false);
+    }
+  };
 
   const save = async () => {
     if (title.trim().length === 0 || body.trim().length === 0) return;
@@ -140,7 +169,10 @@ export default function PostDetailClient({
           </>
         ) : (
           <>
-            <h1 className={styles.postTitle}>{post.title}</h1>
+            <h1 className={styles.postTitle}>
+              {post.pinned && <span className={styles.noticeChip}>Notice</span>}
+              {post.title}
+            </h1>
             <div className={styles.postMeta}>
               <Link
                 href={`/community/u/${post.username ?? ""}`}
@@ -150,6 +182,21 @@ export default function PostDetailClient({
               </Link>
               <span className={styles.commentDate}>{formatDate(post.createdAt)}</span>
               {edited && <span className={styles.commentDate}>· edited</span>}
+              {isAdmin && (
+                <button
+                  type="button"
+                  className={styles.btnSmall}
+                  disabled={busy}
+                  title={
+                    post.pinned
+                      ? "Remove this post from the top of Discussions"
+                      : "Keep this post at the top of Discussions (replaces the current notice)"
+                  }
+                  onClick={() => void setPinned(!post.pinned)}
+                >
+                  {post.pinned ? "Unpin notice" : "Pin as notice"}
+                </button>
+              )}
               {isOwner && (
                 <>
                   <span className={styles.headerSpacer} />
@@ -193,7 +240,7 @@ export default function PostDetailClient({
             </div>
             {error && <div className={styles.formError}>{error}</div>}
             <div className={styles.postBody}>
-              <LinkedText text={post.body} />
+              <FencedText text={post.body} />
             </div>
           </>
         )}

--- a/web/src/lib/community/feedView.ts
+++ b/web/src/lib/community/feedView.ts
@@ -1,46 +1,49 @@
-// Feed density — two ways to look at the same feed.
+// Feed density — one continuous knob, not two presets.
 //
-// Lives in the URL (`?view=`) alongside sort and the hardware filter, so a view
-// is shareable and the back button works. The server needs it too: it decides
-// how many patterns to send on a first load, before the client has measured the
-// viewport, and two rows of half-size cards need a lot more of them than one
-// row of large ones.
+// Card size follows Ctrl + scroll (and trackpad pinch), Pinterest-style: the
+// grid refits as the target card width changes, and the choice is remembered
+// per browser (localStorage) rather than in the URL — it is a personal
+// reading preference, not something a shared link should impose.
+//
+// The server still needs one number: how many patterns the first paint ships,
+// before the client has measured anything. After that the feed loads batch by
+// batch as you scroll, because every card ships its full source and fetching
+// patterns nobody has scrolled to would pay for them twice — in transfer and
+// in sandboxes.
 
-export type FeedView = "large" | "small";
+/** Target card width, px. The grid fits as many as the row allows. */
+export const SLOT_DEFAULT = 205;
+export const SLOT_MIN = 90;
+export const SLOT_MAX = 320;
 
-export type FeedViewConfig = {
-  label: string;
-  /** Target card width in px. The grid fits as many of these as it can. */
-  slot: number;
-  /** Grid gap in px — part of the fit calculation, so keep it with the slot. */
-  gap: number;
-  rows: number;
-  /** First-load page size, used before the client knows the real row width. */
-  defaultSize: number;
-};
+/** At and below this width the card swaps to its compact furniture
+ *  (the CSS keyed off data-view="small"). */
+export const SLOT_COMPACT = 140;
 
-export const FEED_VIEWS: Record<FeedView, FeedViewConfig> = {
-  large: { label: "Large", slot: 205, gap: 16, rows: 1, defaultSize: 12 },
-  small: { label: "Small", slot: 104, gap: 10, rows: 2, defaultSize: 30 },
-};
+/** Where the browser remembers the chosen size. */
+export const FEED_SLOT_KEY = "pf-feed-slot";
 
-export const DEFAULT_FEED_VIEW: FeedView = "large";
-
-// Mobile ignores the Large/Small toggle entirely: cards are static thumbnails
-// (no hover on a phone), packed dense and stacked several rows deep so one
-// page is a real scrollable wall of patterns. The client detects mobile and
-// swaps this config in; the page URL keeps working like any other view.
-export const MOBILE_FEED_VIEW: FeedViewConfig = {
-  label: "Mobile",
-  slot: 100,
-  gap: 8,
-  rows: 6,
-  defaultSize: 18,
-};
+/** First-paint batch, served before the client knows its viewport. */
+export const FEED_FIRST_PAINT = 18;
 
 /** Ceiling on how much pattern source one request can ship. */
 export const MAX_FEED_PAGE_SIZE = 44;
 
-export function parseFeedView(raw: string | undefined): FeedView {
-  return raw === "small" ? "small" : DEFAULT_FEED_VIEW;
+// Mobile ignores the zoom entirely: cards are static thumbnails (no hover, no
+// Ctrl+wheel on a phone), packed dense so the feed is a real scrollable wall.
+export const MOBILE_FEED_VIEW = {
+  slot: 100,
+  gap: 8,
+  batchRows: 6,
+} as const;
+
+/** Grid gap for a given card size — compact cards sit tighter. */
+export function gapForSlot(slot: number): number {
+  return slot <= SLOT_COMPACT ? 10 : 16;
+}
+
+/** Rows fetched per scroll batch — enough that scrolling one row does not
+ *  cost one request, small enough that the tail stays cheap. */
+export function batchRowsForSlot(slot: number): number {
+  return slot <= SLOT_COMPACT ? 4 : 3;
 }

--- a/web/src/lib/community/notify.ts
+++ b/web/src/lib/community/notify.ts
@@ -19,7 +19,7 @@ function snippetOf(body: string): string {
   return flat.length > SNIPPET_MAX ? `${flat.slice(0, SNIPPET_MAX - 1)}…` : flat;
 }
 
-export type NotificationType = "comment" | "thread" | "fork" | "deck";
+export type NotificationType = "comment" | "thread" | "fork" | "deck" | "port" | "pin";
 
 type Seed = {
   userId: string;
@@ -186,6 +186,54 @@ export async function notifyDeckInclusion(opts: {
     });
   }
   await insertAll(seeds);
+}
+
+/**
+ * A community port landed on the author's pattern — the one notification the
+ * whole feature leans on: ports go live without acceptance, so the author has
+ * to hear about it to exercise their pick.
+ */
+export async function notifyPortAdded(opts: {
+  patternOwnerId: string;
+  patternId: string;
+  patternTitle: string;
+  portId: string;
+  actorId: string;
+}): Promise<void> {
+  if (opts.patternOwnerId === opts.actorId) return;
+  await insertAll([
+    {
+      userId: opts.patternOwnerId,
+      type: "port",
+      actorId: opts.actorId,
+      targetType: "pattern",
+      targetId: opts.patternId,
+      targetTitle: opts.patternTitle,
+      sourceId: opts.portId,
+    },
+  ]);
+}
+
+/** The author pinned a port — told to the porter whose board earned it. */
+export async function notifyPortPinned(opts: {
+  porterId: string;
+  patternId: string;
+  patternTitle: string;
+  portId: string;
+  actorId: string;
+}): Promise<void> {
+  if (opts.porterId === opts.actorId) return;
+  await insertAll([
+    {
+      userId: opts.porterId,
+      type: "pin",
+      actorId: opts.actorId,
+      targetType: "pattern",
+      targetId: opts.patternId,
+      targetTitle: opts.patternTitle,
+      sourceId: opts.portId,
+    },
+  ]);
 }
 
 /**

--- a/web/src/lib/community/ports.ts
+++ b/web/src/lib/community/ports.ts
@@ -1,0 +1,50 @@
+// Which .h a pattern actually ships — pure resolution, no database access,
+// so the page, the header route and the smoke test cannot disagree.
+//
+// The order:
+//   1. the author's own header — their pattern, their port, always wins
+//   2. the port the author pinned, if it is still live
+//   3. the oldest live port — first come, and being first is not hijackable
+//      the way "latest wins" would be
+//
+// "Live" means not stale: a port is of a SPECIFIC version of the JS, and once
+// the source moves the guarantee is gone (same rule that detaches the
+// author's own header on edit).
+
+export type PortRow = {
+  id: string;
+  userId: string;
+  codeCpp: string;
+  note: string | null;
+  stale: boolean;
+  createdAt: Date;
+  username: string | null;
+  displayUsername: string | null;
+};
+
+export type EffectiveHeader =
+  | { codeCpp: string; source: "author" }
+  | { codeCpp: string; source: "port"; portId: string; handle: string | null }
+  | null;
+
+export function resolveHeader(
+  pattern: { codeCpp: string | null; pinnedHeaderId: string | null },
+  /** All of the pattern's ports, ordered oldest first. */
+  ports: PortRow[],
+): EffectiveHeader {
+  if (pattern.codeCpp) return { codeCpp: pattern.codeCpp, source: "author" };
+
+  const live = ports.filter((port) => !port.stale);
+  const pinned = pattern.pinnedHeaderId
+    ? live.find((port) => port.id === pattern.pinnedHeaderId)
+    : undefined;
+  const chosen = pinned ?? live[0];
+  if (!chosen) return null;
+
+  return {
+    codeCpp: chosen.codeCpp,
+    source: "port",
+    portId: chosen.id,
+    handle: chosen.displayUsername ?? chosen.username ?? null,
+  };
+}

--- a/web/src/lib/community/queries.ts
+++ b/web/src/lib/community/queries.ts
@@ -374,6 +374,8 @@ export type PostListItem = {
   id: string;
   title: string;
   body: string;
+  /** The notice — moderator-pinned, floats above everything. */
+  pinned: boolean;
   createdAt: Date;
   updatedAt: Date;
   username: string | null;
@@ -393,11 +395,12 @@ export async function listPosts({
   limit: number;
   offset?: number;
 }): Promise<PostListItem[]> {
-  return getDb()
+  const rows = await getDb()
     .select({
       id: posts.id,
       title: posts.title,
       body: posts.body,
+      pinnedAt: posts.pinnedAt,
       createdAt: posts.createdAt,
       updatedAt: posts.updatedAt,
       ...authorFields,
@@ -405,9 +408,11 @@ export async function listPosts({
     })
     .from(posts)
     .innerJoin(user, eq(posts.userId, user.id))
-    .orderBy(desc(posts.createdAt))
+    // The notice first (there is at most one), then newest.
+    .orderBy(sql`${posts.pinnedAt} IS NULL`, desc(posts.createdAt))
     .limit(limit)
     .offset(offset);
+  return rows.map(({ pinnedAt, ...row }) => ({ ...row, pinned: pinnedAt !== null }));
 }
 
 export async function getPost(id: string) {
@@ -417,6 +422,7 @@ export async function getPost(id: string) {
       userId: posts.userId,
       title: posts.title,
       body: posts.body,
+      pinnedAt: posts.pinnedAt,
       createdAt: posts.createdAt,
       updatedAt: posts.updatedAt,
       ...authorFields,

--- a/web/src/lib/community/queries.ts
+++ b/web/src/lib/community/queries.ts
@@ -43,8 +43,10 @@ const deckCount = sql<number>`(
     AND d.user_id != ${patterns.userId}
 )`;
 
-/** Feed ordering. "top"/"forks"/"decks" are all-time; add a time window once volume justifies it. */
-export const FEED_SORTS = ["new", "top", "forks", "decks"] as const;
+/** Feed ordering. "top"/"forks" are all-time; add a time window once volume justifies it.
+ *  The deck-inclusion count rides on every card (DCK) but is not a sort yet —
+ *  with a handful of decks it would reorder the feed on almost no signal. */
+export const FEED_SORTS = ["new", "top", "forks"] as const;
 export type FeedSort = (typeof FEED_SORTS)[number];
 
 export function parseFeedSort(raw: string | undefined): FeedSort {
@@ -121,9 +123,7 @@ export async function listFeed({
       ? [desc(likeCount), desc(patterns.createdAt)]
       : sort === "forks"
         ? [desc(forkCount), desc(patterns.createdAt)]
-        : sort === "decks"
-          ? [desc(deckCount), desc(patterns.createdAt)]
-          : [desc(patterns.createdAt)];
+        : [desc(patterns.createdAt)];
 
   const rows = await db
     .select(feedColumns)

--- a/web/src/lib/community/queries.ts
+++ b/web/src/lib/community/queries.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, inArray, isNotNull, isNull, ne, sql } from "drizzle-orm";
+import { and, desc, eq, inArray, isNull, ne, sql } from "drizzle-orm";
 import { getDb } from "./db";
 import {
   comments,
@@ -6,6 +6,7 @@ import {
   decks,
   likes,
   notifications,
+  patternHeaders,
   patterns,
   postComments,
   posts,
@@ -30,7 +31,13 @@ const authorFields = {
 // that can drift out of sync with reality.
 const likeCount = sql<number>`(SELECT COUNT(*) FROM ${likes} WHERE ${likes.patternId} = ${patterns.id})`;
 const forkCount = sql<number>`(SELECT COUNT(*) FROM ${patterns} AS child WHERE child.parent_id = ${patterns.id})`;
-const hasCpp = sql<number>`(${patterns.codeCpp} IS NOT NULL)`;
+// "Hardware ready" means an EFFECTIVE header exists: the author's own, or a
+// live community port (see lib/community/ports.ts). Which one wins is the
+// page's business; the feed only cares that a build has something to compile.
+const hasCpp = sql<number>`(${patterns.codeCpp} IS NOT NULL OR EXISTS (
+  SELECT 1 FROM ${patternHeaders} AS ph
+  WHERE ph.pattern_id = ${patterns.id} AND ph.stale = 0
+))`;
 // How many *other people* put this pattern in a public deck. Distinct owners,
 // not rows, and never the pattern's own author: a like costs a click, but this
 // costs one of somebody's two public deck slots spent on someone else's work —
@@ -95,12 +102,15 @@ function toFeedItems(rows: FeedRow[]): FeedItem[] {
 // same table, so EVERY listing query needs this — a miss here is a leak (#255).
 const feedVisible = eq(patterns.visibility, "public");
 
+// The hardware filter and the card chip must agree, so both read `hasCpp`.
+const hardwareReady = sql`${hasCpp} = 1`;
+
 /** How many patterns match the current filter — drives the page count. */
 export async function countFeed(hardwareOnly = false): Promise<number> {
   const rows = await getDb()
     .select({ count: sql<number>`COUNT(*)` })
     .from(patterns)
-    .where(and(feedVisible, hardwareOnly ? isNotNull(patterns.codeCpp) : undefined));
+    .where(and(feedVisible, hardwareOnly ? hardwareReady : undefined));
   return rows[0]?.count ?? 0;
 }
 
@@ -129,7 +139,7 @@ export async function listFeed({
     .select(feedColumns)
     .from(patterns)
     .innerJoin(user, eq(patterns.userId, user.id))
-    .where(and(feedVisible, hardwareOnly ? isNotNull(patterns.codeCpp) : undefined))
+    .where(and(feedVisible, hardwareOnly ? hardwareReady : undefined))
     .orderBy(...order)
     .limit(limit)
     .offset(offset);
@@ -151,6 +161,7 @@ export async function getPattern(id: string) {
       madeHow: patterns.madeHow,
       parentId: patterns.parentId,
       visibility: patterns.visibility,
+      pinnedHeaderId: patterns.pinnedHeaderId,
       createdAt: patterns.createdAt,
       updatedAt: patterns.updatedAt,
       ...authorFields,
@@ -710,6 +721,47 @@ export async function countPublicDecksByUser(
       ),
     );
   return rows[0]?.count ?? 0;
+}
+
+// ── Community ports ──────────────────────────────────────────────────────────
+
+/** A pattern's ports, oldest first — the order resolution reads them in. */
+export async function listPatternPorts(patternId: string) {
+  return getDb()
+    .select({
+      id: patternHeaders.id,
+      userId: patternHeaders.userId,
+      codeCpp: patternHeaders.codeCpp,
+      note: patternHeaders.note,
+      stale: sql<number>`${patternHeaders.stale}`,
+      createdAt: patternHeaders.createdAt,
+      ...authorFields,
+    })
+    .from(patternHeaders)
+    .innerJoin(user, eq(patternHeaders.userId, user.id))
+    .where(eq(patternHeaders.patternId, patternId))
+    .orderBy(patternHeaders.createdAt)
+    .then((rows) =>
+      // SQLite booleans come back 0/1 — normalise once, here.
+      rows.map((row) => ({ ...row, stale: Boolean(row.stale) })),
+    );
+}
+
+/** Ownership check for deleting a port — and the pin's validation, which
+ *  needs to know the port belongs to the pattern and is still live. */
+export async function getPortStub(id: string) {
+  const rows = await getDb()
+    .select({
+      id: patternHeaders.id,
+      userId: patternHeaders.userId,
+      patternId: patternHeaders.patternId,
+      stale: sql<number>`${patternHeaders.stale}`,
+    })
+    .from(patternHeaders)
+    .where(eq(patternHeaders.id, id))
+    .limit(1);
+  const row = rows[0];
+  return row ? { ...row, stale: Boolean(row.stale) } : null;
 }
 
 // ── Notifications ────────────────────────────────────────────────────────────

--- a/web/src/lib/community/schema.ts
+++ b/web/src/lib/community/schema.ts
@@ -272,6 +272,12 @@ export const posts = sqliteTable(
       .references(() => user.id, { onDelete: "cascade" }),
     title: text("title").notNull(),
     body: text("body").notNull(),
+    /**
+     * Set on THE notice — the one post moderators keep at the top of the
+     * list. One slot, not a flag: pinning a post un-pins the previous one,
+     * because two notices are a noticeboard and this is a welcome mat.
+     */
+    pinnedAt: integer("pinned_at", { mode: "timestamp" }),
     createdAt: integer("created_at", { mode: "timestamp" }).notNull(),
     updatedAt: integer("updated_at", { mode: "timestamp" }).notNull(),
   },

--- a/web/src/lib/community/schema.ts
+++ b/web/src/lib/community/schema.ts
@@ -259,9 +259,10 @@ export const deckPatterns = sqliteTable(
 );
 
 // ── Discussions ────────────────────────────────────────────────────────────────────
-// Plain-text discussion, separate from patterns. A post is a title and a body;
-// that's the whole feature. No attachments, no markup — bodies are stored as
-// typed and escaped by React on output, same rule as comments.
+// The free board, separate from patterns. A post is a title and a body;
+// that's the whole feature. No attachments — bodies are stored as typed and
+// escaped by React on output, same rule as comments. (Rendering grants one
+// nicety, the ``` code fence; storage stays exactly what was typed.)
 
 export const posts = sqliteTable(
   "posts",

--- a/web/src/lib/community/schema.ts
+++ b/web/src/lib/community/schema.ts
@@ -126,6 +126,13 @@ export const patterns = sqliteTable(
      * everything — visibility is not a shield from a report).
      */
     visibility: text("visibility").notNull().default("public"),
+    /**
+     * The community port the author chose, when they chose one. No foreign
+     * key (the delete path clears it): resolution falls back gracefully when
+     * the row it names is gone or stale. See lib/community/ports.ts for the
+     * order — the author's own header always outranks it.
+     */
+    pinnedHeaderId: text("pinned_header_id"),
     createdAt: integer("created_at", { mode: "timestamp" }).notNull(),
     updatedAt: integer("updated_at", { mode: "timestamp" }).notNull(),
   },
@@ -134,6 +141,47 @@ export const patterns = sqliteTable(
     index("patterns_user_id_idx").on(table.userId),
     // The feed's exact shape: visible rows, newest first.
     index("patterns_visibility_created_idx").on(table.visibility, table.createdAt),
+  ],
+);
+
+// ── Community firmware ports ─────────────────────────────────────────────────
+// Some people make patterns without owning a board; some people own boards.
+// A port is the second group finishing the first group's work: a hand-verified
+// .h for somebody else's pattern, live the moment it is submitted — an
+// acceptance queue would rot on authors who moved on. Several can coexist
+// (the first may be wrong); arrival order breaks ties and the author's pick
+// overrides it (patterns.pinnedHeaderId). The author's own header, when they
+// attach one, outranks everything.
+//
+// A port is a derivative of the pattern, so it lives under the pattern's
+// licence with the porter credited — same rule as forks, applied to C++.
+
+export const patternHeaders = sqliteTable(
+  "pattern_headers",
+  {
+    id: text("id").primaryKey(),
+    patternId: text("pattern_id")
+      .notNull()
+      .references(() => patterns.id, { onDelete: "cascade" }),
+    /** The porter — the person whose board vouched for it. */
+    userId: text("user_id")
+      .notNull()
+      .references(() => user.id, { onDelete: "cascade" }),
+    codeCpp: text("code_cpp").notNull(),
+    /** Porter's word on how it was verified — "tested on v2.1" etc. */
+    note: text("note"),
+    /**
+     * Set when the pattern's JS changes after this port was made: the port is
+     * of a SPECIFIC version, and once the source moves the guarantee is gone.
+     * Stale rows stay listed ("for an older version") but stop resolving —
+     * the same rule that detaches the author's own header, kept visible.
+     */
+    stale: integer("stale", { mode: "boolean" }).notNull().default(false),
+    createdAt: integer("created_at", { mode: "timestamp" }).notNull(),
+  },
+  (table) => [
+    // Resolution reads "oldest live port for this pattern".
+    index("pattern_headers_pattern_created_idx").on(table.patternId, table.createdAt),
   ],
 );
 

--- a/web/src/lib/community/validate.ts
+++ b/web/src/lib/community/validate.ts
@@ -71,9 +71,10 @@ export function cleanMadeOn(raw: unknown): string | null | undefined {
 }
 
 /**
- * Board post body. Roomier than a comment because a post is the long-form
- * side of the community — a build log or a question with output pasted in —
- * but still plain text with no markup.
+ * Board post body. Discussions is the community's free board — ideas,
+ * questions, whatever is on someone's mind — so a post gets room a comment
+ * does not. Plain text; the one render-time nicety is the ``` code fence
+ * (see FencedText), for the rare pasted log.
  */
 export const POST_BODY_MAX = 20_000;
 


### PR DESCRIPTION
Four commits, three features and a copy repair.

## Infinite scroll feed with Ctrl+scroll zoom (`c4a57f1`)

Pagination is gone: the feed flows with the document and loads batch by batch as a sentinel approaches — one scrollbar, the page's own. (The old layout locked itself to the viewport, which also clipped the pager off short screens.) Card size becomes a continuous Pinterest-style zoom — Ctrl + scroll or pinch, clamped 90–320px, remembered per browser; below 140px cards swap to compact furniture. Cards are a dead zone for page scroll (the wheel belongs to the knobs there), sandbox iframes mount only near the viewport, and batches read through a new GET on `/api/community/patterns` that reuses `listFeed`, so visibility filters cannot drift. The "In decks" sort is gone from the UI — with a handful of decks it reordered on almost no signal; the DCK count stays on every card.

## Community firmware ports (`bed8bda`)

Some people make patterns without owning a board; some people own boards. Anyone signed in can now propose a hand-verified `.h` for a pattern whose author has not attached their own. Ports go live immediately (an acceptance queue would rot on absent authors — the author is notified instead), several can coexist, and the pattern ships: the author's own header first, else the author's pinned pick, else the oldest live port. Resolution is one pure function read by the page, the header route, and the feed's hardware-ready chip and filter alike. Ports carry the pattern's licence with the porter credited ("port by @who"); when the JS changes every port goes stale, same rule that detaches the author's own header. New suite: `check:ports` (15 checks).

## Discussion notice + code fences (`d13aee5`)

Moderators can pin one post as THE notice — one slot, pinning replaces the previous, own route so the author-only edit rule stays intact. ``` fences render as code blocks in posts and comments — the board's only markup, zero cost when unused, escaping unchanged. Also restores the pagination styles the infinite-scroll commit deleted while Discussions still pages.

## Copy repair (`0470a9a`)

Discussions was described as a build-log inbox in the intro, metadata and comments. It is the community's free board — ideas, questions, anything that isn't a pattern — and now says so.

## Verification

`check:ports` new + all seven suites green, tsc/lint clean. Live walkthroughs: scroll-loading to the end note, zoom + knob-wheel coexistence, port proposal → effective header → feed chip flip → author notification, notice pin/unpin with single-slot displacement, fences rendering beside auto-linked URLs. Migration `0012` applies on first DB open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)