### PR TITLE
Auto-grow the thread and comment writing boxes

### DIFF
--- a/web/src/components/community/CommentSection.tsx
+++ b/web/src/components/community/CommentSection.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import { useRef, useState } from "react";
+import { useAutoGrow } from "@/lib/useAutoGrow";
 import { useRouter } from "next/navigation";
 import { authClient } from "@/lib/community/auth-client";
 import { COMMUNITY_FETCH_INIT, communityApiUrl } from "@/lib/community/apiBase";
@@ -72,6 +73,11 @@ export default function CommentSection({
   // Deleting is one click away but takes two, because there is no undo and the
   // button sits right beside "edit".
   const [confirmDelete, setConfirmDelete] = useState<string | null>(null);
+
+  // One ref, not one per row: `editingId` is a single value, so exactly one of
+  // these textareas exists at a time.
+  const draftRef = useAutoGrow<HTMLTextAreaElement>(editingId ? draft : "");
+  const bodyRef = useAutoGrow<HTMLTextAreaElement>(body);
 
   const viewerId = session?.user.id ?? null;
   const on = target.kind === "post" ? "post" : "pattern";
@@ -245,6 +251,7 @@ export default function CommentSection({
             {editing ? (
               <div className={styles.commentForm}>
                 <textarea
+                  ref={draftRef}
                   value={draft}
                   maxLength={COMMENT_MAX}
                   autoFocus
@@ -290,6 +297,7 @@ export default function CommentSection({
       {session ? (
         <div className={styles.commentForm}>
           <textarea
+            ref={bodyRef}
             value={body}
             maxLength={COMMENT_MAX}
             placeholder={

--- a/web/src/components/community/Community.module.css
+++ b/web/src/components/community/Community.module.css
@@ -2246,6 +2246,9 @@
 .commentForm textarea {
   min-height: 84px;
   resize: vertical;
+  /* Grown by useAutoGrow; this is the ceiling. Replies sit in a list of other
+     people's replies, so one long one should not push the thread off screen. */
+  max-height: 60vh;
 }
 
 /* Sit in the head row beside the date, muted: available to the person who
@@ -3295,6 +3298,19 @@
   line-height: 1.6;
   min-height: 180px;
   resize: vertical;
+}
+
+/* useAutoGrow sets an inline height from scrollHeight; these caps are what
+   stops it. It reports the full content height regardless, so max-height wins
+   and the textarea starts scrolling — which is the right ceiling in each case:
+   an editor that owns the page can take most of the viewport, one inside a
+   modal has to leave room for the buttons under it. */
+.postBodyInput[data-grow="page"] {
+  max-height: 75vh;
+}
+
+.postBodyInput[data-grow="modal"] {
+  max-height: 42vh;
 }
 
 .postTitleInput:focus,

--- a/web/src/components/community/NewThreadModal.tsx
+++ b/web/src/components/community/NewThreadModal.tsx
@@ -3,6 +3,7 @@
 import { useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { COMMUNITY_FETCH_INIT, communityApiUrl } from "@/lib/community/apiBase";
+import { useAutoGrow } from "@/lib/useAutoGrow";
 import { deckItems, savedItems } from "@/lib/community/deck";
 import { communityPatternUrl } from "@/lib/community/license";
 import {
@@ -43,6 +44,8 @@ export default function NewThreadModal({
   const [pin, setPin] = useState(true);
   const [files, setFiles] = useState<File[]>([]);
   const [picking, setPicking] = useState(false);
+
+  const bodyRef = useAutoGrow<HTMLTextAreaElement>(body);
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
 
@@ -152,7 +155,9 @@ export default function NewThreadModal({
             onChange={(event) => setTitle(event.target.value)}
           />
           <textarea
+            ref={bodyRef}
             className={styles.postBodyInput}
+            data-grow="modal"
             value={body}
             maxLength={POST_BODY_MAX}
             placeholder="What are you making, what happened, what do you need?"

--- a/web/src/components/community/PostDetailClient.tsx
+++ b/web/src/components/community/PostDetailClient.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { COMMUNITY_FETCH_INIT, communityApiUrl } from "@/lib/community/apiBase";
+import { useAutoGrow } from "@/lib/useAutoGrow";
 import { ATTACHMENT_EXTENSIONS } from "@/lib/community/workshop";
 import type { AttachmentView } from "@/lib/community/queries";
 import { POST_BODY_MAX, TITLE_MAX } from "@/lib/community/validate";
@@ -72,6 +73,10 @@ export default function PostDetailClient({
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
   const [confirmingDelete, setConfirmingDelete] = useState(false);
+
+  // Editing opens on a post that already exists, so the box arrives at the
+  // length of what is in it rather than showing eight lines of forty.
+  const bodyRef = useAutoGrow<HTMLTextAreaElement>(editing ? body : "");
 
   // Attaching more files after the thread exists (author only).
   const attachRef = useRef<HTMLInputElement | null>(null);
@@ -199,7 +204,9 @@ export default function PostDetailClient({
               onChange={(event) => setTitle(event.target.value)}
             />
             <textarea
+              ref={bodyRef}
               className={styles.postBodyInput}
+              data-grow="page"
               value={body}
               maxLength={POST_BODY_MAX}
               aria-label="Post body"

--- a/web/src/lib/useAutoGrow.ts
+++ b/web/src/lib/useAutoGrow.ts
@@ -1,0 +1,45 @@
+"use client";
+
+import { useLayoutEffect, useRef } from "react";
+
+/**
+ * A textarea that is as tall as what is in it.
+ *
+ * A fixed-height box is fine for composing — you start empty and it fills up —
+ * and wrong for editing, where the text already exists and the box shows you
+ * eight lines of forty. Dragging the resize handle every time you hit Edit is
+ * not a feature.
+ *
+ * Growth is bounded by whatever `max-height` the stylesheet sets: scrollHeight
+ * keeps reporting the full content height, the inline height loses to
+ * max-height, and the textarea scrolls from there. So the cap is a CSS
+ * decision, per context — an inline editor can take the page, a modal cannot.
+ *
+ * useLayoutEffect rather than useEffect: the height is measured and applied
+ * before paint, so opening an editor does not flash at 180px and then jump.
+ */
+export function useAutoGrow<T extends HTMLTextAreaElement>(value: string) {
+  const ref = useRef<T>(null);
+
+  useLayoutEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    // Collapse first: scrollHeight can only report content TALLER than the
+    // current box, so without this the textarea would ratchet upward and never
+    // shrink when text is deleted.
+    el.style.height = "auto";
+
+    // scrollHeight is content + padding and stops there — no borders. Assigning
+    // it straight to a border-box height therefore lands two pixels short of
+    // the text, which shows up as a textarea that is permanently scrolled by
+    // its own border and clips the last line. Measured, not guessed.
+    const style = getComputedStyle(el);
+    const height =
+      style.boxSizing === "border-box"
+        ? el.scrollHeight + (el.offsetHeight - el.clientHeight)
+        : el.scrollHeight - parseFloat(style.paddingTop) - parseFloat(style.paddingBottom);
+    el.style.height = `${height}px`;
+  }, [value]);
+
+  return ref;
+}


### PR DESCRIPTION
Reported as: editing a thread post gives you a writing area too short to see what you're editing.

Hitting Edit opened a fixed 180px box onto a post of any length, so reading your own paragraph meant dragging the resize handle first. The comment editor was worse at 84px.

`useAutoGrow` measures the content and sets the height in a layout effect, so opening an editor doesn't render short and then jump. It shrinks back too, with the existing `min-height` as the floor.

**Ceilings stay in CSS**, because they differ by context:

| | cap | why |
|---|---|---|
| thread editor | `75vh` | it owns the page |
| new-thread modal | `42vh` | the buttons underneath have to stay reachable |
| comment / reply | `60vh` | one long reply shouldn't push the thread it answers off screen |

Past the cap they scroll, as they did before. `scrollHeight` reports full content height regardless, so `max-height` wins without any JS knowing about it.

## The measurement is not `scrollHeight`

These textareas are `box-sizing: border-box`, and `scrollHeight` is content + padding — it stops before the borders. Assigning it straight to `height` leaves the box short by exactly its border width: permanently scrolled by 2px with the last line clipped, which is a worse bug than the one being fixed.

Measured in a browser rather than reasoned about, against both box models:

```
border-box   30 lines → 696px, 0px hidden;  2 lines → 180px floor held
content-box  30 lines → 672px, 0px hidden;  2 lines → 180px floor held
75vh cap     wanted 4502px → 683px (viewport 910), scrolls instead
42vh cap     wanted 4502px → 382px, scrolls instead
```

## Checks

`tsc --noEmit` clean · lint clean (15 pre-existing warnings, 0 errors) · production build passes · `npm run check:workshop` green · a thread page loads with no console errors and no `useLayoutEffect` SSR warning.

The signed-in Edit click-path is yours — I can't hold a session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)