### PR TITLE
Preview clock, lab layout, knob ranges, and an honest build cost

### DIFF
--- a/web/content/build.md
+++ b/web/content/build.md
@@ -1,6 +1,6 @@
 ---
 title: Build your own.
-subtitle: About US$100 and an hour of hands-on work.
+subtitle: Around US$100–200 and an hour of hands-on work.
 meta:
   - label: Available now
     value: "3D print + PCB · breadboard"

--- a/web/package.json
+++ b/web/package.json
@@ -21,7 +21,8 @@
     "check:notify": "tsx scripts/notify-smoke.ts",
     "check:ports": "tsx scripts/ports-smoke.ts",
     "seed:map": "tsx scripts/seed-territories.ts",
-    "check:workshop": "tsx scripts/workshop-smoke.ts"
+    "check:workshop": "tsx scripts/workshop-smoke.ts",
+    "check:sandbox": "tsx scripts/sandbox-smoke.ts"
   },
   "dependencies": {
     "@chenglou/pretext": "^0.0.6",

--- a/web/public/pattern-sandbox.html
+++ b/web/public/pattern-sandbox.html
@@ -349,6 +349,16 @@ function resizeLive(frame) {
   imageData = context.createImageData(frame.width, frame.height);
 }
 
+// The longest single step a pattern is ever handed. A frame that took longer
+// than this is split into several of these rather than delivered as one jump:
+// handing a whole stall to a pattern that integrates by dt teleports
+// everything in it.
+var MAX_STEP = 0.05;
+// …and the most real time worth catching up on. Past this the frames are
+// simply lost, which is what you want: returning to a tab that was hidden for
+// a minute should resume, not fast-forward through a minute of simulation.
+var MAX_CATCHUP = 0.25;
+
 var live = {
   runtime: null,
   running: true,
@@ -364,7 +374,10 @@ var live = {
   // something changes what should be on screen, so a paused preview still
   // redraws exactly once instead of either freezing stale or spinning at
   // 60fps. See tick().
-  painted: false
+  painted: false,
+  // The pending requestAnimationFrame handle, or 0 when this sandbox is
+  // asleep. A paused preview schedules NOTHING — see tick().
+  frame: 0
 };
 
 function paint(runtime) {
@@ -376,27 +389,24 @@ function post(message) {
   parent.postMessage(message, "*");
 }
 
-function tick(now) {
-  requestAnimationFrame(tick);
-  var runtime = live.runtime;
-  if (!runtime || live.failed) return;
-  var dt = live.running ? Math.min(Math.max(0, (now - live.lastNow) / 1000), 0.05) : 0;
-  live.lastNow = now;
-
-  // A paused preview keeps its runtime loaded so hovering plays instantly, but
-  // it has nothing new to draw. The community feed mounts one of these per
-  // card, so without this bail-out a page of idle previews each burned a full
-  // renderFrame + putImageData sixty times a second to reproduce a picture
-  // that never changed. Paint once after loading, then go quiet until the
-  // pattern resumes or its knobs move.
-  if (!live.running && live.painted) return;
+/**
+ * One simulation step. Returns false once the pattern has thrown.
+ *
+ * `withKnobDeltas` is true for the first step of a frame only: a knob turn is
+ * one event, and replaying it across the catch-up steps below would multiply
+ * the turn by however far behind the preview had fallen.
+ */
+function step(dt, withKnobDeltas) {
   live.simTime += dt;
 
-  var prev = live.prevKnobs || live.knobValues;
-  var deltas = live.knobValues.map(function (v, i) {
-    return knobDelta(prev[i], v, live.knobWrap[i], live.knobUnitsPerTurn[i]);
-  });
-  live.prevKnobs = live.knobValues.slice();
+  var deltas = null;
+  if (withKnobDeltas) {
+    var prev = live.prevKnobs || live.knobValues;
+    deltas = live.knobValues.map(function (v, i) {
+      return knobDelta(prev[i], v, live.knobWrap[i], live.knobUnitsPerTurn[i]);
+    });
+    live.prevKnobs = live.knobValues.slice();
+  }
 
   var input = makeInput(
     deltas,
@@ -404,19 +414,72 @@ function tick(now) {
     normalize(live.knobValues, live.knobRanges),
     live.knobRanges
   );
-  var result = runtime.renderFrame(dt, live.simTime, input);
-  if (result.ok) {
-    paint(runtime);
-    live.painted = true;
-  } else {
+  var result = live.runtime.renderFrame(dt, live.simTime, input);
+  if (!result.ok) {
     live.failed = true;
     post({ type: "pf-status", ok: false, error: result.error });
+    return false;
   }
+  return true;
 }
-requestAnimationFrame(function (now) {
+
+/** Schedule a frame, unless one is already pending or this sandbox is dead. */
+function wake() {
+  if (live.frame !== 0 || live.failed || !live.runtime) return;
+  // A sandbox that has been asleep has a stale lastNow; without this the first
+  // frame back would bill the pattern for the whole pause.
+  live.lastNow = performance.now();
+  live.frame = requestAnimationFrame(tick);
+}
+
+function tick(now) {
+  live.frame = 0;
+  var runtime = live.runtime;
+  if (!runtime || live.failed) return;
+
+  var elapsed = Math.min(Math.max(0, (now - live.lastNow) / 1000), MAX_CATCHUP);
   live.lastNow = now;
-  requestAnimationFrame(tick);
-});
+
+  // A paused preview keeps its runtime loaded so hovering plays instantly, but
+  // it has nothing new to draw. Paint once — a fresh load, or a knob turned
+  // while stopped — and then stop scheduling frames ENTIRELY.
+  //
+  // It used to re-arm rAF forever and bail out inside the callback. That is
+  // cheap per call and expensive in aggregate: a feed mounts one sandbox per
+  // nearby card (thirteen of them on a full wall), and thirteen documents each
+  // holding a live animation callback share the frame budget with the one card
+  // the cursor is actually on. pf-run/pf-knobs/pf-load call wake() instead.
+  if (!live.running) {
+    if (!live.painted && step(0, true)) {
+      paint(runtime);
+      live.painted = true;
+    }
+    return;
+  }
+
+  // Slow frames must not become slow motion.
+  //
+  // dt used to be clamped to MAX_STEP and handed over once, so a preview
+  // rendering at 10fps advanced the simulation by 50ms per 100ms of wall
+  // clock: a pattern that integrates velocity by dt physically moved at half
+  // speed. That reads as the pattern dying rather than stuttering, and it only
+  // showed up on the wall — the detail page runs one sandbox and never falls
+  // far enough behind to notice. The clamp now bounds each STEP, and whatever
+  // real time is left over is stepped again (at most MAX_CATCHUP/MAX_STEP
+  // times, so a long stall cannot turn into an unbounded burst).
+  var remaining = elapsed;
+  var first = true;
+  do {
+    var slice = remaining > MAX_STEP ? MAX_STEP : remaining;
+    if (!step(slice, first)) return;
+    remaining -= slice;
+    first = false;
+  } while (remaining > 1e-5);
+
+  paint(runtime);
+  live.painted = true;
+  live.frame = requestAnimationFrame(tick);
+}
 
 // ── Still rendering (feed thumbnails) ────────────────────────────────────────
 function renderStill(request) {
@@ -472,6 +535,7 @@ window.addEventListener("message", function (event) {
     if (load.ok) {
       paint(live.runtime);
       post({ type: "pf-status", ok: true });
+      wake();
     } else {
       live.failed = true;
       post({ type: "pf-status", ok: false, error: load.error });
@@ -481,8 +545,12 @@ window.addEventListener("message", function (event) {
     if (Array.isArray(msg.ranges)) live.knobRanges = msg.ranges;
     // Knobs can be turned on a card that is not playing — redraw that once.
     live.painted = false;
+    wake();
   } else if (msg.type === "pf-run") {
     live.running = Boolean(msg.running);
+    // Starting is the whole point of waking; stopping needs it too, so the
+    // paused branch of tick gets a chance to settle the final frame.
+    wake();
   } else if (msg.type === "pf-still") {
     var result;
     try {

--- a/web/scripts/sandbox-smoke.ts
+++ b/web/scripts/sandbox-smoke.ts
@@ -1,0 +1,207 @@
+/**
+ * Sandbox clock smoke — `npm run check:sandbox`.
+ *
+ * Drives the REAL tick()/step()/wake() out of public/pattern-sandbox.html with
+ * a controlled clock. The script text is taken verbatim; the only addition is a
+ * line exposing `live`, appended here rather than shipped.
+ *
+ * What this guards, and why it needs a fake clock rather than a browser: the
+ * live preview turns wall-clock time into simulation time, and getting that
+ * wrong is invisible in every way a normal test looks. dt used to be clamped to
+ * 50 ms and handed over once per frame, so a preview rendering at 10fps
+ * advanced the simulation 50 ms per 100 ms of real time — a flocking pattern
+ * moved at half speed on the wall and full speed on its own page, and nothing
+ * errored. The numbers below are the arithmetic that made it visible.
+ */
+import fs from "node:fs";
+import path from "node:path";
+import vm from "node:vm";
+
+const SANDBOX = path.join(process.cwd(), "public", "pattern-sandbox.html");
+const script = fs.readFileSync(SANDBOX, "utf8").match(/<script>([\s\S]*)<\/script>/)?.[1];
+if (!script) {
+  console.error("Could not find the sandbox script block in", SANDBOX);
+  process.exit(1);
+}
+
+let failures = 0;
+function check(label: string, actual: unknown, expected: unknown) {
+  const ok = JSON.stringify(actual) === JSON.stringify(expected);
+  if (!ok) failures += 1;
+  console.log(
+    `${ok ? "  ok  " : "FAIL  "}${label}${ok ? "" : `\n        got ${JSON.stringify(actual)}\n        want ${JSON.stringify(expected)}`}`,
+  );
+}
+
+type Posted = { type?: string; ok?: boolean; error?: string; dataUrl?: string };
+
+type Harness = {
+  live: () => { runtime: { params: Record<string, number> } };
+  send: (data: unknown) => void;
+  /** Advance the wall clock and run the pending frame, if one is scheduled. */
+  frame: (ms: number) => void;
+  asleep: () => boolean;
+  /** What the pattern reported: accumulated dt, as seconds. */
+  simSeconds: () => number | null;
+  /** Everything posted back to the parent. */
+  posted: Posted[];
+};
+
+function boot(): Harness {
+  let painted: Uint8ClampedArray | null = null;
+  let pending: ((now: number) => void) | null = null;
+  let handler: ((event: { data: unknown }) => void) | null = null;
+  let clock = 1000;
+  const posted: Posted[] = [];
+
+  const ctx = {
+    createImageData: (w: number, h: number) => ({ width: w, height: h, data: new Uint8ClampedArray(w * h * 4) }),
+    putImageData: (img: { data: Uint8ClampedArray }) => { painted = img.data.slice(); },
+    drawImage: () => {},
+    getImageData: (_x: number, _y: number, w: number, h: number) => ({ data: new Uint8ClampedArray(w * h * 4) }),
+  };
+  const canvas = () => ({ width: 128, height: 64, getContext: () => ctx, toDataURL: () => "data:," });
+
+  const sandbox: Record<string, unknown> = {
+    document: { getElementById: canvas, createElement: canvas },
+    parent: { postMessage: (m: Posted) => posted.push(m) },
+    performance: { now: () => clock },
+    requestAnimationFrame: (fn: (now: number) => void) => { pending = fn; return 1; },
+    cancelAnimationFrame: () => { pending = null; },
+    window: {
+      addEventListener: (type: string, fn: (event: { data: unknown }) => void) => {
+        if (type === "message") handler = fn;
+      },
+    },
+    console,
+  };
+  sandbox.self = sandbox;
+  sandbox.globalThis = sandbox;
+  vm.createContext(sandbox);
+  vm.runInContext(`${script}\n;globalThis.__live = live;`, sandbox);
+
+  return {
+    live: () => sandbox.__live as Harness extends never ? never : { runtime: { params: Record<string, number> } },
+    send: (data) => handler?.({ data }),
+    frame: (ms) => { clock += ms; const fn = pending; pending = null; fn?.(clock); },
+    asleep: () => pending === null,
+    simSeconds: () => {
+      if (!painted) return null;
+      let lit = 0;
+      for (let i = 0; i < painted.length; i += 4) if (painted[i] > 128) lit += 1;
+      return Number((lit / 100).toFixed(2));
+    },
+    posted,
+  };
+}
+
+/** Reports the dt it was handed, as one lit pixel per 10 ms. */
+const PROBE = `
+// @matrix 128x64
+export function setup(p){ p.t = 0; p.turns = 0; }
+export function update(dt, input, p){
+  p.t += dt;
+  if (input.knobDeltas && input.knobDeltas[0]) p.turns += 1;
+}
+export function draw(display, p, time){
+  const lit = Math.round(p.t * 100);
+  for (let i = 0; i < lit && i < 128*64; i++) display.setPixel(i % 128, (i/128)|0, 255,255,255);
+}`;
+
+const load = (s: Harness, running: boolean) =>
+  s.send({
+    type: "pf-load", code: PROBE, running,
+    knobValues: [0.5, 0.5, 0.5, 0.5], knobRanges: [[0, 1], [0, 1], [0, 1], [0, 1]],
+    knobWrap: [false, false, false, false], knobUnitsPerTurn: [1, 1, 1, 1],
+  });
+
+// ── A paused preview schedules nothing ──────────────────────────────────────
+// The wall mounts one sandbox per nearby card. They used to re-arm rAF forever
+// and bail out inside the callback — cheap per call, and thirteen documents
+// holding a live animation callback sharing the budget with the one card the
+// cursor is on.
+{
+  const s = boot();
+  load(s, false);
+  check("a paused load wakes once", s.asleep(), false);
+  s.frame(16);
+  check("…paints that frame", s.simSeconds() !== null, true);
+  check("…then stops scheduling entirely", s.asleep(), true);
+  s.frame(16);
+  check("…and stays asleep", s.asleep(), true);
+
+  s.send({ type: "pf-run", running: true });
+  check("running wakes it", s.asleep(), false);
+  s.frame(16);
+  check("…and it keeps itself going", s.asleep(), false);
+
+  s.send({ type: "pf-run", running: false });
+  s.frame(16);
+  check("pausing settles, then sleeps", s.asleep(), true);
+
+  s.send({ type: "pf-knobs", values: [0.7, 0.5, 0.5, 0.5], ranges: [[0, 1], [0, 1], [0, 1], [0, 1]] });
+  check("a knob turn wakes a paused preview", s.asleep(), false);
+  s.frame(16);
+  check("…for exactly one repaint", s.asleep(), true);
+}
+
+// ── Wall-clock time reaches the pattern at any frame rate ───────────────────
+// Before the catch-up stepping these read 3.00 / 3.00 / 3.00 / 2.25 / 1.50 /
+// 0.90 — i.e. below 20fps the pattern ran in slow motion, proportionally.
+for (const [label, frameMs, frames] of [
+  ["60fps", 16.667, 180],
+  ["30fps", 33.333, 90],
+  ["20fps", 50, 60],
+  ["15fps", 66.667, 45],
+  ["10fps", 100, 30],
+  ["6fps", 166.667, 18],
+] as const) {
+  const s = boot();
+  load(s, true);
+  s.frame(0); // the wake frame carries no elapsed time
+  for (let i = 0; i < frames; i += 1) s.frame(frameMs);
+  check(`${label}: 3s of wall clock is 3s of simulation`, s.simSeconds(), 3);
+}
+
+// ── …but a genuine stall is dropped, never fast-forwarded ───────────────────
+{
+  const s = boot();
+  load(s, true);
+  s.frame(0);
+  s.frame(60_000); // a minute in a background tab
+  check("a 60s stall advances at most MAX_CATCHUP", s.simSeconds(), 0.25);
+}
+
+// ── A knob turn is one event, not one per catch-up step ─────────────────────
+{
+  const s = boot();
+  load(s, true);
+  s.frame(0);
+  s.send({ type: "pf-knobs", values: [0.9, 0.5, 0.5, 0.5], ranges: [[0, 1], [0, 1], [0, 1], [0, 1]] });
+  s.frame(250); // 250ms behind — five catch-up steps in the one frame
+  check("a knob turn is seen once, not once per substep", s.live().runtime.params.turns, 1);
+}
+
+// ── The still path is untouched, and never runs the live clock ──────────────
+// Thumbnails step at a fixed 1/fps with no clamp. A still must also not wake
+// the animation loop: the wall renders one per card through a single hidden
+// sandbox, and a still that left a frame scheduled would start them all.
+{
+  const s = boot();
+  load(s, false);
+  s.frame(16);                       // settle the paused load, then sleep
+  check("paused before the still", s.asleep(), true);
+
+  s.send({
+    type: "pf-still", id: "x", code: PROBE,
+    knobValues: [0.5, 0.5, 0.5, 0.5], knobRanges: [[0, 1], [0, 1], [0, 1], [0, 1]],
+    seconds: 0.9, fps: 15,
+  });
+  const result = s.posted.find((m) => m.type === "pf-still-result");
+  check("a still comes back", result?.ok, true);
+  check("…carrying an image", typeof result?.dataUrl === "string", true);
+  check("…and schedules no frame of its own", s.asleep(), true);
+}
+
+console.log(failures === 0 ? "\nAll sandbox clock checks passed." : `\n${failures} FAILED`);
+process.exit(failures === 0 ? 0 : 1);

--- a/web/src/app/pattern-lab/PatternLabClient.tsx
+++ b/web/src/app/pattern-lab/PatternLabClient.tsx
@@ -32,7 +32,7 @@ import PublishModal from "@/components/community/PublishModal";
 import BuildFirmwareModal from "@/components/community/BuildFirmwareModal";
 import { flattenLayers, needsFlatten } from "@/lib/lab/flatten";
 import { buildCppPrompt } from "@/lib/lab/cppPrompt";
-import { LAYOUT_STORAGE } from "@/lib/lab/serialize";
+import { LAYOUT_STORAGE, layoutViewCount } from "@/lib/lab/serialize";
 import { listSessions, type SessionMeta } from "@/lib/lab/sessions";
 import { buildStackAnnotation, importCodeIntoLab } from "@/lib/lab/stackShare";
 import { useLabStore } from "@/lib/lab/store";
@@ -247,6 +247,19 @@ export default function PatternLabClient() {
     setMounted(true);
   }, [hydrate]);
 
+  // A queued layout save must not outlive the dock it describes: leaving the
+  // lab tears the dock down, and a save that lands afterwards writes whatever
+  // the half-disposed dock happened to serialise to.
+  useEffect(
+    () => () => {
+      if (layoutSaveTimer.current !== null) {
+        clearTimeout(layoutSaveTimer.current);
+        layoutSaveTimer.current = null;
+      }
+    },
+    [],
+  );
+
   const syncOpenPanels = useCallback((api: DockviewApi) => {
     setOpenPanels(new Set(api.panels.map((panel) => panel.id)));
   }, []);
@@ -260,14 +273,31 @@ export default function PatternLabClient() {
       try {
         const raw = window.localStorage.getItem(LAYOUT_STORAGE);
         if (raw) {
-          api.fromJSON(JSON.parse(raw));
-          restored = true;
+          const parsed = JSON.parse(raw);
+          // Restoring a layout that places nothing gives you an empty
+          // workspace: every panel gone, and Reset layout the only way out.
+          // dockview will happily do it, so the check has to happen here.
+          if (layoutViewCount(parsed) > 0) {
+            api.fromJSON(parsed);
+            restored = true;
+          }
         }
       } catch {
         restored = false;
       }
       if (!restored) {
+        // Drop the unusable one rather than leaving it to be rejected again on
+        // every future load — onDidLayoutChange is subscribed below, so
+        // nothing overwrites it until the first panel is moved.
         try {
+          window.localStorage.removeItem(LAYOUT_STORAGE);
+        } catch {
+          // Private mode — nothing was persisted anyway.
+        }
+        try {
+          // Whatever a failed fromJSON managed to add is still in there, and
+          // building the default on top of it collides on panel ids.
+          api.clear();
           buildDefaultLayout(api);
         } catch {
           // A half-built layout is still usable; panels can be opened manually.
@@ -281,7 +311,13 @@ export default function PatternLabClient() {
         layoutSaveTimer.current = setTimeout(() => {
           layoutSaveTimer.current = null;
           try {
-            window.localStorage.setItem(LAYOUT_STORAGE, JSON.stringify(api.toJSON()));
+            const next = api.toJSON();
+            // This is where the blank workspace got in. A dock is momentarily
+            // empty while it is being cleared or torn down, and a snapshot
+            // taken then is a layout that restores as nothing at all. It is
+            // never a state worth remembering, so it is never written.
+            if (layoutViewCount(next) === 0) return;
+            window.localStorage.setItem(LAYOUT_STORAGE, JSON.stringify(next));
           } catch {
             // Quota/private mode — layout just won't persist.
           }

--- a/web/src/app/pattern-lab/PatternLabClient.tsx
+++ b/web/src/app/pattern-lab/PatternLabClient.tsx
@@ -30,6 +30,7 @@ import { buildsConfigured, communityConfigured } from "@/lib/community/apiBase";
 import { clearLabHandoff, readLabHandoff } from "@/lib/community/handoff";
 import PublishModal from "@/components/community/PublishModal";
 import BuildFirmwareModal from "@/components/community/BuildFirmwareModal";
+import { withKnobsAnnotation } from "@/lib/lab/annotations";
 import { flattenLayers, needsFlatten } from "@/lib/lab/flatten";
 import { buildCppPrompt } from "@/lib/lab/cppPrompt";
 import { LAYOUT_STORAGE, layoutViewCount } from "@/lib/lab/serialize";
@@ -178,6 +179,12 @@ async function buildExportCode(): Promise<string> {
     (entry) => entry.visible && entry.opacity > 0 && entry.type === "code",
   ) as CodeLayer;
   let code = withMatrixAnnotation(layer.code, state.matrix);
+  // Knob ranges live in the lab, not in the layer's text, so retuning a
+  // slider's min/max left the code saying whatever it was imported with. The
+  // flattened path has always written this line; a single code layer — the
+  // common case — published the original ranges and the retune had to be
+  // redone by hand in the community editor afterwards.
+  code = withKnobsAnnotation(code, state.knobLabels, state.ranges);
   if (codeUsesValueField(layer.code) || layer.recolor) {
     code = withRampAnnotation(code, {
       stops: layer.ramp.stops.map((stop) => ({

--- a/web/src/components/sections/BuildPanel.tsx
+++ b/web/src/components/sections/BuildPanel.tsx
@@ -15,11 +15,18 @@ interface BuildPanelProps {
 // 3D print, see BUILD_GUIDE.md BOM).
 const FACTS = [
   {
-    value: '~$100',
+    // A range, not the floor. The breakdown below adds up to about $100, and
+    // that is the well-sourced, nothing-goes-wrong build — the figure people
+    // who have actually built one report is higher. Shipping, minimum order
+    // quantities on the small parts, and a reprint or two are the difference,
+    // and quoting only the best case makes the project look cheaper than it
+    // is to the one person it matters to: whoever is deciding to start.
+    value: '$100–200',
     name: 'All parts',
     // Printing, not filament: most people order the case rather than owning a
     // printer, and $30 is what that costs.
-    detail: '3D printing ~$30 · panel ~$20 · ESP32-S3 ~$15 · PCB & rest ~$35',
+    detail:
+      'At best: 3D printing ~$30 · panel ~$20 · ESP32-S3 ~$15 · PCB & rest ~$35. Shipping, minimum order quantities and a reprint or two take it up from there.',
   },
   {
     value: '~1 hr',

--- a/web/src/lib/community/sandboxUrl.ts
+++ b/web/src/lib/community/sandboxUrl.ts
@@ -7,4 +7,4 @@
 // immutable Cache-Control (every feed card boots an iframe from it, and
 // without the cache each boot is a round trip to the Pi). An edit without a
 // bump ships to nobody who has ever visited.
-export const PATTERN_SANDBOX_URL = "/pattern-sandbox.html?v=4";
+export const PATTERN_SANDBOX_URL = "/pattern-sandbox.html?v=5";

--- a/web/src/lib/community/thumbs.ts
+++ b/web/src/lib/community/thumbs.ts
@@ -88,7 +88,16 @@ function pump() {
       code: job.code,
       knobValues,
       knobRanges: setup.ranges,
-      seconds: 0.0,
+      // Not frame zero. A still at t=0 is the pattern before anything has
+      // happened in it — particles unspawned, trails empty, most of the screen
+      // dark — so the card advertised a picture the pattern never shows. This
+      // is the sandbox's own default: enough frames for a pattern to become
+      // itself, few enough to stay cheap (the whole feed shares one hidden
+      // iframe, rendering these one at a time, and each result is cached).
+      //
+      // It was 0.9 until b3419cd changed it to 0.0 inside a large unrelated
+      // commit that never mentions thumbnails.
+      seconds: 0.9,
       fps: 15,
     },
     "*",

--- a/web/src/lib/lab/annotations.ts
+++ b/web/src/lib/lab/annotations.ts
@@ -46,6 +46,60 @@ export function defaultKnobState(): { knobs: number[]; ranges: KnobRange[]; labe
   };
 }
 
+/**
+ * The `@knobs` line for a given knob state.
+ *
+ * Ranges live in the lab, not in the code — the same arrangement as `@matrix`
+ * and `@ramp`, where the annotation is how the state LEAVES the lab rather
+ * than where it is kept. Retuning a range therefore has to be written back at
+ * export, or the published pattern carries whatever ranges it was imported
+ * with and the retune is silently lost.
+ */
+export function buildKnobsAnnotationLine(labels: string[], ranges: KnobRange[]): string {
+  const trim = (value: number) => `${Math.round(value * 1000) / 1000}`;
+  const entries = labels.map((label, index) => {
+    const range = ranges[index] ?? [0, 1];
+    // Commas and equals signs are the annotation's own separators.
+    const name = label.replace(/[,=]/g, " ").trim() || "-";
+    return `${name}=${trim(range[0])}..${trim(range[1])}`;
+  });
+  return `// @knobs ${entries.join(", ")}`;
+}
+
+export function stripKnobsAnnotation(code: string): string {
+  return code.replace(KNOBS_ANNOTATION_RE, "").replace(/^\n/, "");
+}
+
+/** True when nothing about the knobs has been named or retuned. */
+export function knobStateIsDefault(labels: string[], ranges: KnobRange[]): boolean {
+  const base = defaultKnobState();
+  return (
+    labels.length === base.labels.length &&
+    labels.every((label, index) => label === base.labels[index]) &&
+    ranges.length === base.ranges.length &&
+    ranges.every(
+      (range, index) => range[0] === base.ranges[index][0] && range[1] === base.ranges[index][1],
+    )
+  );
+}
+
+/**
+ * Replace (or add) the `@knobs` line so the code says what the lab currently
+ * shows.
+ *
+ * A pattern that never touched knobs is left alone: writing
+ * `Knob 1=0..1, Knob 2=0.1..10, …` into something with no knobs in it is noise
+ * that would then travel with every fork of it.
+ */
+export function withKnobsAnnotation(
+  code: string,
+  labels: string[],
+  ranges: KnobRange[],
+): string {
+  if (knobStateIsDefault(labels, ranges) && !matchKnobsAnnotation(code)) return code;
+  return `${buildKnobsAnnotationLine(labels, ranges)}\n${stripKnobsAnnotation(code)}`;
+}
+
 /** Apply a parsed annotation over existing knob state (clamping values in). */
 export function applyKnobEntries(
   entries: KnobAnnotationEntry[],

--- a/web/src/lib/lab/flatten.ts
+++ b/web/src/lib/lab/flatten.ts
@@ -20,7 +20,7 @@
 import { buildRampLUTRGBA } from "@/lib/patternHarness";
 import { withMatrixAnnotation, type MatrixSize } from "@/lib/patternMatrix";
 import { codeUsesValueField } from "@/lib/patternRamp";
-import { KNOBS_ANNOTATION_RE, defaultKnobState } from "./annotations";
+import { KNOBS_ANNOTATION_RE, buildKnobsAnnotationLine, defaultKnobState } from "./annotations";
 import { rampStateToHarness } from "./engine";
 import { bytesToBase64 } from "./serialize";
 import type { CodeLayer, KnobRange, Layer } from "./types";
@@ -262,15 +262,8 @@ export function draw(display, params, time) {
     labels: defaultKnobState().labels,
     ranges: defaultKnobState().ranges,
   };
-  const trim = (value: number) => `${Math.round(value * 1000) / 1000}`;
   const knobsLine = hasCode
-    ? `// @knobs ${knobState.labels
-        .map((label, index) => {
-          const range = knobState.ranges[index] ?? [0, 1];
-          const name = label.replace(/[,=]/g, " ").trim() || "-";
-          return `${name}=${trim(range[0])}..${trim(range[1])}`;
-        })
-        .join(", ")}`
+    ? buildKnobsAnnotationLine(knobState.labels, knobState.ranges)
     : null;
 
   const body = parts.join("\n");

--- a/web/src/lib/lab/serialize.ts
+++ b/web/src/lib/lab/serialize.ts
@@ -36,6 +36,36 @@ import { matchMatrixAnnotation } from "@/lib/patternMatrix";
 
 export const PROJECT_STORAGE = "patternflow_lab_project_v2";
 export const LAYOUT_STORAGE = "patternflow_lab_layout_v1";
+
+/**
+ * How many panels a serialized dockview layout actually PLACES.
+ *
+ * Not `Object.keys(layout.panels).length` — that is a registry, and not the
+ * leaf count either. The blank-workspace layout this exists to catch has all
+ * seven panels registered, five grid leaves at the right sizes, an activeView
+ * named on each… and `views: []` in every one of them. dockview restores it
+ * without complaining and you get a lab with every panel closed and no way
+ * back but Reset layout.
+ *
+ * So the only honest question is how many views are placed in the grid, which
+ * is what this counts. Both the save and the restore ask it: a layout that
+ * places nothing is never written, and never restored if an older one is
+ * already stored.
+ */
+export function layoutViewCount(layout: unknown): number {
+  const walk = (node: unknown): number => {
+    if (!node || typeof node !== "object") return 0;
+    const branch = node as { type?: unknown; data?: unknown };
+    if (branch.type === "leaf") {
+      const views = (branch.data as { views?: unknown } | undefined)?.views;
+      return Array.isArray(views) ? views.length : 0;
+    }
+    if (!Array.isArray(branch.data)) return 0;
+    return branch.data.reduce<number>((sum, child) => sum + walk(child), 0);
+  };
+  const grid = (layout as { grid?: { root?: unknown } } | null | undefined)?.grid;
+  return walk(grid?.root);
+}
 /** Old single-pattern lab keys, read once for migration. */
 const LEGACY_RAMP_STORAGE = "patternflow_ramp_v1";
 


### PR DESCRIPTION
Four fixes from using the thing, batched.

## A slow preview ran slower, not in slow motion (`df30ed6`)

Reported as: a flocking pattern that plays correctly on its own page has its movement die when you hover the same card on the wall.

Not the pattern — measured through the same runtime it costs **1.1 ms/frame**, ~900fps of headroom, with 510 birds and a 260,000-iteration inner loop. It was the clock.

The live tick clamped `dt` to 50 ms and handed it over once per frame. Below 20fps that clamp stops being a safety rail and becomes the simulation speed — anything integrating velocity by `dt` physically moves slower. It only showed up on the wall because the detail page runs one sandbox and never falls far enough behind to notice.

The clamp now bounds each **step**, and leftover real time is stepped again (capped at 250 ms, so returning to a tab hidden for a minute resumes rather than fast-forwards). Knob deltas ride the first substep only — a turn is one event, not one per catch-up step.

Second half: a paused sandbox re-armed `requestAnimationFrame` forever and bailed out inside the callback. Cheap per call, expensive in aggregate — the wall mounts one sandbox per nearby card (**13**, measured, against the detail page's 1). A paused preview now schedules nothing; `pf-run`/`pf-knobs`/`pf-load` wake it.

`npm run check:sandbox` drives the real `tick()` out of the HTML with a fake clock. Against the previous code **9 of its 21 checks fail**:

| card fps | before: sim advanced in 3s | after |
|---|---|---|
| 15fps | 2.25s | **3.00s** |
| 10fps | 1.50s | **3.00s** |
| 6fps | 0.90s | **3.00s** |

Also in there: card thumbnails were rendering **frame zero** — `seconds: 0.0` floors to exactly one `renderFrame` at t=0, the pattern before anything has happened in it. It was `0.9` until `b3419cd` changed it inside a large commit about pagination that never mentions thumbnails.

## The lab opened with every panel closed (`0c8ca5d`)

The saved layout was a real one — seven panels registered, five grid leaves at sensible sizes, an `activeView` named on each — and **`views: []` in every leaf**. Nothing places a panel, so dockview restores exactly what it was asked to. It never throws, so the existing try/catch could not see it, and it persists, so every later visit is blank too.

`layoutViewCount()` counts panels actually **placed** in the grid — not `Object.keys(panels)` (a registry) and not the leaf count (still 5 here). A layout that places nothing is never written and never restored. Plus: the rejected layout is removed rather than re-rejected forever, `api.clear()` runs before the default is built, and the pending save is cancelled on unmount.

Verified against the actual bad layout from localStorage: before, blank and stayed blank; after, self-heals to the default and clears the bad entry. Good layouts still round-trip — closing Gallery saves 6 placed views, reopening saves 7, reload brings all seven panels back.

## Knob ranges you tuned now get published (`88abe39`)

Retuning a slider's min/max and sharing published the **original** ranges, so the fix was reopening the pattern in the community editor and redoing the edit by hand.

Ranges live in the lab, not the layer's text — same as `@matrix` and `@ramp`, where the annotation is how state *leaves* the lab. Those are written back on export; `@knobs` was too, but only on the flattened path. A single code layer — most patterns — went out with whatever it was imported with. `withKnobsAnnotation()` now runs there too, and `flatten.ts` uses the shared builder.

A pattern that never touched knobs is left alone — writing `Knob 1=0..1, …` into something with no knobs is noise that would travel with every fork.

## The build cost is $100–200 (`ad0b159`)

The breakdown adds up to ~$100 and that is the well-sourced, nothing-goes-wrong build. Shipping, minimum order quantities and a reprint or two are the difference. Quoting only the best case makes it look cheaper than it is to the one person the number matters to. The breakdown stays, labelled as the floor it is.

Leaves `README.md`, `BUILD_GUIDE.md` and the v3.1.0 release notes still saying ~US$100.

## Checks

`tsc --noEmit` clean · lint 0 errors · production build passes · `check:sandbox` (21) · `check:workshop` · `check:moderation` · `check:retention` · knob-annotation round-trip (9).

🤖 Generated with [Claude Code](https://claude.com/claude-code)