### PR TITLE
Color pipeline: perceptual ramps + panel calibration

### DIFF
--- a/firmware/patternflow/config.h
+++ b/firmware/patternflow/config.h
@@ -216,12 +216,14 @@ constexpr float EULER      = 2.71828182845904523536f;
 // able to set colour precisely, and were written believing the driver did no
 // curve of its own.
 //
-// STILL OPEN, and deliberately left to whoever wants it: the fine tuning on
-// top of this baseline. Nobody has chosen numbers for it. If that is you —
-// change DEFAULT_BRIGHTNESS for overall level (it scales PWM without bending
-// colour), LED_SAT_BOOST if highlights collapse toward white, LED_WB_* for a
-// colour cast. Gamma is the driver's job and almost never yours: putting a
-// curve back here is how the stack above happened.
+// The fine tuning on top of this baseline was done 2026-08-09 on the
+// maintainer's v2.x panel, by eye against a monitor showing the same test
+// frames (GET /api/display tunes all of these live; the panel tuner page in
+// web/public/panel-tuner.html drives it). The WB and saturation defaults
+// below are that panel's converged numbers. Panels vary — if yours reads
+// differently, tune live and land your own numbers here. Gamma is the
+// driver's job and almost never yours: putting a curve back here is how the
+// stack above happened.
 
 // OPEN: matching panel colour to a monitor properly.
 // Per-channel gain is an approximation. The real difference is that the LED
@@ -248,21 +250,32 @@ constexpr float EULER      = 2.71828182845904523536f;
 #define LED_GAMMA_B 1.0f
 #endif
 
+// Tuned by eye against the Calibration preset's WHITE screen (2026-08-09,
+// maintainer's v2.x panel): this panel leans warm, so red is trimmed hardest.
+// Tune live via /api/display, then land the converged numbers here.
 #ifndef LED_WB_R
-#define LED_WB_R 1.00f
+#define LED_WB_R 0.930f
 #endif
 #ifndef LED_WB_G
-#define LED_WB_G 1.00f
+#define LED_WB_G 1.000f
 #endif
 #ifndef LED_WB_B
-#define LED_WB_B 1.00f
+#define LED_WB_B 0.975f
 #endif
 
 // Saturation boost is applied before gamma in present(). Gray stays gray
 // (mathematically a no-op when r==g==b), saturated colors get pulled
-// further away from gray. 1.10 = +10%; 1.0 disables.
+// further away from gray. 1.0 disables.
+//
+// 1.62 was tuned by eye (2026-08-09) against the Calibration preset's
+// side-by-side sRGB reference in the panel tuner, and held across the
+// brightness range (checked at 14% and 100%). Counter to the wide-gamut
+// theory that predicted a CUT: in practice the panel reads washed-out next
+// to a monitor showing the same frame, so matching the design intent takes
+// a strong boost. Strongly saturated colors clip a channel under it —
+// acceptable; the match is judged on real patterns, not on test bars.
 #ifndef LED_SAT_BOOST
-#define LED_SAT_BOOST 1.00f
+#define LED_SAT_BOOST 1.62f
 #endif
 
 // --- Network features (Wi-Fi, OTA, OSC, audio-react) ---

--- a/firmware/patternflow/net_config.h
+++ b/firmware/patternflow/net_config.h
@@ -72,7 +72,7 @@
 // Firmware version string reported to the flasher (Improv device-info RPC).
 // Keep in sync with web/public/flash/manifest.json.
 #ifndef PF_IMPROV_FW_VERSION
-#define PF_IMPROV_FW_VERSION "3.2.0"
+#define PF_IMPROV_FW_VERSION "3.3.0-cal"
 #endif
 
 // ── OTA (wireless flashing from Arduino IDE / espota.py) ─────

--- a/firmware/patternflow/pattern_registry.h
+++ b/firmware/patternflow/pattern_registry.h
@@ -56,6 +56,10 @@
 #include "presets/preset_0718.h"
 #include "presets/preset_0719.h"
 #include "presets/preset_a_big_hit.h"
+// NOT in presetPatterns[] below on purpose: the calibration test card is an
+// overlay the tuner summons via /api/display, never a knob-browsable pattern.
+// See the header's own comment for the full story.
+#include "presets/preset_calib.h"
 
 struct PatternEntry {
   const char* name;

--- a/firmware/patternflow/patternflow.ino
+++ b/firmware/patternflow/patternflow.ino
@@ -13,6 +13,7 @@
 // After the registry: the pattern manager serves and mutates that list.
 #include "src/core_patterns_http.h"
 #include "src/core_status_http.h"
+#include "src/core_display_http.h"
 #include "src/core_wifi_http.h"
 
 MatrixPanel_I2S_DMA *dma_display = nullptr;
@@ -166,6 +167,9 @@ void setup() {
   for (int i = 0; i < NUM_PATTERNS; i++) {
     if (!patterns[i].modulePath) patterns[i].setup();
   }
+  // The calibration test card lives outside the pattern list (it is an overlay
+  // summoned by /api/display, not art) but still bakes its tables once here.
+  CalibPattern::setup();
   activatePattern(currentPatternIdx);
 
   Serial.printf("Current Pattern: %s\n", patterns[currentPatternIdx].name);
@@ -670,6 +674,7 @@ void loop() {
     PatternflowWebUpdate::begin();
     PatternflowPatternsHttp::begin();
     PatternflowStatusHttp::begin();
+    PatternflowDisplayHttp::begin();
     PatternflowWifiHttp::begin();
     Serial.println("[NET] services started");
     reportHeap("services up");
@@ -872,6 +877,9 @@ void loop() {
     if (currentMode == MODE_RUNNING) {
       currentMode = MODE_SELECTING;
       contentNoticeTimer = 0.0f;
+      // Physical escape hatch for the calibration overlay: whoever is at the
+      // device outranks a browser tab that may no longer exist.
+      CalibPattern::overrideOn = false;
       Serial.printf(">>> SELECT MODE ENTERED: %s\n", patterns[currentPatternIdx].name);
     } else {
       currentMode = MODE_RUNNING;
@@ -907,7 +915,20 @@ void loop() {
     currentPatternIdx = oscPatternIdx;
     currentMode = MODE_RUNNING;
     contentNoticeTimer = CONTENT_NOTICE_SECONDS;
+    CalibPattern::overrideOn = false;  // picking a pattern dismisses the test card
     Serial.printf(">>> OSC pattern → %s\n", patterns[currentPatternIdx].name);
+  }
+
+  // Same contract as the OSC path above, fed by GET /api/patterns/select.
+  int httpPatternIdx;
+  if (PatternflowPatternsHttp::consumeSelectIdx(httpPatternIdx) &&
+      httpPatternIdx >= 0 && httpPatternIdx < NUM_PATTERNS &&
+      activatePattern(httpPatternIdx)) {
+    currentPatternIdx = httpPatternIdx;
+    currentMode = MODE_RUNNING;
+    contentNoticeTimer = CONTENT_NOTICE_SECONDS;
+    CalibPattern::overrideOn = false;  // picking a pattern dismisses the test card
+    Serial.printf(">>> HTTP pattern → %s\n", patterns[currentPatternIdx].name);
   }
   bool frameDrawn = true;
   if (oscInfoShowing) {
@@ -944,6 +965,18 @@ void loop() {
       updateDirty = false;
     } else {
       frameDrawn = false;
+    }
+  } else if (currentMode == MODE_RUNNING && CalibPattern::overrideOn) {
+    // Calibration overlay: the test card draws instead of the pattern, which
+    // freezes underneath (not updated) and resumes exactly where it was once
+    // the tuner dismisses the card. Runs even while the console has the module
+    // evicted — the card is compiled in and needs none of the module's RAM.
+    // K1/K2 still work on the card for whoever is standing at the panel.
+    pausedDirty = true;
+    CalibPattern::update(dt, input);
+    CalibPattern::draw();
+    if (brightnessAdjusting) {
+      drawBrightnessNotice();
     }
   } else if (currentMode == MODE_RUNNING && activePatternIdx < 0) {
     // Same throttled-redraw scheme as the info screens: this is static text and

--- a/firmware/patternflow/presets/preset_calib.h
+++ b/firmware/patternflow/presets/preset_calib.h
@@ -1,0 +1,210 @@
+// SPDX-License-Identifier: MIT
+// Calibration test card — a measuring instrument, NOT a pattern.
+//
+// Deliberately absent from the pattern registry: browsing the knob list is a
+// curated art experience, and a white test field in slot 35 is not art. The
+// card is an OVERLAY the tuner summons — /api/display?screen=N draws it over
+// whatever pattern is running (the pattern freezes underneath and resumes
+// untouched), ?screen=-1 dismisses it. Entering SELECT mode (K4 hold) or
+// switching patterns also dismisses it, so a dead tuner tab can never leave
+// the panel stuck on a test card.
+//
+// Used together with /api/display's wb/gamma/sat params and the reference
+// view in web/public/panel-tuner.html to tune the output stage by eye.
+//
+//   K1 turn  switch screen (works physically while the overlay is up):
+//     0 WHITE   full field at K2's level — the white-balance screen. Tune
+//               wb_* until it reads as neutral white, then drop the level
+//               and check the tint holds at low drive.
+//     1 GRAYS   16-step staircase over a smooth gradient — banding and the
+//               dark end of the curve.
+//     2 COLORS  R G B C M Y W K bars, full drive over half drive — channel
+//               sanity and the saturation control.
+//     3 RAMPS   blue→yellow and red→blue, each as an sRGB lerp band directly
+//               above its OKLab lerp band — the web lab's new ramp math,
+//               shown on the actual LEDs.
+//   K2 turn  WHITE level (8..255, one detent = 8)
+#pragma once
+#include <Arduino.h>
+#include <math.h>
+#include "../config.h"
+#include "../src/core_display.h"
+#include "../src/core_encoders.h"
+#include "../src/core_canvas.h"
+
+namespace CalibPattern {
+  const char* NAME = "Calibration";
+  const char* const KNOB_LABELS[4] = {"Screen", "White Lv", "-", "-"};
+
+  constexpr int NUM_SCREENS = 4;
+  int screen = 0;
+  int whiteLevel = 255;
+  float indicatorTimer = 0.0f;
+
+  // True while the test card is drawn over the running pattern. Flipped by
+  // /api/display (?screen=N on, ?screen=-1 off) and cleared by the sketch on
+  // any pattern switch or SELECT-mode entry.
+  bool overrideOn = false;
+
+  // Absolute remote control, written by /api/display?screen=&level= (see
+  // core_display_http.h — it is included after the registry, so it can reach
+  // this namespace) and consumed in update(). Knob deltas are relative, which
+  // is fine in front of the device but useless for keeping a browser-side
+  // reference view in sync: the page needs to SET screen 2, not nudge by one.
+  int requestedScreen = -1;
+  int requestedLevel = -1;
+
+  // ── OKLab, setup-time only ──────────────────────────────────────────
+  // Same math as web/src/lib/patternHarness.ts, reduced to what a baked ramp
+  // needs. Runs once per boot to fill the RAMPS tables — never per frame.
+  inline float srgbToLin(float c) {
+    return c <= 0.04045f ? c / 12.92f : powf((c + 0.055f) / 1.055f, 2.4f);
+  }
+  inline float linToSrgb(float c) {
+    float v = c <= 0.0031308f ? c * 12.92f : 1.055f * powf(c, 1.0f / 2.4f) - 0.055f;
+    return v < 0.0f ? 0.0f : (v > 1.0f ? 1.0f : v);
+  }
+  inline void srgbToOklab(float r, float g, float b, float out[3]) {
+    float lr = srgbToLin(r), lg = srgbToLin(g), lb = srgbToLin(b);
+    float l = cbrtf(0.4122214708f * lr + 0.5363325363f * lg + 0.0514459929f * lb);
+    float m = cbrtf(0.2119034982f * lr + 0.6806995451f * lg + 0.1073969566f * lb);
+    float s = cbrtf(0.0883024619f * lr + 0.2817188376f * lg + 0.6299787005f * lb);
+    out[0] = 0.2104542553f * l + 0.793617785f * m - 0.0040720468f * s;
+    out[1] = 1.9779984951f * l - 2.428592205f * m + 0.4505937099f * s;
+    out[2] = 0.0259040371f * l + 0.7827717662f * m - 0.808675766f * s;
+  }
+  inline void oklabToSrgb(const float lab[3], uint8_t out[3]) {
+    float l_ = lab[0] + 0.3963377774f * lab[1] + 0.2158037573f * lab[2];
+    float m_ = lab[0] - 0.1055613458f * lab[1] - 0.0638541728f * lab[2];
+    float s_ = lab[0] - 0.0894841775f * lab[1] - 1.291485548f * lab[2];
+    float l = l_ * l_ * l_, m = m_ * m_ * m_, s = s_ * s_ * s_;
+    float r = 4.0767416621f * l - 3.3077115913f * m + 0.2309699292f * s;
+    float g = -1.2684380046f * l + 2.6097574011f * m - 0.3413193965f * s;
+    float b = -0.0041960863f * l - 0.7034186147f * m + 1.707614701f * s;
+    out[0] = (uint8_t)(linToSrgb(r) * 255.0f + 0.5f);
+    out[1] = (uint8_t)(linToSrgb(g) * 255.0f + 0.5f);
+    out[2] = (uint8_t)(linToSrgb(b) * 255.0f + 0.5f);
+  }
+
+  // RAMPS screen tables: [0] b→y sRGB, [1] b→y OKLab, [2] r→b sRGB,
+  // [3] r→b OKLab. 1.5 KB of DRAM, filled once in setup().
+  uint8_t ramps[4][PANEL_RES_W][3];
+
+  inline void bakeRampPair(int srgbRow, int oklabRow,
+                           uint8_t r0, uint8_t g0, uint8_t b0,
+                           uint8_t r1, uint8_t g1, uint8_t b1) {
+    float labA[3], labB[3];
+    srgbToOklab(r0 / 255.0f, g0 / 255.0f, b0 / 255.0f, labA);
+    srgbToOklab(r1 / 255.0f, g1 / 255.0f, b1 / 255.0f, labB);
+    for (int x = 0; x < PANEL_RES_W; x++) {
+      float t = (float)x / (float)(PANEL_RES_W - 1);
+      ramps[srgbRow][x][0] = (uint8_t)(r0 + (r1 - r0) * t + 0.5f);
+      ramps[srgbRow][x][1] = (uint8_t)(g0 + (g1 - g0) * t + 0.5f);
+      ramps[srgbRow][x][2] = (uint8_t)(b0 + (b1 - b0) * t + 0.5f);
+      float lab[3] = {
+        labA[0] + (labB[0] - labA[0]) * t,
+        labA[1] + (labB[1] - labA[1]) * t,
+        labA[2] + (labB[2] - labA[2]) * t,
+      };
+      oklabToSrgb(lab, ramps[oklabRow][x]);
+    }
+  }
+
+  void setup() {
+    bakeRampPair(0, 1, 0, 0, 255, 255, 255, 0);   // blue → yellow
+    bakeRampPair(2, 3, 255, 0, 0, 0, 0, 255);     // red → blue
+  }
+
+  void update(float dt, const InputFrame& input) {
+    if (requestedScreen >= 0) {
+      screen = requestedScreen % NUM_SCREENS;
+      requestedScreen = -1;
+      indicatorTimer = 1.5f;
+    }
+    if (requestedLevel >= 0) {
+      whiteLevel = requestedLevel < 8 ? 8 : (requestedLevel > 255 ? 255 : requestedLevel);
+      requestedLevel = -1;
+    }
+    if (input.knobDeltas[0] != 0) {
+      screen = ((screen + input.knobDeltas[0]) % NUM_SCREENS + NUM_SCREENS) % NUM_SCREENS;
+      indicatorTimer = 1.5f;
+    }
+    if (input.knobDeltas[1] != 0) {
+      whiteLevel += input.knobDeltas[1] * 8;
+      if (whiteLevel < 8) whiteLevel = 8;
+      if (whiteLevel > 255) whiteLevel = 255;
+    }
+    if (indicatorTimer > 0.0f) indicatorTimer -= dt;
+  }
+
+  inline void drawWhite() {
+    uint8_t v = (uint8_t)whiteLevel;
+    for (int y = 0; y < PANEL_RES_H; y++)
+      for (int x = 0; x < PANEL_RES_W; x++)
+        PFCanvas::setPixel(x, y, v, v, v);
+  }
+
+  inline void drawGrays() {
+    for (int y = 0; y < PANEL_RES_H; y++) {
+      for (int x = 0; x < PANEL_RES_W; x++) {
+        uint8_t v;
+        if (y < PANEL_RES_H / 2) {
+          v = (uint8_t)((x / 8) * 17);              // 16 steps, 0..255
+        } else {
+          v = (uint8_t)((x * 255) / (PANEL_RES_W - 1));  // smooth
+        }
+        PFCanvas::setPixel(x, y, v, v, v);
+      }
+    }
+  }
+
+  inline void drawColors() {
+    static const uint8_t BARS[8][3] = {
+      {255, 0, 0}, {0, 255, 0}, {0, 0, 255}, {0, 255, 255},
+      {255, 0, 255}, {255, 255, 0}, {255, 255, 255}, {0, 0, 0},
+    };
+    for (int y = 0; y < PANEL_RES_H; y++) {
+      bool half = y >= PANEL_RES_H / 2;
+      for (int x = 0; x < PANEL_RES_W; x++) {
+        const uint8_t* c = BARS[(x / 16) & 7];
+        if (half) PFCanvas::setPixel(x, y, c[0] >> 1, c[1] >> 1, c[2] >> 1);
+        else PFCanvas::setPixel(x, y, c[0], c[1], c[2]);
+      }
+    }
+  }
+
+  inline void drawRamps() {
+    for (int y = 0; y < PANEL_RES_H; y++) {
+      int band = y / (PANEL_RES_H / 4);
+      if (band > 3) band = 3;
+      // 1px black rule between bands so the pairs read as separate strips.
+      bool rule = (y % (PANEL_RES_H / 4)) == 0 && y != 0;
+      for (int x = 0; x < PANEL_RES_W; x++) {
+        if (rule) PFCanvas::setPixel(x, y, 0, 0, 0);
+        else PFCanvas::setPixel(x, y, ramps[band][x][0], ramps[band][x][1], ramps[band][x][2]);
+      }
+    }
+  }
+
+  void draw() {
+    switch (screen) {
+      case 0: drawWhite(); break;
+      case 1: drawGrays(); break;
+      case 2: drawColors(); break;
+      default: drawRamps(); break;
+    }
+
+    // Screen indicator, shown briefly after a switch so it never pollutes the
+    // measurement: one 2×2 dot per screen along the bottom-left, current lit.
+    if (indicatorTimer > 0.0f) {
+      for (int i = 0; i < NUM_SCREENS; i++) {
+        uint8_t v = (i == screen) ? 255 : 60;
+        for (int dy = 0; dy < 2; dy++)
+          for (int dx = 0; dx < 2; dx++)
+            PFCanvas::setPixel(2 + i * 4 + dx, PANEL_RES_H - 4 + dy, v, i == screen ? 90 : 60, 30);
+      }
+    }
+
+    PFCanvas::present();
+  }
+} // namespace CalibPattern

--- a/firmware/patternflow/src/core_canvas.h
+++ b/firmware/patternflow/src/core_canvas.h
@@ -52,18 +52,36 @@ inline uint8_t gammaLUT_G[256];
 inline uint8_t gammaLUT_B[256];
 inline bool gammaLUTReady = false;
 
+// Runtime copies of the config.h calibration constants. /api/display (see
+// core_display_http.h) edits these live so white balance and saturation can be
+// tuned by eye against the physical panel instead of by reflashing per guess;
+// the converged numbers then become the config.h defaults. Setters only clear
+// gammaLUTReady — present() already rebuilds the LUT lazily, so a handler
+// never does the powf work itself. Values reset to config.h on reboot.
+inline float gammaR = LED_GAMMA_R;
+inline float gammaG = LED_GAMMA_G;
+inline float gammaB = LED_GAMMA_B;
+inline float wbR = LED_WB_R;
+inline float wbG = LED_WB_G;
+inline float wbB = LED_WB_B;
+inline float satBoost = LED_SAT_BOOST;
 
-
-// Saturation boost as 8.8 fixed-point. 256 = identity (no boost). Built
-// once from LED_SAT_BOOST so present()'s inner loop avoids floats.
+// Saturation boost as 8.8 fixed-point. 256 = identity; below 256 desaturates
+// toward luma (the blit's math is y + (c - y) * q8 >> 8, so both directions
+// work). Built once from LED_SAT_BOOST so present()'s inner loop avoids floats.
 inline int satBoostQ8 = (int)(LED_SAT_BOOST * 256.0f + 0.5f);
+
+inline void setSatBoost(float boost) {
+  satBoost = boost;
+  satBoostQ8 = (int)(boost * 256.0f + 0.5f);
+}
 
 inline void buildGammaLUT() {
   for (int i = 0; i < 256; i++) {
     float n = i / 255.0f;
-    float rOut = powf(n, LED_GAMMA_R) * 255.0f * LED_WB_R + 0.5f;
-    float gOut = powf(n, LED_GAMMA_G) * 255.0f * LED_WB_G + 0.5f;
-    float bOut = powf(n, LED_GAMMA_B) * 255.0f * LED_WB_B + 0.5f;
+    float rOut = powf(n, gammaR) * 255.0f * wbR + 0.5f;
+    float gOut = powf(n, gammaG) * 255.0f * wbG + 0.5f;
+    float bOut = powf(n, gammaB) * 255.0f * wbB + 0.5f;
     gammaLUT_R[i] = (uint8_t)(rOut > 255.0f ? 255.0f : (rOut < 0.0f ? 0.0f : rOut));
     gammaLUT_G[i] = (uint8_t)(gOut > 255.0f ? 255.0f : (gOut < 0.0f ? 0.0f : gOut));
     gammaLUT_B[i] = (uint8_t)(bOut > 255.0f ? 255.0f : (bOut < 0.0f ? 0.0f : bOut));

--- a/firmware/patternflow/src/core_display_http.h
+++ b/firmware/patternflow/src/core_display_http.h
@@ -1,0 +1,133 @@
+// ═══════════════════════════════════════════════════════════
+// PatternFlow - Runtime display calibration API
+//
+//   GET /api/display                          current values as JSON
+//   GET /api/display?wb_g=0.72&sat=0.9&...    set any subset, then JSON
+//
+// Params: wb_r wb_g wb_b (0..1.5) · gamma_r gamma_g gamma_b (0.2..5) ·
+//         sat (0..4) · screen (0..3 summons the test-card overlay, -1
+//         dismisses it) · level (8..255, WHITE screen drive).
+//         Color values land in PFCanvas's runtime calibration
+//         state; present() rebuilds its LUT lazily, so the handler does no
+//         per-pixel work. Values are session-only — reboot restores the
+//         config.h defaults. The point is the tuning loop: put a white/test
+//         card on the panel, drag sliders until it looks right, then copy the
+//         converged numbers into config.h as the new shipped defaults.
+//
+// GET on purpose (not POST): tunable from a browser address bar, and the
+// local tuning page can fire simple no-preflight requests. CORS is open —
+// the endpoint mutates nothing persistent and carries no secrets.
+// License: MIT
+// ═══════════════════════════════════════════════════════════
+#pragma once
+
+#include "../net_config.h"
+
+// Same default as core_status_http.h, so this header works whatever the
+// include order — the API rides that module's WebServer.
+#ifndef PF_STATUS_HTTP_ENABLED
+#define PF_STATUS_HTTP_ENABLED 1
+#endif
+
+// The calibration API is a keeper (panels vary; every owner tunes their own
+// numbers), but it is also optional tooling: compile it out with
+// -DPF_DISPLAY_HTTP_ENABLED=0 and the sketch builds with no other change.
+#ifndef PF_DISPLAY_HTTP_ENABLED
+#define PF_DISPLAY_HTTP_ENABLED 1
+#endif
+
+#if PF_STATUS_HTTP_ENABLED && PF_DISPLAY_HTTP_ENABLED
+#include "core_canvas.h"
+#include "core_status_http.h"       // shared WebServer
+#include "../presets/preset_calib.h"  // absolute screen/level control
+#endif
+
+// Global brightness lives in the sketch (K1 longpress UI + NVS); shown here
+// read-only for context while tuning.
+extern uint8_t currentBrightness;
+
+namespace PatternflowDisplayHttp {
+
+#if PF_STATUS_HTTP_ENABLED
+
+inline WebServer& server() { return PatternflowStatusHttp::server(); }
+
+inline bool initialized = false;
+
+inline float clampf(float v, float lo, float hi) {
+  return v < lo ? lo : (v > hi ? hi : v);
+}
+
+// Reads one float query param into `target` if present. Returns true when the
+// LUT has to be rebuilt (any gamma/WB change).
+inline bool applyArg(const char* name, float& target, float lo, float hi) {
+  if (!server().hasArg(name)) return false;
+  target = clampf(server().arg(name).toFloat(), lo, hi);
+  return true;
+}
+
+inline void handleDisplay() {
+  bool lutDirty = false;
+  lutDirty |= applyArg("wb_r", PFCanvas::wbR, 0.0f, 1.5f);
+  lutDirty |= applyArg("wb_g", PFCanvas::wbG, 0.0f, 1.5f);
+  lutDirty |= applyArg("wb_b", PFCanvas::wbB, 0.0f, 1.5f);
+  lutDirty |= applyArg("gamma_r", PFCanvas::gammaR, 0.2f, 5.0f);
+  lutDirty |= applyArg("gamma_g", PFCanvas::gammaG, 0.2f, 5.0f);
+  lutDirty |= applyArg("gamma_b", PFCanvas::gammaB, 0.2f, 5.0f);
+  if (lutDirty) PFCanvas::gammaLUTReady = false;
+
+  if (server().hasArg("sat")) {
+    PFCanvas::setSatBoost(clampf(server().arg("sat").toFloat(), 0.0f, 4.0f));
+  }
+
+  // Test-card overlay control. ?screen=N (0..3) summons the card over the
+  // running pattern and shows that screen; ?screen=-1 dismisses it and the
+  // pattern underneath resumes. ?level= sets the WHITE screen's drive.
+  if (server().hasArg("screen")) {
+    int requested = (int)server().arg("screen").toInt();
+    if (requested >= 0) {
+      CalibPattern::requestedScreen = requested;
+      CalibPattern::overrideOn = true;
+    } else {
+      CalibPattern::overrideOn = false;
+    }
+  }
+  if (server().hasArg("level")) {
+    CalibPattern::requestedLevel = (int)server().arg("level").toInt();
+  }
+
+  // snprintf, not String: this endpoint is hit continuously while somebody
+  // drags a slider, and the shared heap is the scarcest thing on the board.
+  char json[256];
+  snprintf(json, sizeof(json),
+           "{\"wb_r\":%.3f,\"wb_g\":%.3f,\"wb_b\":%.3f,"
+           "\"gamma_r\":%.3f,\"gamma_g\":%.3f,\"gamma_b\":%.3f,"
+           "\"sat\":%.3f,\"brightness\":%u,\"calib\":%d,\"screen\":%d,\"level\":%d}",
+           PFCanvas::wbR, PFCanvas::wbG, PFCanvas::wbB,
+           PFCanvas::gammaR, PFCanvas::gammaG, PFCanvas::gammaB,
+           PFCanvas::satBoost, (unsigned)currentBrightness,
+           CalibPattern::overrideOn ? 1 : 0,
+           CalibPattern::screen, CalibPattern::whiteLevel);
+
+  server().sendHeader("Cache-Control", "no-store");
+  server().sendHeader("Access-Control-Allow-Origin", "*");
+  server().send(200, "application/json", json);
+}
+
+inline void begin() {
+  if (initialized) return;
+  if (WiFi.status() != WL_CONNECTED) return;
+
+  server().on("/api/display", HTTP_GET, handleDisplay);
+
+  initialized = true;
+  Serial.printf("[DISPLAY] Ready - http://%s.local/api/display\n", PF_OTA_HOSTNAME);
+}
+
+#else   // PF_STATUS_HTTP_ENABLED && PF_DISPLAY_HTTP_ENABLED
+
+inline void begin() {}
+
+#endif  // PF_STATUS_HTTP_ENABLED && PF_DISPLAY_HTTP_ENABLED
+
+}  // namespace PatternflowDisplayHttp

--- a/firmware/patternflow/src/core_patterns_http.h
+++ b/firmware/patternflow/src/core_patterns_http.h
@@ -539,6 +539,51 @@ inline void handleUploadDone() {
   sendJsonAndClose(200, body);
 }
 
+// ── Remote pattern selection ─────────────────────────────────────────
+// GET /api/patterns/select?index=N  (or ?name=<display name>) queues a switch;
+// the sketch's loop() consumes it exactly like an OSC pattern-index command.
+// Deferred on principle rather than measured need: a module activation reads
+// FATFS and runs the relocator, and this file's own history says never to do
+// filesystem work inside an HTTP transaction.
+inline int pendingSelectIdx = -1;
+
+inline bool consumeSelectIdx(int& out) {
+  if (pendingSelectIdx < 0) return false;
+  out = pendingSelectIdx;
+  pendingSelectIdx = -1;
+  return true;
+}
+
+inline void handleSelect() {
+  int index = -1;
+  if (server().hasArg("index")) {
+    index = server().arg("index").toInt();
+  } else if (server().hasArg("name")) {
+    String name = server().arg("name");
+    for (int i = 0; i < NUM_PATTERNS; i++) {
+      if (name.equals(patterns[i].name)) {
+        index = i;
+        break;
+      }
+    }
+  }
+
+  server().sendHeader("Cache-Control", "no-store");
+  server().sendHeader("Access-Control-Allow-Origin", "*");
+  if (index < 0 || index >= NUM_PATTERNS) {
+    server().send(404, "application/json", "{\"ok\":false,\"error\":\"no such pattern\"}");
+    return;
+  }
+
+  pendingSelectIdx = index;
+  String body = "{\"ok\":true,\"index\":";
+  body += index;
+  body += ",\"name\":\"";
+  body += patterns[index].name;
+  body += "\"}";
+  server().send(200, "application/json", body);
+}
+
 inline void begin() {
   if (initialized) return;
   if (WiFi.status() != WL_CONNECTED) return;
@@ -549,6 +594,7 @@ inline void begin() {
   server().collectHeaders(headerKeys, 2);
 
   server().on("/patterns", HTTP_GET, handleIndex);
+  server().on("/api/patterns/select", HTTP_GET, handleSelect);
   server().on("/api/patterns", HTTP_GET, handleList);
   server().on("/api/patterns", HTTP_POST, handleUploadDone, handleUpload);
   // Raw-body PUT is what the page actually uses: the WebServer's multipart
@@ -574,6 +620,7 @@ inline void begin() {
 inline bool isCompiledIn() { return false; }
 inline void begin() {}
 inline void tick() {}
+inline bool consumeSelectIdx(int&) { return false; }
 
 #endif  // PF_PATTERNS_HTTP_ENABLED
 

--- a/web/public/panel-tuner.html
+++ b/web/public/panel-tuner.html
@@ -1,0 +1,339 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Patternflow Panel Tuner</title>
+<style>
+  :root { color-scheme: dark; }
+  body {
+    margin: 0; padding: 24px; background: #121110; color: #e8e2d6;
+    font: 13px/1.5 "JetBrains Mono", Consolas, monospace;
+    max-width: 580px; margin-inline: auto;
+  }
+  h1 { font-size: 15px; letter-spacing: 0.06em; text-transform: uppercase; }
+  h1 .dot { color: #e8552e; }
+  fieldset { border: 1px solid #3a362f; border-radius: 4px; margin: 0 0 14px; padding: 12px 14px; }
+  legend { padding: 0 6px; font-size: 11px; text-transform: uppercase; color: #a89f8d; }
+  label { display: block; margin: 8px 0 2px; font-size: 11px; color: #a89f8d; }
+  .row { display: flex; align-items: center; gap: 10px; }
+  .row input[type=range] { flex: 1; accent-color: #e8552e; }
+  .val { width: 52px; text-align: right; font-variant-numeric: tabular-nums; }
+  button {
+    background: #1e1c19; color: #e8e2d6; border: 1px solid #3a362f; border-radius: 3px;
+    padding: 6px 12px; font: inherit; font-size: 12px; cursor: pointer;
+  }
+  button:hover { border-color: #e8552e; }
+  button.primary { border-color: #e8552e; color: #ffb59e; }
+  button.active { background: #3a2119; border-color: #e8552e; color: #ffb59e; }
+  input[type=text] {
+    background: #1e1c19; color: #e8e2d6; border: 1px solid #3a362f; border-radius: 3px;
+    padding: 6px 8px; font: inherit; width: 100%; box-sizing: border-box;
+  }
+  #status { font-size: 11px; color: #a89f8d; min-height: 1.3em; }
+  #status .ok { color: #7fdc8a; } #status .err { color: #ff7a6e; }
+  pre {
+    background: #1a1815; border: 1px solid #3a362f; border-radius: 4px;
+    padding: 10px 12px; font-size: 11px; overflow-x: auto; user-select: all;
+  }
+  .btnrow { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 6px; }
+  .hint { font-size: 11px; color: #6d675c; margin: 6px 0 0; }
+  details { margin-top: 10px; }
+  summary { cursor: pointer; font-size: 11px; color: #a89f8d; text-transform: uppercase; }
+  #ref {
+    display: block; width: 100%; aspect-ratio: 2 / 1; image-rendering: pixelated;
+    border: 1px solid #3a362f; border-radius: 2px; background: #000; margin-bottom: 8px;
+  }
+</style>
+</head>
+<body>
+<h1><span class="dot">●</span> Panel Tuner</h1>
+
+<fieldset>
+  <legend>Device</legend>
+  <div class="row">
+    <input type="text" id="base" value="http://192.168.0.180">
+    <button id="connect" class="primary">Connect</button>
+  </div>
+  <p id="status">not connected</p>
+  <p class="hint">Works from a plain-http origin (localhost dev server) on the same LAN as the
+  device. An https origin cannot reach a http device — browsers block mixed content.</p>
+</fieldset>
+
+<fieldset>
+  <legend>Reference (this canvas = sRGB intent) ↔ LED</legend>
+  <canvas id="ref" width="512" height="256"></canvas>
+  <div class="btnrow">
+    <button data-screen="0">WHITE</button>
+    <button data-screen="1">GRAYS</button>
+    <button data-screen="2">COLORS</button>
+    <button data-screen="3">RAMPS</button>
+    <button id="dismiss" class="primary">Resume pattern</button>
+  </div>
+  <label>White level (WHITE screen only)</label>
+  <div class="row"><input type="range" id="level" min="8" max="255" step="1" value="255"><span class="val" id="level_v">255</span></div>
+  <p class="hint">A screen button overlays the test card on the panel — the running pattern
+  freezes underneath and resumes on <b>Resume pattern</b> (or via K4-hold at the device).
+  This canvas shows the same frame in raw sRGB: your monitor is the design intent, so tune
+  the sliders until the LED gives the same <b>impression</b>. Absolute brightness will differ —
+  match tint, saturation and tonal steps, not nits.</p>
+</fieldset>
+
+<fieldset>
+  <legend>White balance</legend>
+  <label>WB R</label>
+  <div class="row"><input type="range" id="wb_r" min="0.40" max="1.00" step="0.005" value="1"><span class="val" id="wb_r_v">1.000</span></div>
+  <label>WB G</label>
+  <div class="row"><input type="range" id="wb_g" min="0.40" max="1.00" step="0.005" value="1"><span class="val" id="wb_g_v">1.000</span></div>
+  <label>WB B</label>
+  <div class="row"><input type="range" id="wb_b" min="0.40" max="1.00" step="0.005" value="1"><span class="val" id="wb_b_v">1.000</span></div>
+  <div class="btnrow">
+    <button id="wbIdentity">identity (1/1/1)</button>
+  </div>
+  <p class="hint">Judge on WHITE. Also drop the white level and check the tint holds at low drive.</p>
+</fieldset>
+
+<fieldset>
+  <legend>Saturation</legend>
+  <div class="row"><input type="range" id="sat" min="0.00" max="2.00" step="0.01" value="1"><span class="val" id="sat_v">1.00</span></div>
+  <p class="hint">Mathematically a no-op on white and gray — judge on COLORS (the 50%-drive
+  bottom row), RAMPS, or a real pattern. 1.00 = identity; this panel family tends to need a
+  strong boost to match a monitor side by side.</p>
+</fieldset>
+
+<details>
+  <summary>Gamma (advanced — the driver already applies CIE1931; leave at 1.0 unless you know why)</summary>
+  <fieldset style="margin-top:8px">
+    <label>Gamma R</label>
+    <div class="row"><input type="range" id="gamma_r" min="0.50" max="3.00" step="0.01" value="1"><span class="val" id="gamma_r_v">1.00</span></div>
+    <label>Gamma G</label>
+    <div class="row"><input type="range" id="gamma_g" min="0.50" max="3.00" step="0.01" value="1"><span class="val" id="gamma_g_v">1.00</span></div>
+    <label>Gamma B</label>
+    <div class="row"><input type="range" id="gamma_b" min="0.50" max="3.00" step="0.01" value="1"><span class="val" id="gamma_b_v">1.00</span></div>
+  </fieldset>
+</details>
+
+<fieldset>
+  <legend>config.h snippet (copy this once the values converge)</legend>
+  <pre id="snippet">—</pre>
+  <p class="hint">Values set here are session-only — a reboot restores the config.h defaults.
+  To make them permanent, paste this block into firmware/patternflow/config.h and reflash.</p>
+</fieldset>
+
+<script>
+"use strict";
+const $ = (id) => document.getElementById(id);
+const PARAMS = ["wb_r", "wb_g", "wb_b", "sat", "gamma_r", "gamma_g", "gamma_b"];
+const W = 128, H = 64;
+
+let base = $("base").value;
+let screenIdx = 0;
+let overlayOn = false;
+let whiteLevel = 255;
+
+// ── Reference rendering: pixel-for-pixel the same logic as the firmware's
+// preset_calib.h, drawn in raw sRGB — the monitor shows the design intent.
+
+function srgbToLin(c) { return c <= 0.04045 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4); }
+function linToSrgb(c) {
+  const v = c <= 0.0031308 ? c * 12.92 : 1.055 * Math.pow(c, 1 / 2.4) - 0.055;
+  return Math.max(0, Math.min(1, v));
+}
+function srgbToOklab(r, g, b) {
+  const lr = srgbToLin(r), lg = srgbToLin(g), lb = srgbToLin(b);
+  const l = Math.cbrt(0.4122214708 * lr + 0.5363325363 * lg + 0.0514459929 * lb);
+  const m = Math.cbrt(0.2119034982 * lr + 0.6806995451 * lg + 0.1073969566 * lb);
+  const s = Math.cbrt(0.0883024619 * lr + 0.2817188376 * lg + 0.6299787005 * lb);
+  return [
+    0.2104542553 * l + 0.793617785 * m - 0.0040720468 * s,
+    1.9779984951 * l - 2.428592205 * m + 0.4505937099 * s,
+    0.0259040371 * l + 0.7827717662 * m - 0.808675766 * s,
+  ];
+}
+function oklabToSrgb(lab) {
+  const l_ = lab[0] + 0.3963377774 * lab[1] + 0.2158037573 * lab[2];
+  const m_ = lab[0] - 0.1055613458 * lab[1] - 0.0638541728 * lab[2];
+  const s_ = lab[0] - 0.0894841775 * lab[1] - 1.291485548 * lab[2];
+  const l = l_ ** 3, m = m_ ** 3, s = s_ ** 3;
+  return [
+    Math.round(linToSrgb(4.0767416621 * l - 3.3077115913 * m + 0.2309699292 * s) * 255),
+    Math.round(linToSrgb(-1.2684380046 * l + 2.6097574011 * m - 0.3413193965 * s) * 255),
+    Math.round(linToSrgb(-0.0041960863 * l - 0.7034186147 * m + 1.707614701 * s) * 255),
+  ];
+}
+
+// ramps[band][x] = [r,g,b] — bands 0/1: blue→yellow in sRGB/OKLab, 2/3: red→blue.
+const ramps = [[], [], [], []];
+(function bake() {
+  const pairs = [
+    [0, 1, [0, 0, 255], [255, 255, 0]],
+    [2, 3, [255, 0, 0], [0, 0, 255]],
+  ];
+  for (const [si, oi, a, b] of pairs) {
+    const la = srgbToOklab(a[0] / 255, a[1] / 255, a[2] / 255);
+    const lb = srgbToOklab(b[0] / 255, b[1] / 255, b[2] / 255);
+    for (let x = 0; x < W; x++) {
+      const t = x / (W - 1);
+      ramps[si][x] = [0, 1, 2].map((i) => Math.round(a[i] + (b[i] - a[i]) * t));
+      ramps[oi][x] = oklabToSrgb([0, 1, 2].map((i) => la[i] + (lb[i] - la[i]) * t));
+    }
+  }
+})();
+
+const off = document.createElement("canvas");
+off.width = W; off.height = H;
+
+function renderRef() {
+  const octx = off.getContext("2d");
+  const img = octx.createImageData(W, H);
+  const d = img.data;
+  const put = (x, y, r, g, b) => {
+    const i = (y * W + x) * 4;
+    d[i] = r; d[i + 1] = g; d[i + 2] = b; d[i + 3] = 255;
+  };
+  const BARS = [
+    [255, 0, 0], [0, 255, 0], [0, 0, 255], [0, 255, 255],
+    [255, 0, 255], [255, 255, 0], [255, 255, 255], [0, 0, 0],
+  ];
+  for (let y = 0; y < H; y++) {
+    for (let x = 0; x < W; x++) {
+      if (screenIdx === 0) {
+        put(x, y, whiteLevel, whiteLevel, whiteLevel);
+      } else if (screenIdx === 1) {
+        const v = y < H / 2 ? Math.floor(x / 8) * 17 : Math.round((x * 255) / (W - 1));
+        put(x, y, v, v, v);
+      } else if (screenIdx === 2) {
+        const c = BARS[Math.floor(x / 16) & 7];
+        const s = y >= H / 2 ? 1 : 0;
+        put(x, y, c[0] >> s, c[1] >> s, c[2] >> s);
+      } else {
+        const band = Math.min(3, Math.floor(y / (H / 4)));
+        const rule = y % (H / 4) === 0 && y !== 0;
+        const c = rule ? [0, 0, 0] : ramps[band][x];
+        put(x, y, c[0], c[1], c[2]);
+      }
+    }
+  }
+  octx.putImageData(img, 0, 0);
+  const ctx = $("ref").getContext("2d");
+  ctx.imageSmoothingEnabled = false;
+  ctx.drawImage(off, 0, 0, 512, 256);
+}
+
+// ── Serialized request queue: the device is a single-threaded WebServer that
+// answers between frames. One request in flight, latest state wins, 150ms gap.
+let inFlight = false;
+let queued = null;
+let lastSentAt = 0;
+
+async function pump() {
+  if (inFlight || queued === null) return;
+  const gap = Date.now() - lastSentAt;
+  if (gap < 150) { setTimeout(pump, 150 - gap); return; }
+  const url = queued;
+  queued = null;
+  inFlight = true;
+  lastSentAt = Date.now();
+  try {
+    const res = await fetch(url);
+    const json = await res.json();
+    if (json.wb_r !== undefined) reflect(json, false);
+    setStatus(`<span class="ok">ok</span> ${url.replace(base, "")}`);
+  } catch (err) {
+    setStatus(`<span class="err">FAIL</span> ${err.message} — check device power / Wi-Fi, then Connect again`);
+  }
+  inFlight = false;
+  pump();
+}
+
+function send(query) {
+  queued = `${base}/api/display${query}`;
+  pump();
+}
+
+function setStatus(html) { $("status").innerHTML = html; }
+function fmt(id, v) { return id.startsWith("wb") ? Number(v).toFixed(3) : Number(v).toFixed(2); }
+
+function setScreenButtons() {
+  document.querySelectorAll("[data-screen]").forEach((b) =>
+    b.classList.toggle("active", overlayOn && Number(b.dataset.screen) === screenIdx));
+}
+
+// adoptView: on connect, take the device's current overlay/screen/level into
+// the page; during slider echoes leave the view alone (the page is authoritative).
+function reflect(json, adoptView) {
+  for (const p of PARAMS) {
+    if (json[p] === undefined) continue;
+    $(p).value = json[p];
+    $(`${p}_v`).textContent = fmt(p, json[p]);
+  }
+  if (adoptView && json.screen !== undefined) {
+    screenIdx = json.screen;
+    overlayOn = json.calib === 1;
+    whiteLevel = json.level;
+    $("level").value = whiteLevel;
+    $("level_v").textContent = whiteLevel;
+    setScreenButtons();
+    renderRef();
+  }
+  $("snippet").textContent =
+    `#define LED_GAMMA_R ${Number(json.gamma_r).toFixed(2)}f\n` +
+    `#define LED_GAMMA_G ${Number(json.gamma_g).toFixed(2)}f\n` +
+    `#define LED_GAMMA_B ${Number(json.gamma_b).toFixed(2)}f\n\n` +
+    `#define LED_WB_R ${Number(json.wb_r).toFixed(3)}f\n` +
+    `#define LED_WB_G ${Number(json.wb_g).toFixed(3)}f\n` +
+    `#define LED_WB_B ${Number(json.wb_b).toFixed(3)}f\n\n` +
+    `#define LED_SAT_BOOST ${Number(json.sat).toFixed(2)}f\n\n` +
+    `// brightness (knob-set, NVS): ${json.brightness}`;
+}
+
+for (const p of PARAMS) {
+  $(p).addEventListener("input", () => {
+    $(`${p}_v`).textContent = fmt(p, $(p).value);
+    send(`?${p}=${$(p).value}`);
+  });
+}
+
+$("level").addEventListener("input", () => {
+  whiteLevel = Number($("level").value);
+  $("level_v").textContent = whiteLevel;
+  if (screenIdx === 0) renderRef();
+  send(`?level=${whiteLevel}`);
+});
+
+// A screen button summons the overlay on the panel and paints the same frame
+// here; Resume dismisses it and the pattern underneath carries on.
+document.querySelectorAll("[data-screen]").forEach((btn) => {
+  btn.addEventListener("click", () => {
+    screenIdx = Number(btn.dataset.screen);
+    overlayOn = true;
+    setScreenButtons();
+    renderRef();
+    send(`?screen=${screenIdx}`);
+  });
+});
+
+$("dismiss").addEventListener("click", () => {
+  overlayOn = false;
+  setScreenButtons();
+  send("?screen=-1");
+});
+
+$("wbIdentity").addEventListener("click", () => send("?wb_r=1&wb_g=1&wb_b=1"));
+
+$("connect").addEventListener("click", async () => {
+  base = $("base").value.replace(/\/+$/, "");
+  try {
+    const d = await fetch(`${base}/api/display`);
+    const json = await d.json();
+    reflect(json, true);
+    setStatus(`<span class="ok">connected</span> · brightness ${json.brightness}/255 · test card ${json.calib === 1 ? "on" : "off"}`);
+  } catch (err) {
+    setStatus(`<span class="err">FAIL</span> ${err.message}`);
+  }
+});
+
+renderRef();
+</script>
+</body>
+</html>

--- a/web/public/pattern-sandbox.html
+++ b/web/public/pattern-sandbox.html
@@ -103,8 +103,105 @@ function hsvToRgbTuple(h, s, v) {
   return [Math.round(r * 255), Math.round(g * 255), Math.round(b * 255)];
 }
 
+// ── OKLab / OKLCH (port of patternHarness.ts — keep in sync) ────────────────
+// Perceptual interpolation: sRGB/HSV blends drift in lightness; OKLab keeps it
+// honest, OKLCH follows the hue arc. Out-of-gamut blends are pulled back by
+// reducing chroma at constant L and hue (never per-channel clipping).
+
+function srgbChannelToLinear(c) {
+  c /= 255;
+  return c <= 0.04045 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
+}
+
+function linearChannelToSrgb(c) {
+  var v = c <= 0.0031308 ? c * 12.92 : 1.055 * Math.pow(c, 1 / 2.4) - 0.055;
+  return Math.max(0, Math.min(1, v)) * 255;
+}
+
+function srgbToOklab(r, g, b) {
+  var lr = srgbChannelToLinear(r);
+  var lg = srgbChannelToLinear(g);
+  var lb = srgbChannelToLinear(b);
+  var l = Math.cbrt(0.4122214708 * lr + 0.5363325363 * lg + 0.0514459929 * lb);
+  var m = Math.cbrt(0.2119034982 * lr + 0.6806995451 * lg + 0.1073969566 * lb);
+  var s = Math.cbrt(0.0883024619 * lr + 0.2817188376 * lg + 0.6299787005 * lb);
+  return [
+    0.2104542553 * l + 0.793617785 * m - 0.0040720468 * s,
+    1.9779984951 * l - 2.428592205 * m + 0.4505937099 * s,
+    0.0259040371 * l + 0.7827717662 * m - 0.808675766 * s
+  ];
+}
+
+function oklabToLinearRgb(L, A, B) {
+  var l_ = L + 0.3963377774 * A + 0.2158037573 * B;
+  var m_ = L - 0.1055613458 * A - 0.0638541728 * B;
+  var s_ = L - 0.0894841775 * A - 1.291485548 * B;
+  var l = l_ * l_ * l_;
+  var m = m_ * m_ * m_;
+  var s = s_ * s_ * s_;
+  return [
+    4.0767416621 * l - 3.3077115913 * m + 0.2309699292 * s,
+    -1.2684380046 * l + 2.6097574011 * m - 0.3413193965 * s,
+    -0.0041960863 * l - 0.7034186147 * m + 1.707614701 * s
+  ];
+}
+
+var GAMUT_EPS = 1e-4;
+
+function inLinearGamut(rgb) {
+  return (
+    rgb[0] >= -GAMUT_EPS && rgb[0] <= 1 + GAMUT_EPS &&
+    rgb[1] >= -GAMUT_EPS && rgb[1] <= 1 + GAMUT_EPS &&
+    rgb[2] >= -GAMUT_EPS && rgb[2] <= 1 + GAMUT_EPS
+  );
+}
+
+function oklabToSrgb(L, A, B) {
+  var rgb = oklabToLinearRgb(L, A, B);
+  if (!inLinearGamut(rgb)) {
+    var lo = 0;
+    var hi = 1;
+    for (var i = 0; i < 16; i++) {
+      var mid = (lo + hi) / 2;
+      if (inLinearGamut(oklabToLinearRgb(L, A * mid, B * mid))) lo = mid;
+      else hi = mid;
+    }
+    rgb = oklabToLinearRgb(L, A * lo, B * lo);
+  }
+  return [linearChannelToSrgb(rgb[0]), linearChannelToSrgb(rgb[1]), linearChannelToSrgb(rgb[2])];
+}
+
 function mixRampColors(a, b, t, mode) {
   if (mode === "smooth") t = t * t * (3 - 2 * t);
+  if (mode === "oklab" || mode === "oklchShort" || mode === "oklchLong") {
+    var oa = srgbToOklab(a[0], a[1], a[2]);
+    var ob = srgbToOklab(b[0], b[1], b[2]);
+    var L = oa[0] + (ob[0] - oa[0]) * t;
+    if (mode === "oklab") {
+      return oklabToSrgb(L, oa[1] + (ob[1] - oa[1]) * t, oa[2] + (ob[2] - oa[2]) * t);
+    }
+    var CHROMA_EPS = 1e-4;
+    var TWO_PI = Math.PI * 2;
+    var Ca = Math.sqrt(oa[1] * oa[1] + oa[2] * oa[2]);
+    var Cb = Math.sqrt(ob[1] * ob[1] + ob[2] * ob[2]);
+    var hueA = Math.atan2(oa[2], oa[1]) / TWO_PI;
+    if (hueA < 0) hueA += 1;
+    var hueB = Math.atan2(ob[2], ob[1]) / TWO_PI;
+    if (hueB < 0) hueB += 1;
+    var h1 = Ca < CHROMA_EPS ? (Cb < CHROMA_EPS ? 0 : hueB) : hueA;
+    var h2 = Cb < CHROMA_EPS ? h1 : hueB;
+    var dh = h2 - h1;
+    if (mode === "oklchShort") {
+      if (dh > 0.5) dh -= 1;
+      if (dh < -0.5) dh += 1;
+    } else {
+      if (dh > 0 && dh < 0.5) dh -= 1;
+      else if (dh <= 0 && dh > -0.5) dh += 1;
+    }
+    var C = Ca + (Cb - Ca) * t;
+    var H = (h1 + dh * t) * TWO_PI;
+    return oklabToSrgb(L, Math.cos(H) * C, Math.sin(H) * C);
+  }
   if (mode === "hsvShort" || mode === "hsvLong") {
     var ha = rgbToHsv(a[0], a[1], a[2]);
     var hb = rgbToHsv(b[0], b[1], b[2]);
@@ -168,7 +265,7 @@ function buildRampLUT(stops, mode, wrap) {
 
 var RAMP_LINE_RE = /^[ \t]*\/\/[ \t]*@ramp[ \t]+(.+)$/m;
 var RAMP_STOP_RE = /^(\d*\.?\d+):(#[0-9a-fA-F]{6})$/;
-var RAMP_MODES = ["linear", "smooth", "step", "hsvShort", "hsvLong"];
+var RAMP_MODES = ["linear", "smooth", "step", "hsvShort", "hsvLong", "oklab", "oklchShort", "oklchLong"];
 
 function parseRampAnnotation(code) {
   var match = String(code).match(RAMP_LINE_RE);

--- a/web/scripts/ramp-oklab-smoke.ts
+++ b/web/scripts/ramp-oklab-smoke.ts
@@ -1,0 +1,242 @@
+// Smoke test for the OKLab/OKLCH ramp modes: checks the conversion against
+// Björn Ottosson's published reference values, round-trips the sRGB cube,
+// asserts every mode stays finite and in-gamut across random ramps, proves the
+// oklab midpoint actually fixes the muddy sRGB middle, and — because the
+// sandbox carries a hand-ported copy of this math — diffs the plain-JS port in
+// public/pattern-sandbox.html against the TypeScript LUT byte-for-byte.
+// Run: npx tsx scripts/ramp-oklab-smoke.ts
+
+import fs from "node:fs";
+import path from "node:path";
+import vm from "node:vm";
+
+import {
+  RAMP_MODES,
+  buildRampLUT,
+  sampleRamp,
+  sampleRampRGBA,
+  srgbToOklab,
+  oklabToSrgb,
+  type ColorRamp,
+  type RampMode,
+} from "../src/lib/patternHarness";
+import { buildRampAnnotationLine, parseRampAnnotation } from "../src/lib/patternRamp";
+
+let failures = 0;
+
+function check(label: string, ok: boolean, detail?: string) {
+  if (ok) {
+    console.log(`  ok  ${label}`);
+  } else {
+    failures++;
+    console.error(`FAIL  ${label}${detail ? ` — ${detail}` : ""}`);
+  }
+}
+
+// ── 1. Reference values (bottosson.github.io/posts/oklab, table of sRGB primaries)
+const REFS: Array<{ rgb: [number, number, number]; lab: [number, number, number] }> = [
+  { rgb: [255, 255, 255], lab: [1.0, 0.0, 0.0] },
+  { rgb: [255, 0, 0], lab: [0.62796, 0.22486, 0.12585] },
+  { rgb: [0, 255, 0], lab: [0.86644, -0.23389, 0.1795] },
+  { rgb: [0, 0, 255], lab: [0.45201, -0.03246, -0.31153] },
+];
+for (const ref of REFS) {
+  const lab = srgbToOklab(...ref.rgb);
+  const maxErr = Math.max(...lab.map((v, i) => Math.abs(v - ref.lab[i])));
+  check(
+    `reference oklab of rgb(${ref.rgb.join(",")})`,
+    maxErr < 1e-3,
+    `got [${lab.map((v) => v.toFixed(5)).join(", ")}]`,
+  );
+}
+
+// ── 2. Round-trip: sRGB → OKLab → sRGB is identity within rounding
+{
+  let maxErr = 0;
+  for (let r = 0; r <= 255; r += 15) {
+    for (let g = 0; g <= 255; g += 15) {
+      for (let b = 0; b <= 255; b += 15) {
+        const [L, A, B] = srgbToOklab(r, g, b);
+        const [r2, g2, b2] = oklabToSrgb(L, A, B);
+        maxErr = Math.max(maxErr, Math.abs(r2 - r), Math.abs(g2 - g), Math.abs(b2 - b));
+      }
+    }
+  }
+  check("round-trip identity over the sRGB cube", maxErr < 1, `max channel error ${maxErr.toFixed(4)}`);
+}
+
+// ── 3. Gamut + finiteness: random ramps × every mode × dense t
+{
+  let bad = "";
+  const rand = (() => {
+    let seed = 0x9e3779b9;
+    return () => {
+      seed ^= seed << 13;
+      seed ^= seed >>> 17;
+      seed ^= seed << 5;
+      seed >>>= 0;
+      return seed / 0xffffffff;
+    };
+  })();
+  outer: for (let trial = 0; trial < 40; trial++) {
+    const stopCount = 2 + Math.floor(rand() * 3);
+    const stops = Array.from({ length: stopCount }, () => ({
+      position: Math.round(rand() * 100) / 100,
+      color: [Math.floor(rand() * 256), Math.floor(rand() * 256), Math.floor(rand() * 256)] as [
+        number,
+        number,
+        number,
+      ],
+      alpha: rand(),
+    }));
+    for (const mode of RAMP_MODES) {
+      for (const wrap of [false, true]) {
+        const ramp: ColorRamp = { stops, mode, wrap };
+        for (let i = 0; i <= 256; i++) {
+          const [r, g, b, a] = sampleRampRGBA(ramp, i / 256);
+          const finite = [r, g, b, a].every((v) => Number.isFinite(v));
+          const inRange =
+            r > -0.5 && r < 255.5 && g > -0.5 && g < 255.5 && b > -0.5 && b < 255.5 && a >= 0 && a <= 1;
+          if (!finite || !inRange) {
+            bad = `trial ${trial} mode ${mode} wrap ${wrap} t=${(i / 256).toFixed(3)} → [${r}, ${g}, ${b}, ${a}]`;
+            break outer;
+          }
+        }
+      }
+    }
+  }
+  check("all modes finite and in range over random ramps", bad === "", bad);
+}
+
+// ── 4. The muddy middle: blue→yellow keeps chroma in oklab, dies in sRGB
+{
+  const stops = [
+    { position: 0, color: [0, 0, 255] as [number, number, number] },
+    { position: 1, color: [255, 255, 0] as [number, number, number] },
+  ];
+  const chromaOfMid = (mode: RampMode) => {
+    const [r, g, b] = sampleRamp({ stops, mode, wrap: false }, 0.5);
+    const [, A, B] = srgbToOklab(r, g, b);
+    return Math.sqrt(A * A + B * B);
+  };
+  const linearC = chromaOfMid("linear");
+  const oklabC = chromaOfMid("oklab");
+  check(
+    "blue→yellow midpoint keeps chroma in oklab",
+    oklabC > linearC + 0.05,
+    `linear C=${linearC.toFixed(4)}, oklab C=${oklabC.toFixed(4)}`,
+  );
+}
+
+// ── 5. OKLCH short vs long actually take different hue paths (red→blue)
+{
+  const stops = [
+    { position: 0, color: [255, 0, 0] as [number, number, number] },
+    { position: 1, color: [0, 0, 255] as [number, number, number] },
+  ];
+  const short = sampleRamp({ stops, mode: "oklchShort", wrap: false }, 0.5);
+  const long = sampleRamp({ stops, mode: "oklchLong", wrap: false }, 0.5);
+  // Short path red→blue crosses magenta (green stays low); the long way runs
+  // through green territory.
+  check(
+    "oklchShort red→blue passes through magenta",
+    short[0] > short[1] && short[2] > short[1],
+    `mid [${short.map((v) => v.toFixed(0)).join(", ")}]`,
+  );
+  check(
+    "oklchLong red→blue takes the green route",
+    long[1] > short[1] + 40,
+    `short g=${short[1].toFixed(0)}, long g=${long[1].toFixed(0)}`,
+  );
+}
+
+// ── 6. Black→white in oklab keeps L monotone (the default-ramp guarantee)
+{
+  const lut = buildRampLUT({
+    stops: [
+      { position: 0, color: [0, 0, 0] },
+      { position: 1, color: [255, 255, 255] },
+    ],
+    mode: "oklab",
+    wrap: false,
+  });
+  let monotone = true;
+  for (let i = 1; i < 256; i++) {
+    const prev = srgbToOklab(lut[(i - 1) * 3], lut[(i - 1) * 3 + 1], lut[(i - 1) * 3 + 2])[0];
+    const cur = srgbToOklab(lut[i * 3], lut[i * 3 + 1], lut[i * 3 + 2])[0];
+    if (cur < prev - 1e-6) {
+      monotone = false;
+      break;
+    }
+  }
+  check("black→white oklab ramp has monotone L", monotone);
+}
+
+// ── 7. @ramp annotation survives the new mode tokens
+{
+  const line = buildRampAnnotationLine({
+    stops: [
+      { position: 0, color: "#081840" },
+      { position: 1, color: "#ffe89a" },
+    ],
+    mode: "oklchShort",
+    wrap: true,
+    recolor: false,
+  });
+  const parsed = parseRampAnnotation(`${line}\nexport function draw() {}`);
+  check(
+    "@ramp round-trips oklchShort",
+    parsed !== null && parsed.mode === "oklchShort" && parsed.wrap && parsed.stops.length === 2,
+    line,
+  );
+}
+
+// ── 8. Sandbox parity: the plain-JS port must build the same LUT bytes
+{
+  const html = fs.readFileSync(path.resolve(__dirname, "../public/pattern-sandbox.html"), "utf8");
+  const start = html.indexOf("// ── Color ramp");
+  const end = html.indexOf("var RAMP_LINE_RE");
+  if (start < 0 || end < 0 || end <= start) {
+    check("sandbox ramp code found", false, "slice markers missing — update ramp-oklab-smoke.ts");
+  } else {
+    const context = vm.createContext({ Math, Uint8Array, isFinite });
+    vm.runInContext(
+      `function clampByte(v){ if (!isFinite(v)) return 0; return Math.max(0, Math.min(255, Math.round(v))); }\n${html.slice(start, end)}`,
+      context,
+    );
+    const sandboxBuild = vm.runInContext("buildRampLUT", context) as (
+      stops: { position: number; color: [number, number, number] }[],
+      mode: string,
+      wrap: boolean,
+    ) => Uint8Array;
+
+    let maxDiff = 0;
+    let where = "";
+    const stops = [
+      { position: 0.0, color: [8, 24, 64] as [number, number, number] },
+      { position: 0.35, color: [255, 77, 0] as [number, number, number] },
+      { position: 0.7, color: [0, 200, 120] as [number, number, number] },
+      { position: 1.0, color: [255, 232, 154] as [number, number, number] },
+    ];
+    for (const mode of RAMP_MODES) {
+      for (const wrap of [false, true]) {
+        const ts = buildRampLUT({ stops, mode, wrap });
+        const js = sandboxBuild(stops, mode, wrap);
+        for (let i = 0; i < ts.length; i++) {
+          const diff = Math.abs(ts[i] - js[i]);
+          if (diff > maxDiff) {
+            maxDiff = diff;
+            where = `mode ${mode} wrap ${wrap} byte ${i}`;
+          }
+        }
+      }
+    }
+    check("sandbox port matches TypeScript LUT", maxDiff === 0, `max diff ${maxDiff} at ${where}`);
+  }
+}
+
+if (failures > 0) {
+  console.error(`\nramp-oklab-smoke: ${failures} FAILURE(S)`);
+  process.exit(1);
+}
+console.log("\nramp-oklab-smoke: OK");

--- a/web/src/app/pattern-lab/PatternLab.module.css
+++ b/web/src/app/pattern-lab/PatternLab.module.css
@@ -573,6 +573,32 @@
   border-width: 2px;
 }
 
+.rampLuma {
+  display: block;
+  width: 100%;
+  height: 8px;
+  margin-top: 6px;
+  border: 1px solid rgba(23, 21, 18, 0.22);
+}
+
+.rampLumaRow {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  font-family: var(--font-jetbrains), monospace;
+  font-size: 10px;
+  color: rgba(23, 21, 18, 0.5);
+  text-transform: uppercase;
+}
+
+.rampLumaBadge {
+  margin-left: auto;
+}
+
+.rampLumaMixed {
+  color: #171512;
+}
+
 .rampStopEdit {
   display: flex;
   align-items: center;

--- a/web/src/app/pattern-lab/panels/RampPanel.tsx
+++ b/web/src/app/pattern-lab/panels/RampPanel.tsx
@@ -5,11 +5,13 @@
 // a checkerboard, which is what lets a value field fade out and reveal the
 // layers underneath.
 
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 import {
   RAMP_MODES,
   buildRampLUTRGBA,
+  oklabToSrgb,
   sampleRampRGBA,
+  srgbToOklab,
   type RampMode,
 } from "@/lib/patternHarness";
 import { codeUsesValueField } from "@/lib/patternRamp";
@@ -23,6 +25,20 @@ function rgbToHex(r: number, g: number, b: number): string {
   const toByte = (value: number) => Math.max(0, Math.min(255, Math.round(value)));
   return `#${((toByte(r) << 16) | (toByte(g) << 8) | toByte(b)).toString(16).padStart(6, "0")}`;
 }
+
+/** "hsvShort" → "hsv short" — camelCase mode ids read as plain words. */
+function modeLabel(mode: string): string {
+  return mode.replace(/([A-Z])/g, " $1").toLowerCase();
+}
+
+type LumaTrend = "up" | "down" | "flat" | "mixed";
+
+const LUMA_TREND_LABEL: Record<LumaTrend, string> = {
+  up: "monotonic ↑",
+  down: "monotonic ↓",
+  flat: "flat",
+  mixed: "non-monotonic",
+};
 
 export default function RampPanel() {
   const layer = useFocusCodeLayer();
@@ -38,6 +54,7 @@ export default function RampPanel() {
   const setRampSelection = useLabStore((state) => state.setRampSelection);
 
   const rampBarRef = useRef<HTMLCanvasElement | null>(null);
+  const lumaBarRef = useRef<HTMLCanvasElement | null>(null);
   const rampTrackRef = useRef<HTMLDivElement | null>(null);
   const stopDragRef = useRef<{ index: number } | null>(null);
   const layerIdRef = useRef<string | null>(null);
@@ -48,13 +65,49 @@ export default function RampPanel() {
 
   const ramp = layer?.ramp ?? null;
 
+  // LUT + perceptual-lightness read of the ramp, shared by both preview strips.
+  // OKLab L of the RGB only — alpha is layering, not color — with the trend
+  // (the "squint test": does the palette keep its structure in grayscale?).
+  const rampAnalysis = useMemo(() => {
+    if (!ramp) return null;
+    const lut = buildRampLUTRGBA(rampStateToHarness(ramp));
+    const luma = new Float32Array(256);
+    for (let i = 0; i < 256; i++) {
+      luma[i] = srgbToOklab(lut[i * 4], lut[i * 4 + 1], lut[i * 4 + 2])[0];
+    }
+    // Cumulative drawup/drawdown, not per-step deltas: a gentle full-range ramp
+    // moves ~0.002 L per LUT step, far below any noise floor a step test could
+    // use, while byte rounding wiggles adjacent entries. Track how far L climbs
+    // above its running minimum and falls below its running maximum instead.
+    const EPS = 0.02;
+    let runningMin = luma[0];
+    let runningMax = luma[0];
+    let drawup = 0;
+    let drawdown = 0;
+    for (let i = 1; i < 256; i++) {
+      runningMin = Math.min(runningMin, luma[i]);
+      runningMax = Math.max(runningMax, luma[i]);
+      drawup = Math.max(drawup, luma[i] - runningMin);
+      drawdown = Math.max(drawdown, runningMax - luma[i]);
+    }
+    const trend: LumaTrend =
+      drawup > EPS && drawdown > EPS
+        ? "mixed"
+        : drawup > EPS
+          ? "up"
+          : drawdown > EPS
+            ? "down"
+            : "flat";
+    return { lut, luma, trend };
+  }, [ramp]);
+
   // Paint the gradient bar: checkerboard first, then the RGBA LUT over it, so
   // transparent stops are visibly transparent.
   useEffect(() => {
     const canvas = rampBarRef.current;
     const context = canvas?.getContext("2d");
-    if (!canvas || !context || !ramp) return;
-    const lut = buildRampLUTRGBA(rampStateToHarness(ramp));
+    if (!canvas || !context || !rampAnalysis) return;
+    const lut = rampAnalysis.lut;
     const width = 256;
     const height = 14;
     context.clearRect(0, 0, width, height);
@@ -80,7 +133,26 @@ export default function RampPanel() {
       }
     }
     context.putImageData(imageData, 0, 0);
-  }, [ramp]);
+
+    // Luminance strip: each column is the perceptual gray of that LUT entry.
+    const lumaCanvas = lumaBarRef.current;
+    const lumaContext = lumaCanvas?.getContext("2d");
+    if (!lumaCanvas || !lumaContext) return;
+    const lumaHeight = 8;
+    const lumaImage = lumaContext.createImageData(width, lumaHeight);
+    const lumaData = lumaImage.data;
+    for (let x = 0; x < width; x++) {
+      const gray = Math.round(oklabToSrgb(rampAnalysis.luma[x], 0, 0)[0]);
+      for (let y = 0; y < lumaHeight; y++) {
+        const index = (y * width + x) * 4;
+        lumaData[index] = gray;
+        lumaData[index + 1] = gray;
+        lumaData[index + 2] = gray;
+        lumaData[index + 3] = 255;
+      }
+    }
+    lumaContext.putImageData(lumaImage, 0, 0);
+  }, [rampAnalysis]);
 
   const rampPositionFromClientX = useCallback((clientX: number) => {
     const track = rampTrackRef.current;
@@ -171,7 +243,7 @@ export default function RampPanel() {
         >
           {RAMP_MODES.map((mode) => (
             <option key={mode} value={mode}>
-              {mode === "hsvShort" ? "hsv short" : mode === "hsvLong" ? "hsv long" : mode}
+              {modeLabel(mode)}
             </option>
           ))}
         </select>
@@ -233,6 +305,26 @@ export default function RampPanel() {
             </button>
           ))}
         </div>
+
+        <canvas
+          ref={lumaBarRef}
+          className={styles.rampLuma}
+          width={256}
+          height={8}
+          aria-label="Ramp luminance preview"
+          title="Perceptual lightness (OKLab L) of the ramp — the squint test: structure should survive in grayscale"
+        />
+        {rampAnalysis && (
+          <div className={styles.rampLumaRow}>
+            <span>luminance</span>
+            <span
+              className={`${styles.rampLumaBadge}${rampAnalysis.trend === "mixed" && !ramp.wrap ? ` ${styles.rampLumaMixed}` : ""}`}
+              title="Lightness trend across the ramp. Monotonic reads as ordered values on the panel; non-monotonic is a stylistic choice, not an error."
+            >
+              {ramp.wrap ? "cyclic" : LUMA_TREND_LABEL[rampAnalysis.trend]}
+            </span>
+          </div>
+        )}
 
         {activeStop && (
           <>

--- a/web/src/lib/patternHarness.ts
+++ b/web/src/lib/patternHarness.ts
@@ -67,8 +67,25 @@ function clampByte(value: number) {
 // draw with display.setValue() produce a pure value field; the ramp is the
 // user's color decision, applied by the runtime (and baked in on C++ export).
 
-export type RampMode = "linear" | "smooth" | "step" | "hsvShort" | "hsvLong";
-export const RAMP_MODES: RampMode[] = ["linear", "smooth", "step", "hsvShort", "hsvLong"];
+export type RampMode =
+  | "linear"
+  | "smooth"
+  | "step"
+  | "hsvShort"
+  | "hsvLong"
+  | "oklab"
+  | "oklchShort"
+  | "oklchLong";
+export const RAMP_MODES: RampMode[] = [
+  "linear",
+  "smooth",
+  "step",
+  "hsvShort",
+  "hsvLong",
+  "oklab",
+  "oklchShort",
+  "oklchLong",
+];
 
 export type RampStop = {
   position: number; // 0..1
@@ -126,6 +143,78 @@ function hsvToRgbTuple(h: number, s: number, v: number): [number, number, number
   return [Math.round(r * 255), Math.round(g * 255), Math.round(b * 255)];
 }
 
+// ── OKLab / OKLCH ───────────────────────────────────────────────────────────
+// Perceptually uniform interpolation (Björn Ottosson's OKLab, 2020). sRGB and
+// HSV blends drift in lightness — complementary stops meet in a muddy gray,
+// hue sweeps pulse bright and dark. Interpolating in OKLab keeps lightness
+// honest; OKLCH additionally follows the hue arc at steady chroma.
+
+function srgbChannelToLinear(c: number): number {
+  c /= 255;
+  return c <= 0.04045 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
+}
+
+function linearChannelToSrgb(c: number): number {
+  const v = c <= 0.0031308 ? c * 12.92 : 1.055 * Math.pow(c, 1 / 2.4) - 0.055;
+  return Math.max(0, Math.min(1, v)) * 255;
+}
+
+export function srgbToOklab(r: number, g: number, b: number): [number, number, number] {
+  const lr = srgbChannelToLinear(r);
+  const lg = srgbChannelToLinear(g);
+  const lb = srgbChannelToLinear(b);
+  const l = Math.cbrt(0.4122214708 * lr + 0.5363325363 * lg + 0.0514459929 * lb);
+  const m = Math.cbrt(0.2119034982 * lr + 0.6806995451 * lg + 0.1073969566 * lb);
+  const s = Math.cbrt(0.0883024619 * lr + 0.2817188376 * lg + 0.6299787005 * lb);
+  return [
+    0.2104542553 * l + 0.793617785 * m - 0.0040720468 * s,
+    1.9779984951 * l - 2.428592205 * m + 0.4505937099 * s,
+    0.0259040371 * l + 0.7827717662 * m - 0.808675766 * s,
+  ];
+}
+
+function oklabToLinearRgb(L: number, A: number, B: number): [number, number, number] {
+  const l_ = L + 0.3963377774 * A + 0.2158037573 * B;
+  const m_ = L - 0.1055613458 * A - 0.0638541728 * B;
+  const s_ = L - 0.0894841775 * A - 1.291485548 * B;
+  const l = l_ * l_ * l_;
+  const m = m_ * m_ * m_;
+  const s = s_ * s_ * s_;
+  return [
+    4.0767416621 * l - 3.3077115913 * m + 0.2309699292 * s,
+    -1.2684380046 * l + 2.6097574011 * m - 0.3413193965 * s,
+    -0.0041960863 * l - 0.7034186147 * m + 1.707614701 * s,
+  ];
+}
+
+// A blend between two in-gamut colors can leave sRGB (OKLCH hue arcs cross the
+// gamut boundary routinely). Clipping per channel would bend hue and lightness;
+// instead walk chroma down at constant L and hue until the color fits.
+const GAMUT_EPS = 1e-4;
+
+function inLinearGamut(rgb: [number, number, number]): boolean {
+  return (
+    rgb[0] >= -GAMUT_EPS && rgb[0] <= 1 + GAMUT_EPS &&
+    rgb[1] >= -GAMUT_EPS && rgb[1] <= 1 + GAMUT_EPS &&
+    rgb[2] >= -GAMUT_EPS && rgb[2] <= 1 + GAMUT_EPS
+  );
+}
+
+export function oklabToSrgb(L: number, A: number, B: number): [number, number, number] {
+  let rgb = oklabToLinearRgb(L, A, B);
+  if (!inLinearGamut(rgb)) {
+    let lo = 0;
+    let hi = 1;
+    for (let i = 0; i < 16; i++) {
+      const mid = (lo + hi) / 2;
+      if (inLinearGamut(oklabToLinearRgb(L, A * mid, B * mid))) lo = mid;
+      else hi = mid;
+    }
+    rgb = oklabToLinearRgb(L, A * lo, B * lo);
+  }
+  return [linearChannelToSrgb(rgb[0]), linearChannelToSrgb(rgb[1]), linearChannelToSrgb(rgb[2])];
+}
+
 function mixRampColors(
   a: [number, number, number],
   b: [number, number, number],
@@ -133,6 +222,37 @@ function mixRampColors(
   mode: RampMode,
 ): [number, number, number] {
   if (mode === "smooth") t = t * t * (3 - 2 * t);
+  if (mode === "oklab" || mode === "oklchShort" || mode === "oklchLong") {
+    const [La, Aa, Ba] = srgbToOklab(a[0], a[1], a[2]);
+    const [Lb, Ab, Bb] = srgbToOklab(b[0], b[1], b[2]);
+    const L = La + (Lb - La) * t;
+    if (mode === "oklab") {
+      return oklabToSrgb(L, Aa + (Ab - Aa) * t, Ba + (Bb - Ba) * t);
+    }
+    // OKLCH: polar form. Hue in turns, mirroring the hsv logic below — a
+    // near-gray endpoint has no meaningful hue, so borrow the other side's.
+    const CHROMA_EPS = 1e-4;
+    const TWO_PI = Math.PI * 2;
+    const Ca = Math.sqrt(Aa * Aa + Ba * Ba);
+    const Cb = Math.sqrt(Ab * Ab + Bb * Bb);
+    let hueA = Math.atan2(Ba, Aa) / TWO_PI;
+    if (hueA < 0) hueA += 1;
+    let hueB = Math.atan2(Bb, Ab) / TWO_PI;
+    if (hueB < 0) hueB += 1;
+    const h1 = Ca < CHROMA_EPS ? (Cb < CHROMA_EPS ? 0 : hueB) : hueA;
+    const h2 = Cb < CHROMA_EPS ? h1 : hueB;
+    let dh = h2 - h1;
+    if (mode === "oklchShort") {
+      if (dh > 0.5) dh -= 1;
+      if (dh < -0.5) dh += 1;
+    } else {
+      if (dh > 0 && dh < 0.5) dh -= 1;
+      else if (dh <= 0 && dh > -0.5) dh += 1;
+    }
+    const C = Ca + (Cb - Ca) * t;
+    const H = (h1 + dh * t) * TWO_PI;
+    return oklabToSrgb(L, Math.cos(H) * C, Math.sin(H) * C);
+  }
   if (mode === "hsvShort" || mode === "hsvLong") {
     const ha = rgbToHsv(a[0], a[1], a[2]);
     const hb = rgbToHsv(b[0], b[1], b[2]);

--- a/web/src/lib/patternRamp.ts
+++ b/web/src/lib/patternRamp.ts
@@ -10,8 +10,10 @@
 // tolerates any order). Parsed by this module (lab, community pages) AND by
 // public/pattern-sandbox.html (plain-JS port) — keep the two in sync.
 
-export const RAMP_MODES = ["linear", "smooth", "step", "hsvShort", "hsvLong"] as const;
-export type RampAnnotationMode = (typeof RAMP_MODES)[number];
+import { RAMP_MODES, type RampMode } from "@/lib/patternHarness";
+
+export { RAMP_MODES };
+export type RampAnnotationMode = RampMode;
 
 export type RampAnnotation = {
   stops: { position: number; color: string }[];


### PR DESCRIPTION
## What

Two halves of one color-quality push — the web's ramp math and the device's output stage — plus the tool that connects them.

### Web: OKLab/OKLCH ramp interpolation (`9413106`)
- New ramp modes `oklab` / `oklch short` / `oklch long`: no more muddy-gray midpoints in sRGB blends, no more lightness pulsing in hue sweeps. Out-of-gamut blends reduce chroma at constant L+hue instead of clipping channels.
- Ramps bake to LUTs web-side, so flatten / .h export / C++ prompts / .pfm builds all inherit the new modes with **zero firmware changes**.
- RampPanel: luminance strip (OKLab L) + monotonicity badge — the "squint test" as a fixture.
- `scripts/ramp-oklab-smoke.ts`: Ottosson reference values, round-trip, gamut safety, and **byte-exact parity** between the TS math and the sandbox's hand-ported JS copy.

### Firmware: live calibration + tuned defaults (`a82129b`)
- `GET /api/display` tunes WB / gamma / saturation at runtime (handler clears a flag; `present()`'s lazy LUT rebuild does the rest). Session-only; converged values land in config.h.
- Shipped defaults are real measurements off a physical panel tuned against an sRGB reference: `LED_WB 0.930/1.000/0.975`, `LED_SAT_BOOST 1.62` — the saturation *direction* reversed the wide-gamut folklore (the panel reads washed-out next to a monitor, verified at 14% and 100% brightness).
- Calibration test card is an **overlay**, not a pattern: knob browsing stays a curated art list; `?screen=0..3` covers the running pattern, `?screen=-1` (or K4-hold at the device) resumes it.
- `GET /api/patterns/select` for remote pattern selection, same deferred-consume path as OSC.

### Tool: panel tuner (`e07711e`)
- `web/public/panel-tuner.html` — reference canvas (monitor = sRGB intent) beside the LED, screen switching synced to the device, serialized HTTP queue (no WebSockets — an earlier WS revision sat on the device's tight heap while it wedged), auto-generated config.h snippet.

## Testing
- Web: `ramp-oklab-smoke` (12 checks) + `lab-flatten-smoke` green, eslint + tsc clean, modes exercised in the browser (linear vs oklab midpoints verified per-pixel).
- Firmware: compiled clean (41% flash), flashed to the maintainer's board over `/update`, verified on hardware: boot defaults carry the tuned WB/sat, overlay on/off round-trip, remote select, `presets:34` (test card absent from the list). `PF_DISPLAY_HTTP_ENABLED=0` build verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)