### PR TITLE
Stop the signed-in header scrolling a phone sideways

### DIFF
--- a/web/src/app/community/layout.tsx
+++ b/web/src/app/community/layout.tsx
@@ -89,7 +89,7 @@ export default async function CommunityLayout({ children }: { children: React.Re
                 className={styles.makeCta}
                 title="Open Pattern Lab — make a pattern and publish it here"
               >
-                Make &amp; publish — Pattern Lab ↗
+                Make<span className={styles.ctaRest}> &amp; publish — Pattern Lab</span> ↗
               </Link>
             ) : (
               <Link href="/pattern-lab" title="Open Pattern Lab editor">

--- a/web/src/app/community/u/[username]/page.tsx
+++ b/web/src/app/community/u/[username]/page.tsx
@@ -8,6 +8,7 @@ import { getUserByUsername, listDecksByUser, listPatternsByUser } from "@/lib/co
 import { toCardItem, toDeckCardItem } from "@/lib/community/serialize";
 import DeckCard from "@/components/community/DeckCard";
 import PatternCard from "@/components/community/PatternCard";
+import SignOutLink from "@/components/community/SignOutLink";
 import { PUBLIC_DECKS_MAX } from "@/lib/community/deck";
 import styles from "@/components/community/Community.module.css";
 
@@ -75,9 +76,13 @@ export default async function CommunityUserPage(props: RouteParams) {
         </div>
         <span className={styles.headerSpacer} />
         {isSelf && (
-          <Link href="/pattern-lab" className={styles.btnAccent}>
-            Make &amp; publish ↗
-          </Link>
+          <div className={styles.profileSelfActions}>
+            <Link href="/pattern-lab" className={styles.btnAccent}>
+              Make &amp; publish ↗
+            </Link>
+            {/* Phone only — the header carries it everywhere else. */}
+            <SignOutLink className={styles.profileSignOut} />
+          </div>
         )}
       </header>
 

--- a/web/src/components/community/AuthStatus.tsx
+++ b/web/src/components/community/AuthStatus.tsx
@@ -5,6 +5,7 @@ import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { authClient } from "@/lib/community/auth-client";
 import AuthModal from "./AuthModal";
+import SignOutLink from "./SignOutLink";
 import styles from "./Community.module.css";
 
 // Header widget: signed-out → "Sign in" button; signed-in → username link
@@ -30,18 +31,9 @@ export default function AuthStatus() {
           <Link href={`/community/u/${username ?? ""}`} className={styles.userChip}>
             @{displayName}
           </Link>
-          {/* Signing out is necessary and almost never wanted, so it recedes to
-              a faint mono link beside the handle rather than taking a button's
-              weight next to the one CTA the header is built around. */}
-          <button
-            type="button"
-            className={styles.signOutLink}
-            onClick={() => {
-              void authClient.signOut().then(() => router.refresh());
-            }}
-          >
-            sign out
-          </button>
+          {/* Hidden on a phone, where it lives on your own profile instead —
+              see SignOutLink. */}
+          <SignOutLink />
         </div>
       ) : (
         <button type="button" className={styles.btn} onClick={() => setAuthOpen(true)}>

--- a/web/src/components/community/Community.module.css
+++ b/web/src/components/community/Community.module.css
@@ -3052,6 +3052,20 @@
   color: var(--pfc-ink-muted);
 }
 
+/* Your own profile's right-hand side: the CTA, and on a phone the sign-out
+   that the header cannot fit. */
+.profileSelfActions {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 10px;
+}
+
+/* Off by default — the header's copy is the one you see on a desktop. */
+.profileSignOut {
+  display: none;
+}
+
 /* A profile is an archive, so it wraps and scrolls — unlike the wall's
    zoomable grid. */
 .profileGrid {
@@ -4654,10 +4668,50 @@
     display: none;
   }
 
-  .makeCta {
+  /* Signed in this row carries five things — CTA, deck chip, Alerts, handle,
+     sign out — and it used to be an unwrappable 461px against a 343px content
+     box, which scrolled the whole page sideways on a phone. Wrapping is the
+     structural fix: no combination of labels can push the page wider than the
+     screen again. The measures below are what keep it to one line anyway. */
+  .headerNav {
+    flex-wrap: wrap;
+    justify-content: flex-end;
+    gap: 6px 12px;
+    min-width: 0;
+    /* Right-aligned as a group. This used to be `margin-left: auto` on the CTA
+       itself, which was fine while the row could not wrap and disastrous once
+       it could: an auto margin swallows the line's free space, so the CTA sat
+       alone on row one and pushed everything else onto row two. */
     margin-left: auto;
+  }
+
+  .makeCta {
     font-size: 12px;
     padding: 8px 12px;
+  }
+
+  /* "Make ↗". The full sentence is a desktop measure — on a phone it alone was
+     212px, over half the screen. The title attribute still says the rest. */
+  .ctaRest {
+    display: none;
+  }
+
+  /* A handle can be any length; a header row cannot. */
+  .userChip {
+    max-width: 96px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  /* The fifth item is what tipped the row onto a second line, and it is the
+     one the "You" tab already leads to. It moves to your own profile. */
+  .headerNav .signOutLink {
+    display: none;
+  }
+
+  .profileSignOut {
+    display: inline-block;
   }
 
   .pageBody {

--- a/web/src/components/community/SignOutLink.tsx
+++ b/web/src/components/community/SignOutLink.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { authClient } from "@/lib/community/auth-client";
+import styles from "./Community.module.css";
+
+// Signing out is necessary and almost never wanted, so it stays a faint mono
+// link rather than taking a button's weight.
+//
+// It renders in two places and is visible in exactly one of them at a time:
+// beside the handle in the header on a desktop, and on your own profile on a
+// phone — where the header has no room for it and the "You" tab is where
+// people look for account things anyway. The media query in the stylesheet
+// picks; both call the same endpoint.
+
+export default function SignOutLink({ className }: { className?: string }) {
+  const router = useRouter();
+
+  return (
+    <button
+      type="button"
+      className={className ? `${styles.signOutLink} ${className}` : styles.signOutLink}
+      onClick={() => {
+        void authClient.signOut().then(() => router.refresh());
+      }}
+    >
+      sign out
+    </button>
+  );
+}


### PR DESCRIPTION
Signing in on a phone dragged the whole page ~100px to the right and every screen under it came out crooked.

## Why

Signing in swaps a 60px `Pattern Lab ↗` link for a 212px `Make & publish — Pattern Lab ↗` button, and adds Alerts, the handle and sign out beside it. `.headerNav` could not wrap, so it measured **461px against a 343px content box**. Signed out it fit — which is why it only appeared after logging in.

Measured on the running server at 375px:

| | page scrollWidth | viewport |
|---|---|---|
| signed out | 375 | 375 |
| signed in, before | **478** | 375 |
| signed in, after | 375 | 375 |

## Fix

1. **The row wraps.** The structural guarantee — no combination of labels can push the page wider than the screen again. At 320px with a 23-character handle it degrades to two rows instead of overflowing.
2. **The CTA drops its middle clause on a phone** — `Make ↗`, with the full sentence still in the `title`. One button was taking over half the width.
3. **Sign out moves to your own profile on a phone**, which is where the "You" tab already leads and where people look for account things. The header keeps it on every other size; a media query picks, so exactly one is ever visible. Without this the row was 370px and still wrapped to two lines, giving a 126px header on an 812px screen.
4. The handle truncates at 96px so a long one cannot re-open the same hole.

Also swept every community route at 375px for horizontal overflow: home, patterns, decks, workshop, workshop map — all clean.

## Checks

`tsc --noEmit` clean · lint clean (15 pre-existing warnings, 0 errors) · production build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)