### PR TITLE
Community: sandbox cache and iframe windowing for the live feed

### DIFF
--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -38,6 +38,16 @@ const nextConfig: NextConfig = {
         source: "/flash/manifest.json",
         headers: [{ key: "Cache-Control", value: "no-store, must-revalidate" }],
       },
+      {
+        // Every pattern card boots its own sandboxed iframe from this one
+        // document, so the feed loads it dozens of times per visit. Without
+        // this header each load is a round trip to the origin (a Raspberry
+        // Pi), and the cards visibly warm up one by one. Safe to cache hard:
+        // the URL carries ?v= (see lib/community/sandboxUrl.ts), and bumping
+        // it on change is already the rule.
+        source: "/pattern-sandbox.html",
+        headers: [{ key: "Cache-Control", value: "public, max-age=31536000, immutable" }],
+      },
     ];
   },
 };

--- a/web/src/components/community/PatternCard.tsx
+++ b/web/src/components/community/PatternCard.tsx
@@ -150,23 +150,38 @@ export default function PatternCard({
     return () => el.removeEventListener("wheel", onWheel);
   }, [interactive]);
 
-  // The live sandbox iframe mounts only once the card has been near the
-  // viewport, and stays mounted after. An infinite feed accumulates hundreds
-  // of cards; pre-warming every one of them would be hundreds of iframes.
-  const [nearViewport, setNearViewport] = useState(false);
+  // The live sandbox iframe exists only while the card is anywhere near the
+  // viewport. An infinite feed accumulates hundreds of cards, and an iframe
+  // is a whole document with a canvas — warming all of them would be
+  // hundreds of live frames. Two thresholds with a wide gap between them:
+  // approach within 300px and the iframe boots (cheap — the sandbox document
+  // is immutable-cached); fall more than ~2 screens behind and it is torn
+  // down. The gap is hysteresis, so a card at the boundary does not flap
+  // while you scroll past it.
+  const [warm, setWarm] = useState(false);
   useEffect(() => {
-    if (!interactive || nearViewport) return;
+    if (!interactive) return;
     const el = thumbRef.current;
     if (!el) return;
-    const observer = new IntersectionObserver(
+    const warmObserver = new IntersectionObserver(
       (entries) => {
-        if (entries.some((entry) => entry.isIntersecting)) setNearViewport(true);
+        if (entries.some((entry) => entry.isIntersecting)) setWarm(true);
       },
       { rootMargin: "300px 0px" },
     );
-    observer.observe(el);
-    return () => observer.disconnect();
-  }, [interactive, nearViewport]);
+    const coolObserver = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((entry) => !entry.isIntersecting)) setWarm(false);
+      },
+      { rootMargin: "2400px 0px" },
+    );
+    warmObserver.observe(el);
+    coolObserver.observe(el);
+    return () => {
+      warmObserver.disconnect();
+      coolObserver.disconnect();
+    };
+  }, [interactive]);
 
   // Initial static thumbnail
   useEffect(() => {
@@ -278,9 +293,9 @@ export default function PatternCard({
             <div className={styles.cardThumbNote}>{failed ? "render error" : "rendering…"}</div>
           )}
 
-          {/* Live sandbox, pre-warmed once the card nears the viewport so the
-              first hover still plays instantly. */}
-          {interactive && nearViewport && (
+          {/* Live sandbox, pre-warmed while the card is near the viewport so
+              a hover plays instantly. */}
+          {interactive && warm && (
             <SandboxPreview
               code={item.code}
               knobValues={knobValues}

--- a/web/src/lib/community/sandboxUrl.ts
+++ b/web/src/lib/community/sandboxUrl.ts
@@ -2,4 +2,9 @@
 // static /pattern-sandbox.html — bump it whenever that file changes, or stale
 // browser caches will keep running the old runtime (and silently ignore new
 // protocol features like the @ramp annotation).
+//
+// Bumping is not optional: next.config serves this file with a year-long
+// immutable Cache-Control (every feed card boots an iframe from it, and
+// without the cache each boot is a round trip to the Pi). An edit without a
+// bump ships to nobody who has ever visited.
 export const PATTERN_SANDBOX_URL = "/pattern-sandbox.html?v=4";


### PR DESCRIPTION
One performance fix with two halves, for the symptom reported on the live host: cards warming up visibly front-to-back, and dead hovers after a fast scroll.

**Diagnosis.** Every card boots its live preview iframe from `/pattern-sandbox.html`, which was served `max-age=0` and passed through Cloudflare as `DYNAMIC` — thirty visible cards meant thirty round trips to the Pi (~280ms each measured from outside). Local never showed it because the same fetch is a millisecond there.

**Fixes.**
- The sandbox document is now served `public, max-age=31536000, immutable`. Safe: its URL already carries `?v=` and bumping on change is the standing rule — now marked non-optional at the constant, since an edit without a bump ships to nobody cached. One download per browser ever; every iframe after that boots from disk cache.
- Card iframes are windowed instead of accumulated: boot within 300px of the viewport, tear down beyond ~2400px, the wide gap as anti-flap hysteresis. A 62-card scroll now holds ~12 live frames instead of 62.

**Verified:** header served, live-frame count bounded across a full-feed scroll and back (12 → 14 → 12 over 62 cards), hover unaffected, zero console/server errors. Optional extra (dashboard, not code): a Cloudflare cache rule for the path would make even the first-ever visit edge-served.

🤖 Generated with [Claude Code](https://claude.com/claude-code)