### PR TITLE
Quote the build as US$100–200 in the README and build guide

### DIFF
--- a/BUILD_GUIDE.md
+++ b/BUILD_GUIDE.md
@@ -32,7 +32,7 @@ This guide walks you through building a Patternflow v3.0.0 from scratch. No prio
 
 The authoritative parts list is [`hardware/bom/bom_v3.0.csv`](hardware/bom/bom_v3.0.csv) — every part specified by manufacturer part number. Read the [BOM README](hardware/bom/README.md) for sourcing notes before ordering.
 
-Rough breakdown of the ~US$100 total: 3D printing filament ~$30, LED matrix panel ~$20, ESP32-S3 ~$13, PCB + remaining parts (encoders, connectors, etc.) ~$35.
+Budget **US$100–200**. The lower end is the well-sourced build where nothing goes wrong: 3D printing filament ~$30, LED matrix panel ~$20, ESP32-S3 ~$13, PCB + remaining parts (encoders, connectors, etc.) ~$35. Shipping, minimum order quantities on the small parts, and a reprint or two are what take it up from there — so treat ~$100 as the floor rather than the estimate.
 
 ### On the board
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@
 | **Firmware** | Arduino-compatible C++, modular pattern architecture, runtime switching (no reflash) |
 | **Flashing** | Everything from the browser (Chrome/Edge) — stock firmware, and custom patterns compiled by the build server; after the first USB flash, new builds can go over Wi-Fi. Arduino IDE only for firmware development or other matrix resolutions |
 | **Connectivity** | Wi-Fi — bidirectional OSC (Ableton/Max/TouchDesigner) and audio-react WebSocket · USB |
-| **Build** | ~1 h hands-on (≈30 min soldering + ≈30 min assembly — first-build friendly) + ~10 h 3D printing · around US$100 in parts ([BOM](BUILD_GUIDE.md#1-bill-of-materials-bom)) |
+| **Build** | ~1 h hands-on (≈30 min soldering + ≈30 min assembly — first-build friendly) + ~10 h 3D printing · US$100–200 in parts ([BOM](BUILD_GUIDE.md#1-bill-of-materials-bom)) |
 | **License** | MIT (firmware & web code) · CC-BY-SA 4.0 (hardware, docs, bundled patterns) · community patterns are licensed by their authors ([summary](docs/LICENSE-SUMMARY.md)) |
 
 ### Power & runtime


### PR DESCRIPTION
Follow-on to `ad0b159`, which changed the figure on the site. The site links to `BUILD_GUIDE.md`, and that still said `~US$100` — so the two disagreed at exactly the moment somebody was deciding whether to start.

`~$100` is the well-sourced build where nothing goes wrong. Shipping, minimum order quantities on the small parts, and a reprint or two are the difference. The per-part breakdown stays, now labelled as the floor it is.

Now consistent across all three:

| | |
|---|---|
| `web/content/build.md` | Around US$100–200 and an hour of hands-on work. |
| `README.md` | US$100–200 in parts |
| `BUILD_GUIDE.md` | Budget **US$100–200**. The lower end is… treat ~$100 as the floor rather than the estimate. |

`CHANGELOG.md` and `docs/releases/v3.1.0.md` keep their figure — those describe what a past release shipped, not what a build costs today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)