### PR TITLE
feat(wifi): cap max TX power at 13 dBm

### DIFF
--- a/firmware/patternflow/net_config.h
+++ b/firmware/patternflow/net_config.h
@@ -32,14 +32,25 @@
 #ifndef PF_WIFI_PASS
 #define PF_WIFI_PASS "YOUR_WIFI_PASSWORD"
 #endif
-// ⚠️ If an RF conformance test fails on output power / EIRP:
-// nothing here sets the transmit power, so the radio runs at the ESP32
-// default of 19.5 dBm — the maximum. With the WROOM-1 antenna's gain that
-// can sit at or over the EU 20 dBm EIRP limit. The knob is
-// WiFi.setTxPower(WIFI_POWER_17dBm) in core_wifi.h after the join; ~17 dBm
-// buys margin for roughly a quarter of the range. Take the number from the
-// test report, not from a guess. (This is the RADIO test — for EMC, see the
-// note in core_display.h; Wi-Fi power is almost irrelevant there.)
+// Maximum Wi-Fi transmit power, applied in core_wifi.h right after the join.
+// The ESP32 default is WIFI_POWER_19_5dBm — the maximum — which with the
+// WROOM-1 antenna's gain can sit at or over the EU 20 dBm EIRP limit, so a
+// conformance failure on output power / EIRP is fixed here.
+//
+// ⚠️ Take the number from the test report, not from a guess. 13 dBm is a
+// 6.5 dB cut from the default: uplink power drops ~4.5x and indoor range to
+// very roughly 60%. Only the device→router direction is affected, so the
+// RSSI reported by /status will NOT move — that is the downlink. If range
+// regresses, WIFI_POWER_17dBm is the smaller first step.
+//
+// Valid values (WiFiGeneric.h): WIFI_POWER_19_5dBm, _19dBm, _18_5dBm,
+// _17dBm, _15dBm, _13dBm, _11dBm, _8_5dBm, _7dBm, _5dBm, _2dBm.
+//
+// (This is the RADIO test — for EMC, see the note in core_display.h; Wi-Fi
+// power is almost irrelevant there.)
+#ifndef PF_WIFI_TX_POWER
+#define PF_WIFI_TX_POWER WIFI_POWER_13dBm
+#endif
 
 // Wi-Fi is non-blocking (see core_wifi.h): boot never waits for the join.
 // While disconnected, core_wifi.h re-issues WiFi.begin() at this interval

--- a/firmware/patternflow/src/core_wifi.h
+++ b/firmware/patternflow/src/core_wifi.h
@@ -202,6 +202,20 @@ inline void begin() {
   WiFi.setAutoReconnect(true);  // let the IDF re-join on transient drops
   WiFi.begin(activeSsid.c_str(), activePass.c_str());
   lastBeginMs = millis();
+
+  // Cap transmit power (PF_WIFI_TX_POWER in net_config.h). Must come after
+  // begin() — setTxPower() refuses while neither STA nor AP is started. The
+  // cap lives in the driver, so the retry path's disconnect()/begin() cycle
+  // keeps it; only a full driver stop would clear it. Logged as a readback
+  // rather than the requested value because the IDF clamps to what the radio
+  // can actually do, and an RF test wants the achieved number.
+  if (WiFi.setTxPower(PF_WIFI_TX_POWER)) {
+    Serial.printf("[WiFi] max TX power set — radio reports %.1f dBm\n",
+                  WiFi.getTxPower() / 4.0f);
+  } else {
+    Serial.println("[WiFi] WARNING: TX power cap rejected; radio is at default");
+  }
+
   Serial.printf("[WiFi] connecting to \"%s\" (%s creds, non-blocking)...\n",
                 activeSsid.c_str(), credsFromNvs ? "provisioned" : "built-in");
 }


### PR DESCRIPTION
Nothing set the Wi-Fi transmit power, so the radio ran at the ESP32 default of **19.5 dBm** — the maximum. With the WROOM-1 antenna's gain that can sit at or over the EU 20 dBm EIRP limit, leaving no headroom for an RF conformance pass.

The cap is now `PF_WIFI_TX_POWER` in `net_config.h`, applied in `core_wifi.h` right after the join.

## Why after `WiFi.begin()`

`setTxPower()` returns false and only logs a warning when neither STA nor AP has started — an earlier call is silently ignored. The failure branch is logged rather than dropped, and the **readback** is logged instead of the requested value, because the IDF clamps to what the radio can actually do and an RF test wants the achieved number.

No re-apply on reconnect: the cap lives in the driver and survives the retry path's `disconnect()`/`begin()` cycle.

## Measured on hardware

**A fully assembled unit** — enclosure closed, LED panel mounted — so enclosure and panel attenuation are included in these numbers. Studio apartment, device 5 m away behind a closed wooden door; that spot costs **17 dB** of path loss versus the desk. 180 s OSC heartbeat capture + 150 ICMP per condition.

| setting | RSSI | OSC heartbeat loss | ping loss | ping max RTT |
|---|---|---|---|---|
| **13 dBm** | −54 | 1/180 (0.56%) | 0/150 | **7 ms** |
| 2 dBm | −47 | 1/180 (0.56%) | 0/150 | **21 ms** |

Packet loss is **identical** — it is background collision noise, not transmit power. The discriminator is tail latency: 11 dB below the new cap the link still loses nothing, it just retries at the MAC layer. 13 dBm therefore has ample margin, and the 13 dBm row was measured at a 4–7 dB *worse* RSSI, so the real gap is wider than the table shows.

Serial confirms the cap takes exactly, with no clamping:

```
[WiFi] max TX power set — radio reports 13.0 dBm
[WiFi] connecting to "..." (provisioned creds, non-blocking)...
[WiFi] connected — IP 192.168.0.180
```

## Not covered

- **The 13 dBm value itself is a conservative pick, not a conformance result.** `net_config.h` documents `WIFI_POWER_17dBm` as the smaller first step if range regresses, and the knob is overridable per device from `patternflow_secrets.h`.
- **Uplink was not measured directly.** The router's client-RSSI view is the only direct evidence; the RSSI the device reports is downlink and does not respond to this change. That trap is called out in the code comment.
- **Throughput was not measured** — only small-packet loss and latency. Bulk transfers (OTA, pattern upload) were not timed.

> **Corrections to the commit message.** `4ece4cc` describes the measurements as bench-only and attributes the untested risk to "the LED panel's metal frame". Both are wrong: the measurements above were taken on a fully assembled unit, and the panel has no metal frame. The commit message could not be amended after merge; this body is the corrected record. No code comment was affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)