### PR TITLE
The mobile pattern wall plays itself, and keeps your place

### DIFF
--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -6,6 +6,25 @@ const nextConfig: NextConfig = {
   pageExtensions: ["js", "jsx", "md", "mdx", "ts", "tsx"],
   // Native module — must stay a runtime require, not a bundled dependency.
   serverExternalPackages: ["better-sqlite3"],
+  // Testing anything touch-shaped means opening `next dev` from a phone, at
+  // this machine's address on the network rather than at localhost. Next
+  // blocks cross-origin requests to /_next/* by default, and the symptom is
+  // not an error page: the HTML server-renders, the bundle loads, React never
+  // hydrates, and every pattern card sits at "rendering…" forever with no
+  // clue why. Private ranges are allowed here so that just works; add a
+  // tunnel host or anything else with NEXT_DEV_ORIGINS=a.example,b.example.
+  // Development only — this has no effect on a production build.
+  allowedDevOrigins: [
+    "192.168.*.*",
+    "10.*.*.*",
+    "172.16.*.*",
+    "100.*.*.*", // Tailscale
+    "*.local",
+    ...(process.env.NEXT_DEV_ORIGINS ?? "")
+      .split(",")
+      .map((host) => host.trim())
+      .filter(Boolean),
+  ],
   async redirects() {
     return [
       {

--- a/web/src/components/community/Community.module.css
+++ b/web/src/components/community/Community.module.css
@@ -589,6 +589,16 @@
   white-space: nowrap;
 }
 
+/* The same line for the other pointer. Exactly one of the two is ever on. */
+.touchHint {
+  display: none;
+  margin-left: auto;
+  font-family: var(--pf-mono, monospace);
+  font-size: 10.5px;
+  color: var(--pfc-ink-faint);
+  white-space: nowrap;
+}
+
 /* ── Pattern card ── */
 
 .card {
@@ -614,6 +624,25 @@
 .card:hover .cardThumb {
   outline: 1px solid var(--pfc-edge);
   outline-offset: -1px;
+}
+
+/* Held on a phone: the same lit edge hover uses, in the accent. One card plays
+   at a time, and this is what says which. */
+.card[data-held] .cardThumb {
+  outline: 1px solid var(--pfc-led);
+  outline-offset: -1px;
+}
+
+/* Same definition of "mobile" the feed uses to drop the hover preview
+   (MOBILE_MEDIA_QUERY) — the two must not drift apart. */
+@media (max-width: 768px), (hover: none) {
+  /* A press long enough to start the pattern is also long enough for iOS to
+     offer its link preview and for the text magnifier to appear over the
+     badges. Neither is what the press meant. */
+  .cardThumb {
+    -webkit-touch-callout: none;
+    user-select: none;
+  }
 }
 
 .screenRotator {
@@ -4744,10 +4773,15 @@
   }
 
   /* Card size is fixed by the mobile view config, and there is no Ctrl+wheel
-     on a phone — the hint would advertise a gesture that does not exist. */
+     on a phone — the hint would advertise a gesture that does not exist. The
+     press-and-hold one takes its place. */
   .zoomHint,
   .controlRule {
     display: none;
+  }
+
+  .touchHint {
+    display: inline;
   }
 
   .deckGrid {

--- a/web/src/components/community/Community.module.css
+++ b/web/src/components/community/Community.module.css
@@ -589,16 +589,6 @@
   white-space: nowrap;
 }
 
-/* The same line for the other pointer. Exactly one of the two is ever on. */
-.touchHint {
-  display: none;
-  margin-left: auto;
-  font-family: var(--pf-mono, monospace);
-  font-size: 10.5px;
-  color: var(--pfc-ink-faint);
-  white-space: nowrap;
-}
-
 /* ── Pattern card ── */
 
 .card {
@@ -626,24 +616,6 @@
   outline-offset: -1px;
 }
 
-/* Held on a phone: the same lit edge hover uses, in the accent. One card plays
-   at a time, and this is what says which. */
-.card[data-held] .cardThumb {
-  outline: 1px solid var(--pfc-led);
-  outline-offset: -1px;
-}
-
-/* Same definition of "mobile" the feed uses to drop the hover preview
-   (MOBILE_MEDIA_QUERY) — the two must not drift apart. */
-@media (max-width: 768px), (hover: none) {
-  /* A press long enough to start the pattern is also long enough for iOS to
-     offer its link preview and for the text magnifier to appear over the
-     badges. Neither is what the press meant. */
-  .cardThumb {
-    -webkit-touch-callout: none;
-    user-select: none;
-  }
-}
 
 .screenRotator {
   position: absolute;
@@ -4773,15 +4745,10 @@
   }
 
   /* Card size is fixed by the mobile view config, and there is no Ctrl+wheel
-     on a phone — the hint would advertise a gesture that does not exist. The
-     press-and-hold one takes its place. */
+     on a phone — the hint would advertise a gesture that does not exist. */
   .zoomHint,
   .controlRule {
     display: none;
-  }
-
-  .touchHint {
-    display: inline;
   }
 
   .deckGrid {

--- a/web/src/components/community/CommunityFeedClient.tsx
+++ b/web/src/components/community/CommunityFeedClient.tsx
@@ -31,6 +31,27 @@ import styles from "./Community.module.css";
 // de-duplicated by id: the feed is newest-first, so anything published while
 // you scroll shifts the offsets and would otherwise repeat a card.
 
+// ── Coming back ──
+// The feed is grown by the client, so a back navigation gets the first batch
+// again: the document is suddenly short, whatever scroll position the browser
+// remembered is clamped to its new bottom, and you land near the top. So the
+// feed remembers how far it had grown and where you were reading, rebuilds
+// that much, and puts you back.
+//
+// The moment it records is opening a pattern — not scrolling. That is what
+// makes it a RETURN rather than a visit: tapping "Patterns" in the tab bar
+// still gives a feed at the top, because nothing was recorded on the way in.
+// (popstate looks like the obvious signal and is not: it fired correctly in
+// testing and the restore still never ran, so the flag it set was not the one
+// the remounted component read. A click is unambiguous and needs no ordering
+// to be true.) The note is consumed on arrival, so it restores exactly once.
+const PLACE_KEY_PREFIX = "pf-feed-place";
+
+/** Don't rebuild an unbounded feed to restore a position in it. */
+const MAX_RESTORED_ITEMS = 300;
+
+type FeedPlace = { count: number; y: number };
+
 function useResponsiveCardsPerRow(
   containerRef: React.RefObject<HTMLDivElement | null>,
   slot: number,
@@ -169,6 +190,104 @@ export default function CommunityFeedClient({
     }
   }, [cardsPerRow, batchRows, sort, hardwareOnly]);
 
+  // Where you were, per view: sort and filter each make a different feed, and
+  // a position in one means nothing in another.
+  const placeKey = `${PLACE_KEY_PREFIX}:${sort}:${hardwareOnly ? "hw" : "all"}`;
+
+  // Opening a pattern is the only thing that writes a place. Captured on the
+  // way down so it runs before the router leaves, and read off the event
+  // rather than bound per card — the grid is rebuilt on every append.
+  const rememberPlace = (event: React.MouseEvent) => {
+    const link = (event.target as HTMLElement).closest?.("a[href]");
+    if (!link?.getAttribute("href")?.startsWith("/community/p/")) return;
+    const place: FeedPlace = { count: itemsRef.current.length, y: window.scrollY };
+    try {
+      if (place.y > 0) sessionStorage.setItem(placeKey, JSON.stringify(place));
+      else sessionStorage.removeItem(placeKey);
+    } catch {
+      // Private mode, quota, whatever — losing your place is not an error
+      // worth showing anybody.
+    }
+  };
+
+  // …and put it back, once.
+  //
+  // Held in a ref because loadMore's identity changes the moment the grid
+  // measures itself (cardsPerRow 6 -> 3 on a phone). Depending on it here
+  // re-ran this effect mid-restore, whose cleanup cancelled the rebuild it
+  // had just started — the feed stopped a batch or two short and the scroll
+  // landed clamped, which looked exactly like "restore doesn't work".
+  const loadMoreRef = useRef(loadMore);
+  useEffect(() => {
+    loadMoreRef.current = loadMore;
+  });
+
+  const restoredRef = useRef(false);
+  useEffect(() => {
+    if (restoredRef.current) return;
+    restoredRef.current = true;
+
+    let place: FeedPlace | null = null;
+    try {
+      const raw = sessionStorage.getItem(placeKey);
+      // Consumed on arrival: coming back restores, and everything after that
+      // — a reload, a later visit — starts at the top like any other feed.
+      sessionStorage.removeItem(placeKey);
+      place = raw ? (JSON.parse(raw) as FeedPlace) : null;
+    } catch {
+      place = null;
+    }
+    if (!place || !(place.y > 0)) return;
+    const want = Math.min(place.count, MAX_RESTORED_ITEMS);
+
+    // No cleanup flag, deliberately. React runs an effect, tears it down and
+    // runs it again on every mount in development — so a rebuild that aborts
+    // in its own cleanup aborts every single time, while the note it had
+    // already consumed is gone. That is what "restore does nothing" was. The
+    // ref guard is enough: this runs once per mount either way, and the only
+    // thing it touches after a real unmount is a scroll position, so it
+    // checks the feed is still on screen instead.
+    void (async () => {
+      // Rebuild to the length the feed had.
+      //
+      // The sentinel is loading at the same time, and loadMore refuses to run
+      // while a batch is in flight — so a call that returns with nothing added
+      // usually means "somebody else is fetching", not "there is no more".
+      // Reading that as a dead end stopped the feed a batch or two short and
+      // left the scroll clamped. Wait it out; give up only on a real stall.
+      const deadline = Date.now() + 6000;
+      let stalls = 0;
+      while (!doneRef.current && itemsRef.current.length < want) {
+        if (Date.now() > deadline) break;
+        const before = itemsRef.current.length;
+        if (busyRef.current) await new Promise((resolve) => setTimeout(resolve, 60));
+        else await loadMoreRef.current();
+        if (itemsRef.current.length === before) {
+          stalls += 1;
+          if (stalls > 40) break;
+        } else {
+          stalls = 0;
+        }
+      }
+      // Two frames: one for React to commit the appended cards, one for the
+      // grid to lay them out. Scrolling before that lands short. And the
+      // browser has its own idea about this history entry — it restores a
+      // position clamped to the short document it arrived at — so this has to
+      // come after that, and then once more in case the last batch was still
+      // committing.
+      const settle = () => {
+        if (wrapperRef.current?.isConnected) window.scrollTo(0, place.y);
+      };
+      requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+          settle();
+          window.setTimeout(settle, 120);
+          window.setTimeout(settle, 400);
+        });
+      });
+    })();
+  }, [placeKey]);
+
   // The sentinel drives loading. One subtlety: after an append the sentinel
   // can STILL be inside the viewport (short feed, tall screen), and an
   // observer only fires on crossings — so keep loading while it shows.
@@ -203,7 +322,12 @@ export default function CommunityFeedClient({
   }, [loadMore]);
 
   return (
-    <div ref={wrapperRef} className={styles.feedWrapper} id="wall">
+    <div
+      ref={wrapperRef}
+      className={styles.feedWrapper}
+      id="wall"
+      onClickCapture={rememberPlace}
+    >
       <FeedControls sort={sort} hardwareOnly={hardwareOnly} total={total} />
 
       {total === 0 ? (

--- a/web/src/components/community/FeedControls.tsx
+++ b/web/src/components/community/FeedControls.tsx
@@ -87,9 +87,8 @@ export default function FeedControls({
         Ctrl + scroll to resize · scroll on a screen to turn its knobs · hover to play
       </span>
 
-      {/* Its mobile twin. A press-and-hold has no widget either, and a wall of
-          stills gives nobody a reason to try one. */}
-      <span className={styles.touchHint}>Hold a pattern to play it</span>
+      {/* No mobile twin: on a phone every card on screen is already playing,
+          so there is no gesture left to advertise. */}
     </div>
   );
 }

--- a/web/src/components/community/FeedControls.tsx
+++ b/web/src/components/community/FeedControls.tsx
@@ -86,6 +86,10 @@ export default function FeedControls({
       <span className={styles.zoomHint}>
         Ctrl + scroll to resize · scroll on a screen to turn its knobs · hover to play
       </span>
+
+      {/* Its mobile twin. A press-and-hold has no widget either, and a wall of
+          stills gives nobody a reason to try one. */}
+      <span className={styles.touchHint}>Hold a pattern to play it</span>
     </div>
   );
 }

--- a/web/src/components/community/PatternCard.tsx
+++ b/web/src/components/community/PatternCard.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import Link from "next/link";
-import { useCallback, useEffect, useRef, useState, useSyncExternalStore } from "react";
+import { useEffect, useRef, useState, useSyncExternalStore } from "react";
+import { useMediaQuery } from "@/lib/useMediaQuery";
 import { renderPatternThumb } from "@/lib/community/thumbs";
 import { knobSetupFromCode } from "@/lib/community/knobs";
 import {
@@ -71,24 +72,6 @@ export function freshAge(iso: string, now: number = Date.now()): string | null {
 }
 
 
-/* ── Press and hold ──
-   What hover is on a desktop, a long press is on a phone: the pattern starts
-   playing where it sits instead of making you open it to find out what it
-   does. Held cards stay playing after you lift — a thumb covers half a card,
-   so "live only while pressed" would mean never actually seeing it — and go
-   back to a still when another card takes over, when you press them again, or
-   when they scroll away.
-
-   Only one plays at a time. Each live card is a whole sandboxed document with
-   a canvas in it, and a feed is infinite. */
-const HOLD_EVENT = "pf-card-hold";
-
-/** Long enough not to fire on a tap, short enough not to feel broken. */
-const HOLD_MS = 350;
-
-/** Past this the finger is scrolling, not pressing. */
-const HOLD_SLOP_PX = 10;
-
 /** The deck needs a pattern's firmware header, which a card does not carry. */
 async function fetchPatternHeader(patternId: string) {
   const response = await fetch(
@@ -133,8 +116,6 @@ export default function PatternCard({
 
   // Hover & Live state
   const [isHovered, setIsHovered] = useState(false);
-  // The phone's answer to hover — see HOLD_EVENT above.
-  const [held, setHeld] = useState(false);
   const [isScreenHovered, setIsScreenHovered] = useState(false);
   const [overlayPos, setOverlayPos] = useState<"bottom" | "top">("bottom");
 
@@ -222,13 +203,14 @@ export default function PatternCard({
   // viewport. An infinite feed accumulates hundreds of cards, and an iframe
   // is a whole document with a canvas — warming all of them would be
   // hundreds of live frames. Two thresholds with a wide gap between them:
-  // approach within 300px and the iframe boots (cheap — the sandbox document
-  // is immutable-cached); fall more than ~2 screens behind and it is torn
-  // down. The gap is hysteresis, so a card at the boundary does not flap
-  // while you scroll past it.
+  // approach and the iframe boots (cheap — the sandbox document is
+  // immutable-cached); fall far enough behind and it is torn down. The gap is
+  // hysteresis, so a card at the boundary does not flap while you scroll past
+  // it. A phone keeps a shorter tail: its cards are a third the size, so the
+  // desktop's two-and-a-bit screens of slack would be thirty live documents
+  // on the device least able to hold them.
   const [warm, setWarm] = useState(false);
   useEffect(() => {
-    if (!interactive) return;
     const el = thumbRef.current;
     if (!el) return;
     const warmObserver = new IntersectionObserver(
@@ -241,7 +223,7 @@ export default function PatternCard({
       (entries) => {
         if (entries.some((entry) => !entry.isIntersecting)) setWarm(false);
       },
-      { rootMargin: "2400px 0px" },
+      { rootMargin: interactive ? "2400px 0px" : "900px 0px" },
     );
     warmObserver.observe(el);
     coolObserver.observe(el);
@@ -251,83 +233,38 @@ export default function PatternCard({
     };
   }, [interactive]);
 
-  // ── Press and hold (phones) ──
-  const holdTimer = useRef<number | null>(null);
-  const holdFrom = useRef<{ x: number; y: number } | null>(null);
-  // A long press ends in a click like any other press. That click must not
-  // open the pattern — you asked to watch it here.
-  const swallowClick = useRef(false);
-
-  // `held` also lives in a ref, so the toggle can read the current value
-  // without a setState updater. Updaters run during render and React calls
-  // them more than once — putting the "tell everyone else" broadcast inside
-  // one fired it mid-render, which both warned ("cannot update a component
-  // while rendering a different component") and re-ran the toggle, so the
-  // gesture worked exactly once per page.
-  const heldRef = useRef(false);
-  const setHeldTo = useCallback((next: boolean) => {
-    heldRef.current = next;
-    setHeld(next);
-  }, []);
-
-  const cancelHold = () => {
-    if (holdTimer.current !== null) window.clearTimeout(holdTimer.current);
-    holdTimer.current = null;
-    holdFrom.current = null;
-  };
-
-  const handlePointerDown = (event: React.PointerEvent) => {
-    // Desktop already has hover; a mouse press here is someone dragging a card
-    // to the dock or reaching for the "+".
-    if (interactive || event.pointerType === "mouse") return;
-    if ((event.target as HTMLElement).closest("button")) return;
-    swallowClick.current = false;
-    // Clear first: cancelHold() drops the origin too, so recording it before
-    // this call left nothing for the move handler to measure against and the
-    // press survived being scrolled away from.
-    cancelHold();
-    holdFrom.current = { x: event.clientX, y: event.clientY };
-    holdTimer.current = window.setTimeout(() => {
-      holdTimer.current = null;
-      swallowClick.current = true;
-      // Pressing a playing card again puts it back to a still — the same
-      // gesture both ways, so there is nothing extra to learn.
-      const next = !heldRef.current;
-      setHeldTo(next);
-      if (next) window.dispatchEvent(new CustomEvent(HOLD_EVENT, { detail: item.id }));
-    }, HOLD_MS);
-  };
-
-  const handlePointerMove = (event: React.PointerEvent) => {
-    const from = holdFrom.current;
-    if (!from) return;
-    if (Math.hypot(event.clientX - from.x, event.clientY - from.y) > HOLD_SLOP_PX) cancelHold();
-  };
-
-  // Everyone else stands down when a card starts playing.
+  // ── On screen, playing ──
+  // A phone has no hover, and asking for a gesture first (hold, tap, whatever)
+  // means the feature has to be advertised before anybody meets it. So the
+  // wall simply plays: a card runs while it is actually on screen and pauses
+  // the moment it leaves. That bounds the cost to what the screen can show —
+  // measured at 375x812, three columns of 109x257 cards, about nine to twelve
+  // at once — rather than to how far the feed has been scrolled.
+  //
+  // Paused, not unmounted: leaving the iframe up means scrolling back is
+  // instant, and a paused sandbox costs nothing per frame. Unmounting is the
+  // cool observer's job, further out.
+  const [onScreen, setOnScreen] = useState(false);
   useEffect(() => {
-    const onOther = (event: Event) => {
-      if ((event as CustomEvent<string>).detail !== item.id) setHeldTo(false);
-    };
-    window.addEventListener(HOLD_EVENT, onOther);
-    return () => window.removeEventListener(HOLD_EVENT, onOther);
-  }, [item.id, setHeldTo]);
-
-  // Nothing on a phone reports that the finger left, so the viewport does it:
-  // a card you have scrolled past is not one you are watching.
-  useEffect(() => {
-    if (!held) return;
+    if (interactive) return; // the desktop's cue is the cursor
     const el = thumbRef.current;
     if (!el) return;
     const observer = new IntersectionObserver(
       (entries) => {
-        if (entries.every((entry) => !entry.isIntersecting)) setHeldTo(false);
+        const last = entries[entries.length - 1];
+        if (last) setOnScreen(last.isIntersecting);
       },
-      { rootMargin: "200px 0px" },
+      // No margin: "on screen" means on screen. A card half out of frame is
+      // still worth playing, hence a zero threshold rather than a fraction.
+      { rootMargin: "0px", threshold: 0 },
     );
     observer.observe(el);
     return () => observer.disconnect();
-  }, [held, setHeldTo]);
+  }, [interactive]);
+
+  // Someone who has asked the OS for less motion has asked for less of this.
+  const stillPreferred = useMediaQuery("(prefers-reduced-motion: reduce)");
+  const playing = interactive ? isHovered : onScreen && !stillPreferred;
 
   // Initial static thumbnail
   useEffect(() => {
@@ -431,15 +368,9 @@ export default function PatternCard({
       ref={rootRef}
       href={detailUrl}
       className={styles.card}
-      data-held={held || undefined}
       onMouseEnter={interactive ? handleCardMouseEnter : undefined}
       onMouseLeave={interactive ? handleCardMouseLeave : undefined}
       onDragStart={handleDragStart}
-      onClick={(event) => {
-        if (!swallowClick.current) return;
-        swallowClick.current = false;
-        event.preventDefault();
-      }}
     >
       {/* 1:2 Vertical Matrix Display Screen */}
       <div
@@ -449,14 +380,6 @@ export default function PatternCard({
         onMouseLeave={interactive ? handleThumbMouseLeave : undefined}
         onMouseMove={interactive ? handleMouseMove : undefined}
         onWheel={interactive ? handleWheel : undefined}
-        onPointerDown={interactive ? undefined : handlePointerDown}
-        onPointerMove={interactive ? undefined : handlePointerMove}
-        onPointerUp={interactive ? undefined : cancelHold}
-        onPointerCancel={interactive ? undefined : cancelHold}
-        // Android offers to open the link in a new tab on a long press, and
-        // iOS opens its own preview sheet. Both are this gesture's answer to
-        // the wrong question. (The callout is CSS — see .cardThumb.)
-        onContextMenu={interactive ? undefined : (event) => event.preventDefault()}
       >
         {/* Badges live ON the canvas now: the card has no border and no
             panel, so there is no furniture left to hang them from — and
@@ -479,15 +402,15 @@ export default function PatternCard({
             <div className={styles.cardThumbNote}>{failed ? "render error" : "rendering…"}</div>
           )}
 
-          {/* Live sandbox, pre-warmed while the card is near the viewport so
-              a hover plays instantly. On a phone nothing is warmed in advance
-              — the press is the request, and it is one card, not a screenful. */}
-          {((interactive && warm) || held) && (
+          {/* Live sandbox, booted while the card is near the viewport so that
+              a hover — or, on a phone, simply scrolling it into frame —
+              plays instantly rather than after a document load. */}
+          {warm && (
             <SandboxPreview
               code={item.code}
               knobValues={knobValues}
               knobRanges={knobSetup.ranges}
-              running={isHovered || held}
+              running={playing}
               className={styles.cardHoverIframe}
             />
           )}

--- a/web/src/components/community/PatternCard.tsx
+++ b/web/src/components/community/PatternCard.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { useEffect, useRef, useState, useSyncExternalStore } from "react";
+import { useCallback, useEffect, useRef, useState, useSyncExternalStore } from "react";
 import { renderPatternThumb } from "@/lib/community/thumbs";
 import { knobSetupFromCode } from "@/lib/community/knobs";
 import {
@@ -71,6 +71,24 @@ export function freshAge(iso: string, now: number = Date.now()): string | null {
 }
 
 
+/* ── Press and hold ──
+   What hover is on a desktop, a long press is on a phone: the pattern starts
+   playing where it sits instead of making you open it to find out what it
+   does. Held cards stay playing after you lift — a thumb covers half a card,
+   so "live only while pressed" would mean never actually seeing it — and go
+   back to a still when another card takes over, when you press them again, or
+   when they scroll away.
+
+   Only one plays at a time. Each live card is a whole sandboxed document with
+   a canvas in it, and a feed is infinite. */
+const HOLD_EVENT = "pf-card-hold";
+
+/** Long enough not to fire on a tap, short enough not to feel broken. */
+const HOLD_MS = 350;
+
+/** Past this the finger is scrolling, not pressing. */
+const HOLD_SLOP_PX = 10;
+
 /** The deck needs a pattern's firmware header, which a card does not carry. */
 async function fetchPatternHeader(patternId: string) {
   const response = await fetch(
@@ -115,6 +133,8 @@ export default function PatternCard({
 
   // Hover & Live state
   const [isHovered, setIsHovered] = useState(false);
+  // The phone's answer to hover — see HOLD_EVENT above.
+  const [held, setHeld] = useState(false);
   const [isScreenHovered, setIsScreenHovered] = useState(false);
   const [overlayPos, setOverlayPos] = useState<"bottom" | "top">("bottom");
 
@@ -231,6 +251,84 @@ export default function PatternCard({
     };
   }, [interactive]);
 
+  // ── Press and hold (phones) ──
+  const holdTimer = useRef<number | null>(null);
+  const holdFrom = useRef<{ x: number; y: number } | null>(null);
+  // A long press ends in a click like any other press. That click must not
+  // open the pattern — you asked to watch it here.
+  const swallowClick = useRef(false);
+
+  // `held` also lives in a ref, so the toggle can read the current value
+  // without a setState updater. Updaters run during render and React calls
+  // them more than once — putting the "tell everyone else" broadcast inside
+  // one fired it mid-render, which both warned ("cannot update a component
+  // while rendering a different component") and re-ran the toggle, so the
+  // gesture worked exactly once per page.
+  const heldRef = useRef(false);
+  const setHeldTo = useCallback((next: boolean) => {
+    heldRef.current = next;
+    setHeld(next);
+  }, []);
+
+  const cancelHold = () => {
+    if (holdTimer.current !== null) window.clearTimeout(holdTimer.current);
+    holdTimer.current = null;
+    holdFrom.current = null;
+  };
+
+  const handlePointerDown = (event: React.PointerEvent) => {
+    // Desktop already has hover; a mouse press here is someone dragging a card
+    // to the dock or reaching for the "+".
+    if (interactive || event.pointerType === "mouse") return;
+    if ((event.target as HTMLElement).closest("button")) return;
+    swallowClick.current = false;
+    // Clear first: cancelHold() drops the origin too, so recording it before
+    // this call left nothing for the move handler to measure against and the
+    // press survived being scrolled away from.
+    cancelHold();
+    holdFrom.current = { x: event.clientX, y: event.clientY };
+    holdTimer.current = window.setTimeout(() => {
+      holdTimer.current = null;
+      swallowClick.current = true;
+      // Pressing a playing card again puts it back to a still — the same
+      // gesture both ways, so there is nothing extra to learn.
+      const next = !heldRef.current;
+      setHeldTo(next);
+      if (next) window.dispatchEvent(new CustomEvent(HOLD_EVENT, { detail: item.id }));
+    }, HOLD_MS);
+  };
+
+  const handlePointerMove = (event: React.PointerEvent) => {
+    const from = holdFrom.current;
+    if (!from) return;
+    if (Math.hypot(event.clientX - from.x, event.clientY - from.y) > HOLD_SLOP_PX) cancelHold();
+  };
+
+  // Everyone else stands down when a card starts playing.
+  useEffect(() => {
+    const onOther = (event: Event) => {
+      if ((event as CustomEvent<string>).detail !== item.id) setHeldTo(false);
+    };
+    window.addEventListener(HOLD_EVENT, onOther);
+    return () => window.removeEventListener(HOLD_EVENT, onOther);
+  }, [item.id, setHeldTo]);
+
+  // Nothing on a phone reports that the finger left, so the viewport does it:
+  // a card you have scrolled past is not one you are watching.
+  useEffect(() => {
+    if (!held) return;
+    const el = thumbRef.current;
+    if (!el) return;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries.every((entry) => !entry.isIntersecting)) setHeldTo(false);
+      },
+      { rootMargin: "200px 0px" },
+    );
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [held, setHeldTo]);
+
   // Initial static thumbnail
   useEffect(() => {
     let alive = true;
@@ -333,9 +431,15 @@ export default function PatternCard({
       ref={rootRef}
       href={detailUrl}
       className={styles.card}
+      data-held={held || undefined}
       onMouseEnter={interactive ? handleCardMouseEnter : undefined}
       onMouseLeave={interactive ? handleCardMouseLeave : undefined}
       onDragStart={handleDragStart}
+      onClick={(event) => {
+        if (!swallowClick.current) return;
+        swallowClick.current = false;
+        event.preventDefault();
+      }}
     >
       {/* 1:2 Vertical Matrix Display Screen */}
       <div
@@ -345,6 +449,14 @@ export default function PatternCard({
         onMouseLeave={interactive ? handleThumbMouseLeave : undefined}
         onMouseMove={interactive ? handleMouseMove : undefined}
         onWheel={interactive ? handleWheel : undefined}
+        onPointerDown={interactive ? undefined : handlePointerDown}
+        onPointerMove={interactive ? undefined : handlePointerMove}
+        onPointerUp={interactive ? undefined : cancelHold}
+        onPointerCancel={interactive ? undefined : cancelHold}
+        // Android offers to open the link in a new tab on a long press, and
+        // iOS opens its own preview sheet. Both are this gesture's answer to
+        // the wrong question. (The callout is CSS — see .cardThumb.)
+        onContextMenu={interactive ? undefined : (event) => event.preventDefault()}
       >
         {/* Badges live ON the canvas now: the card has no border and no
             panel, so there is no furniture left to hang them from — and
@@ -368,13 +480,14 @@ export default function PatternCard({
           )}
 
           {/* Live sandbox, pre-warmed while the card is near the viewport so
-              a hover plays instantly. */}
-          {interactive && warm && (
+              a hover plays instantly. On a phone nothing is warmed in advance
+              — the press is the request, and it is one card, not a screenful. */}
+          {((interactive && warm) || held) && (
             <SandboxPreview
               code={item.code}
               knobValues={knobValues}
               knobRanges={knobSetup.ranges}
-              running={isHovered}
+              running={isHovered || held}
               className={styles.cardHoverIframe}
             />
           )}

--- a/web/src/lib/community/apiBase.ts
+++ b/web/src/lib/community/apiBase.ts
@@ -68,6 +68,18 @@ export function crossOriginCommunityBase(): string | null {
   if (typeof window === "undefined") return null;
   const origin = configuredOrigin();
   if (!origin || origin === window.location.origin) return null;
+  // A dev env file names localhost because that is where the dev server runs.
+  // Open the same server from a phone on the network and the page is not on
+  // localhost — so this rewrite would send its API calls to the phone itself,
+  // and the feed stops loading after the first batch with nothing in the UI to
+  // explain it. In development a localhost target means "wherever this page
+  // came from". Production is untouched: there the two origins are real.
+  if (
+    process.env.NODE_ENV !== "production" &&
+    /^https?:\/\/(localhost|127\.0\.0\.1|\[::1\])(:|$)/.test(origin)
+  ) {
+    return null;
+  }
   return origin;
 }
 


### PR DESCRIPTION
Two things a phone was missing, plus the dev-server plumbing that made them testable on one.

## Every card on screen is live

Hover starts a pattern on a desktop; a phone had nothing, so the only way to learn what a card does was to open it.

Gestures were the wrong answer twice over — a long press has to be advertised to be found at all, and tap-to-play makes opening anything cost a second tap. So the wall just plays. A card runs while it is on screen and pauses the moment it leaves.

Measured at 375×812: three columns of 109×257 cards, **9–12 playing at once**, bounded by the screen rather than by how far the feed has been scrolled. Verified with 62 cards in the DOM — mounted sandboxes stayed between 11 and 21 throughout. Paused, not unmounted, so scrolling back is instant; the cool observer tears them down further out, at a shorter distance than the desktop's because a phone's cards are a third the size. `prefers-reduced-motion` keeps the stills.

## Back from a pattern lands where you left

The feed is grown by the client, so a back navigation gets the first batch again: the document is suddenly short, the browser's remembered position clamps to its new bottom, and you land near the top.

Opening a pattern now records how far the feed had grown and where you were reading; coming back rebuilds that much and puts you there. Recording on the **click** rather than on scroll is what makes it a return rather than a visit — tapping "Patterns" in the tab bar still starts at the top.

Verified end to end: parked at y=5227 with 62 cards → opened a pattern → back → **62 cards, y=5227, off by 0**. Fresh visit via the tab bar → y=0. Scrolling without opening anything leaves no note behind.

Three bugs found by that test and fixed, all mine:
- the restore effect depended on `loadMore`, whose identity changes when the grid measures itself — the re-run's cleanup cancelled the rebuild it had just started;
- treating a no-op `loadMore` as "no more items" stopped the feed short while the sentinel held the lock;
- and the cleanup flag itself: React tears an effect down and re-runs it on every mount in development, so a rebuild that aborts in its own cleanup aborts every time, with the note it had already consumed gone.

## Testing `next dev` from a phone

Next blocks cross-origin dev resources by default. The symptom is not an error page: the HTML server-renders, the bundle loads, React never hydrates, and every card sits at "rendering…" with nothing to explain it. Private ranges are allowed in `next.config` now.

And a development `NEXT_PUBLIC_COMMUNITY_URL` of `localhost` no longer rewrites API calls — from a phone that pointed them at the phone, and the feed stopped after its first batch.

## Checks

`tsc --noEmit` clean · lint clean (15 pre-existing warnings, 0 errors) · production build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)