### PR TITLE
feat(web): pattern atlas — a map of pattern-technique space

### DIFF
--- a/web/drizzle/0017_add-atlas-pins.sql
+++ b/web/drizzle/0017_add-atlas-pins.sql
@@ -1,0 +1,7 @@
+CREATE TABLE `atlas_pins` (
+	`pattern_id` text PRIMARY KEY NOT NULL,
+	`x` integer NOT NULL,
+	`y` integer NOT NULL,
+	`updated_at` integer NOT NULL,
+	FOREIGN KEY (`pattern_id`) REFERENCES `patterns`(`id`) ON UPDATE no action ON DELETE cascade
+);

--- a/web/drizzle/0018_atlas-pin-entry.sql
+++ b/web/drizzle/0018_atlas-pin-entry.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `atlas_pins` ADD `entry_id` text;

--- a/web/drizzle/meta/_journal.json
+++ b/web/drizzle/meta/_journal.json
@@ -120,6 +120,20 @@
       "when": 1786338000000,
       "tag": "0016_add-presence",
       "breakpoints": true
+    },
+    {
+      "idx": 17,
+      "version": "6",
+      "when": 1786830000000,
+      "tag": "0017_add-atlas-pins",
+      "breakpoints": true
+    },
+    {
+      "idx": 18,
+      "version": "6",
+      "when": 1786833000000,
+      "tag": "0018_atlas-pin-entry",
+      "breakpoints": true
     }
   ]
 }

--- a/web/src/app/api/community/atlas/route.ts
+++ b/web/src/app/api/community/atlas/route.ts
@@ -1,0 +1,144 @@
+import { eq } from "drizzle-orm";
+import { ENTRY_BY_ID } from "@/lib/atlas/data";
+import { isAdminSession } from "@/lib/community/admin";
+import { getAuth } from "@/lib/community/auth";
+import { originBlocked, preflight, withCors } from "@/lib/community/cors";
+import { communityEnabled, getDb } from "@/lib/community/db";
+import { listAtlasPins } from "@/lib/community/queries";
+import { rateLimit } from "@/lib/community/ratelimit";
+import { atlasPins, patterns } from "@/lib/community/schema";
+
+// GET    /api/community/atlas — every pattern pinned on the atlas.
+// POST   — place or move a pin: { patternId, x, y } in the atlas's 0..100
+//          data space. Only the pattern's author (or a moderator) may.
+// DELETE — take a pin off the map: { patternId }. Same permission.
+//
+// A pin says "this work lives at this spot of pattern space". One per
+// pattern; placing again just moves it.
+
+export async function GET(request: Request) {
+  const blocked = originBlocked(request);
+  if (blocked) return blocked;
+  return withCors(request, await handleGet());
+}
+
+export async function POST(request: Request) {
+  const blocked = originBlocked(request);
+  if (blocked) return blocked;
+  return withCors(request, await handleWrite(request, "place"));
+}
+
+export async function DELETE(request: Request) {
+  const blocked = originBlocked(request);
+  if (blocked) return blocked;
+  return withCors(request, await handleWrite(request, "remove"));
+}
+
+export const OPTIONS = preflight;
+
+async function handleGet() {
+  if (!communityEnabled()) {
+    return Response.json({ error: "Community is not enabled on this deployment." }, { status: 503 });
+  }
+  const pins = await listAtlasPins();
+  return Response.json({
+    pins: pins.map((pin) => ({
+      patternId: pin.patternId,
+      x: pin.x,
+      y: pin.y,
+      entryId: pin.entryId,
+      title: pin.title,
+      userId: pin.userId,
+      username: pin.username,
+      displayUsername: pin.displayUsername,
+    })),
+  });
+}
+
+function cleanCoord(value: unknown): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value)) return undefined;
+  const rounded = Math.round(value);
+  if (rounded < 0 || rounded > 100) return undefined;
+  return rounded;
+}
+
+async function handleWrite(request: Request, mode: "place" | "remove") {
+  if (!communityEnabled()) {
+    return Response.json({ error: "Community is not enabled on this deployment." }, { status: 503 });
+  }
+
+  const session = await getAuth().api.getSession({ headers: request.headers });
+  if (!session) {
+    return Response.json({ error: "Sign in to place work on the atlas." }, { status: 401 });
+  }
+
+  if (!rateLimit(`atlas:${session.user.id}`, 60, 60_000)) {
+    return Response.json({ error: "Too many moves — let the pin settle a moment." }, { status: 429 });
+  }
+
+  let payload: Record<string, unknown>;
+  try {
+    payload = (await request.json()) as Record<string, unknown>;
+  } catch {
+    return Response.json({ error: "Invalid JSON body." }, { status: 400 });
+  }
+
+  const patternId = typeof payload.patternId === "string" ? payload.patternId : "";
+  if (!patternId) {
+    return Response.json({ error: "Which pattern?" }, { status: 400 });
+  }
+
+  const [pattern] = await getDb()
+    .select({ id: patterns.id, userId: patterns.userId, visibility: patterns.visibility })
+    .from(patterns)
+    .where(eq(patterns.id, patternId))
+    .limit(1);
+  if (!pattern) {
+    return Response.json({ error: "No such pattern." }, { status: 404 });
+  }
+
+  // The author decides where their work sits; moderators can tidy the map.
+  if (pattern.userId !== session.user.id && !isAdminSession(session)) {
+    return Response.json({ error: "Only the pattern's author can place it." }, { status: 403 });
+  }
+
+  if (mode === "remove") {
+    await getDb().delete(atlasPins).where(eq(atlasPins.patternId, patternId));
+    return Response.json({ ok: true });
+  }
+
+  if (pattern.visibility !== "public") {
+    return Response.json(
+      { error: "Only public patterns can sit on the shared map." },
+      { status: 400 },
+    );
+  }
+
+  const x = cleanCoord(payload.x);
+  const y = cleanCoord(payload.y);
+  if (x === undefined || y === undefined) {
+    return Response.json({ error: "Bad position." }, { status: 400 });
+  }
+
+  // Lineage is a deliberate, human act: the author links a pattern to the
+  // prompt point it came from (or to none). Nothing is inferred from code.
+  let entryId: string | null;
+  if (payload.entryId === undefined || payload.entryId === null || payload.entryId === "") {
+    entryId = null;
+  } else if (typeof payload.entryId === "string" && ENTRY_BY_ID.has(payload.entryId)) {
+    entryId = payload.entryId;
+  } else {
+    return Response.json({ error: "No such point on the map." }, { status: 400 });
+  }
+
+  const now = new Date();
+  await getDb()
+    .insert(atlasPins)
+    .values({ patternId, x, y, entryId, updatedAt: now })
+    .onConflictDoUpdate({
+      target: atlasPins.patternId,
+      set: { x, y, entryId, updatedAt: now },
+    });
+
+  return Response.json({ ok: true });
+}

--- a/web/src/app/community/atlas/page.tsx
+++ b/web/src/app/community/atlas/page.tsx
@@ -1,0 +1,68 @@
+import { headers } from "next/headers";
+import type { Metadata } from "next";
+import { isAdminSession } from "@/lib/community/admin";
+import { getAuth } from "@/lib/community/auth";
+import { communityEnabled } from "@/lib/community/db";
+import { listAtlasPins, listPatternsByUser } from "@/lib/community/queries";
+import AtlasClient from "@/components/community/AtlasClient";
+
+// The atlas: a map of pattern-technique space, sibling to the workshop map.
+// The workshop charts where the HARDWARE could go (territories = project
+// directions); this charts where PATTERNS could go — verified continents,
+// open frontier, invented hypotheses, and, pinned between them, the actual
+// published work: each pin is a live pattern placed where it belongs.
+//
+// Technique entries live in lib/atlas/data.ts and are edited like the seed
+// script. Pins live in the atlas_pins table.
+//
+// Connecting work to the map happens HERE, by hand: publishing stays its own
+// flow, and the atlas offers "add my pattern" — pick one of your published
+// patterns, click where it belongs, and (optionally) tie it to the prompt
+// point it came from. Nothing is inferred, nothing rides the publish flow.
+
+export const dynamic = "force-dynamic";
+
+export const metadata: Metadata = {
+  title: "Atlas / Patternflow Community",
+  description:
+    "A map of pattern-technique space — verified continents, open frontier, published patterns pinned in place, and ready-made generation prompts for exploring each point.",
+};
+
+export default async function AtlasPage() {
+  if (!communityEnabled()) return null; // layout already redirected or rendered the notice
+
+  const session = await getAuth().api.getSession({ headers: await headers() });
+  const viewerId = session?.user.id ?? null;
+  const isAdmin = isAdminSession(session);
+
+  const pins = await listAtlasPins();
+
+  // The picker: the viewer's own public patterns that are not on the map yet,
+  // newest first (listPatternsByUser already orders that way) and carrying
+  // their code — you pick by looking at the pattern, not by reading a title.
+  const pinned = new Set(pins.map((pin) => pin.patternId));
+  const myPatterns = viewerId
+    ? (await listPatternsByUser(viewerId, viewerId))
+        .filter((pattern) => pattern.visibility === "public" && !pinned.has(pattern.id))
+        .map((pattern) => ({ id: pattern.id, title: pattern.title, code: pattern.code }))
+    : [];
+
+  return (
+    <AtlasClient
+      pins={pins.map((pin) => ({
+        patternId: pin.patternId,
+        x: pin.x,
+        y: pin.y,
+        entryId: pin.entryId,
+        title: pin.title,
+        code: pin.code,
+        userId: pin.userId,
+        username: pin.username,
+        displayUsername: pin.displayUsername,
+      }))}
+      viewerId={viewerId}
+      isAdmin={isAdmin}
+      myPatterns={myPatterns}
+    />
+  );
+}

--- a/web/src/components/community/Atlas.module.css
+++ b/web/src/components/community/Atlas.module.css
@@ -1,0 +1,716 @@
+/* Pattern Atlas — lives in the community's dark room, so everything here
+   speaks --pfc-* tokens (see globals.css). Radius 0, hairline borders, and
+   the orange reserved for live signals: the pulsing "탐사중" ring, the
+   critical-knob box, and the one CTA. */
+
+.atlas {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+  padding-bottom: 24px;
+}
+
+.toolbar {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 14px 0;
+}
+
+.tagline {
+  font-size: 13px;
+  color: var(--pfc-ink-muted);
+  margin: 0;
+}
+
+.toolbarSpacer {
+  flex: 1;
+}
+
+.toolBtn {
+  background: transparent;
+  color: var(--pfc-ink-muted);
+  border: 1px solid var(--pfc-hair);
+  font-family: var(--pf-mono, monospace);
+  font-size: 10px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  padding: 7px 12px;
+  cursor: pointer;
+  border-radius: 0;
+}
+
+.toolBtn:hover {
+  color: var(--pfc-ink);
+  border-color: var(--pfc-edge);
+}
+
+.toolBtn[data-on="true"] {
+  color: var(--pfc-led);
+  border-color: var(--pfc-led-edge);
+  background: var(--pfc-led-wash);
+}
+
+.body {
+  display: flex;
+  flex: 1;
+  min-height: 540px;
+  height: calc(100vh - 230px);
+  border: 1px solid var(--pfc-hair);
+}
+
+.mapWrap {
+  flex: 1;
+  position: relative;
+  min-width: 0;
+  background: var(--pfc-well);
+}
+
+.map {
+  width: 100%;
+  height: 100%;
+  display: block;
+  cursor: default;
+}
+
+/* ── filter chips ── */
+
+.chips {
+  position: absolute;
+  top: 12px;
+  left: 16px;
+  display: flex;
+  z-index: 1;
+}
+
+.chip {
+  composes: toolBtn;
+  border-right-width: 0;
+  padding: 5px 10px;
+}
+
+.chip:last-child {
+  border-right-width: 1px;
+}
+
+.chip[data-on="true"] {
+  color: var(--pfc-ink);
+  background: var(--pfc-well-2);
+  border-color: var(--pfc-edge);
+}
+
+/* ── map furniture ── */
+
+.frame {
+  stroke: var(--pfc-hair);
+}
+
+.grid line {
+  stroke: rgba(244, 239, 230, 0.045);
+}
+
+.axis {
+  fill: var(--pfc-ink-faint);
+  font-family: var(--pf-mono, monospace);
+  font-size: 10px;
+  letter-spacing: 0.22em;
+}
+
+.famLabel {
+  font-family: var(--pf-mono, monospace);
+  font-size: 10px;
+  letter-spacing: 0.18em;
+  font-weight: 500;
+  opacity: 0.55;
+}
+
+.zoomHint {
+  color: var(--pfc-ink-faint);
+  font-family: var(--pf-mono, monospace);
+  font-size: 10px;
+  letter-spacing: 0.06em;
+  margin-left: 10px;
+}
+
+.mapWrap[data-placing="true"] .map {
+  cursor: crosshair;
+}
+
+/* ── "Add my pattern" picker ── */
+
+.pickerWrap {
+  position: relative;
+  display: inline-flex;
+}
+
+.picker {
+  position: absolute;
+  right: 0;
+  top: calc(100% + 6px);
+  z-index: 6;
+  width: 396px;
+  max-height: 420px;
+  overflow-y: auto;
+  background: var(--pfc-panel);
+  border: 1px solid var(--pfc-edge);
+  padding: 4px;
+}
+
+/* You recognise your own work by looking at it — the picker is a contact
+   sheet of thumbnails, newest first, not a list of titles. */
+.pickerGrid {
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 8px;
+  padding: 2px 4px 6px;
+}
+
+.pickerItem {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+}
+
+.pickerTile {
+  position: relative;
+  display: block;
+  width: 100%;
+  aspect-ratio: 1 / 2;
+  border: 1px solid var(--pfc-hair);
+  background: var(--pfc-well);
+  overflow: hidden;
+}
+
+.pickerItem:hover .pickerTile {
+  border-color: var(--pfc-led);
+}
+
+.pickerCaption {
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: var(--pf-mono, monospace);
+  font-size: 8.5px;
+  color: var(--pfc-ink-muted);
+}
+
+.pickerItem:hover .pickerCaption {
+  color: var(--pfc-ink);
+}
+
+.pickerHead {
+  font-family: var(--pf-mono, monospace);
+  font-size: 9.5px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--pfc-ink-faint);
+  padding: 6px 10px 8px;
+}
+
+.pickerSearch {
+  width: calc(100% - 8px);
+  margin: 0 4px 6px;
+  background: var(--pfc-well);
+  border: 1px solid var(--pfc-hair);
+  border-radius: 0;
+  color: var(--pfc-ink);
+  font-family: var(--pf-sans, sans-serif);
+  font-size: 12px;
+  padding: 6px 8px;
+}
+
+.pickerSearch:focus {
+  outline: none;
+  border-color: var(--pfc-edge);
+}
+
+.placeBanner {
+  position: absolute;
+  top: 12px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 2;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 12px;
+  background: var(--pfc-led-wash);
+  border: 1px solid var(--pfc-led-edge);
+  color: var(--pfc-led);
+  font-size: 12.5px;
+  white-space: nowrap;
+}
+
+.bannerLink {
+  color: var(--pfc-ink);
+}
+
+/* ── pattern pins: live tiles on the map ── */
+
+.pin {
+  width: 44px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 3px;
+  cursor: pointer;
+}
+
+.pin[data-draggable="true"] {
+  cursor: grab;
+}
+
+.pinTile {
+  position: relative;
+  width: 44px;
+  height: 88px;
+  border: 1px solid var(--pfc-edge);
+  background: var(--pfc-well);
+  overflow: hidden;
+}
+
+.pin[data-selected="true"] .pinTile {
+  border-color: var(--pfc-ink);
+  box-shadow: 0 0 8px rgba(244, 239, 230, 0.25);
+}
+
+.pinWell {
+  position: absolute;
+  inset: 0;
+}
+
+.pinCaption {
+  max-width: 44px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: var(--pf-mono, monospace);
+  font-size: 8px;
+  letter-spacing: 0.04em;
+  color: var(--pfc-ink-muted);
+}
+
+/* ── pin panel ── */
+
+.panelCanvas {
+  margin: 6px 0 14px;
+}
+
+.panelWell {
+  position: relative;
+  width: 140px;
+  height: 280px;
+  border: 1px solid var(--pfc-hair);
+  background: var(--pfc-well);
+  overflow: hidden;
+}
+
+.openLink {
+  display: inline-block;
+  margin-top: 4px;
+  font-size: 13px;
+  color: var(--pfc-ink);
+  text-decoration: none;
+  border-bottom: 1px solid var(--pfc-edge);
+  padding-bottom: 1px;
+}
+
+.openLink:hover {
+  border-bottom-color: var(--pfc-led);
+  color: var(--pfc-led);
+}
+
+.moveHint {
+  margin: 14px 0 8px;
+  font-size: 12px;
+  color: var(--pfc-ink-faint);
+}
+
+.removeBtn {
+  composes: toolBtn;
+  color: var(--pfc-danger);
+  border-color: rgba(232, 107, 94, 0.4);
+}
+
+.removeBtn:hover {
+  color: var(--pfc-danger);
+  border-color: var(--pfc-danger);
+}
+
+.legendTile {
+  width: 8px;
+  height: 16px;
+  border: 1px solid var(--pfc-edge);
+  background: var(--pfc-well);
+  flex: 0 0 auto;
+}
+
+/* ── lineage: made-from chip / owner select ── */
+
+.fromChip {
+  composes: toolBtn;
+  text-transform: none;
+  letter-spacing: 0.02em;
+  font-size: 12px;
+  color: var(--pfc-ink);
+}
+
+.fromSelect {
+  width: 100%;
+  background: var(--pfc-well);
+  color: var(--pfc-ink);
+  border: 1px solid var(--pfc-hair);
+  border-radius: 0;
+  font-family: var(--pf-sans, sans-serif);
+  font-size: 12.5px;
+  padding: 7px 8px;
+}
+
+/* ── the player: sandboxed live run + knobs ── */
+
+.playerWell {
+  position: relative;
+  width: 150px;
+  height: 300px;
+  border: 1px solid var(--pfc-hair);
+  background: var(--pfc-well);
+  overflow: hidden;
+}
+
+.knobRow {
+  display: grid;
+  grid-template-columns: 74px 1fr 44px;
+  align-items: center;
+  gap: 8px;
+  margin: 7px 0;
+}
+
+.knobLabel {
+  font-family: var(--pf-mono, monospace);
+  font-size: 10px;
+  letter-spacing: 0.06em;
+  color: var(--pfc-ink-2);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.knobVal {
+  font-family: var(--pf-mono, monospace);
+  font-size: 10px;
+  color: var(--pfc-ink-muted);
+  text-align: right;
+}
+
+.knobInput {
+  width: 100%;
+  accent-color: var(--pfc-led);
+  background: transparent;
+}
+
+/* ── linked-pattern minis in the entry panel ── */
+
+.miniRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.miniItem {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  width: 56px;
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+}
+
+.miniTile {
+  position: relative;
+  display: block;
+  width: 40px;
+  height: 80px;
+  border: 1px solid var(--pfc-hair);
+  background: var(--pfc-well);
+  overflow: hidden;
+}
+
+.miniItem:hover .miniTile {
+  border-color: var(--pfc-edge);
+}
+
+.miniCaption {
+  max-width: 56px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: var(--pf-mono, monospace);
+  font-size: 9px;
+  color: var(--pfc-ink-muted);
+}
+
+/* ── nodes ── */
+
+.node {
+  cursor: pointer;
+  outline: none;
+}
+
+.core {
+  transition: r 0.12s;
+}
+
+.node:hover .core {
+  r: 8;
+}
+
+.node[data-selected="true"] .core {
+  stroke: var(--pfc-ink);
+  stroke-width: 1.5;
+}
+
+.nodeLabel {
+  fill: var(--pfc-ink-muted);
+  font-size: 10.5px;
+  pointer-events: none;
+}
+
+@keyframes pulse {
+  0%, 100% { opacity: 0.2; r: 9; }
+  50% { opacity: 0.8; r: 13; }
+}
+
+.pulseRing {
+  animation: pulse 2.2s ease-in-out infinite;
+}
+
+/* ── side panel ── */
+
+.panel {
+  flex: 0 0 400px;
+  border-left: 1px solid var(--pfc-hair);
+  background: var(--pfc-panel);
+  overflow-y: auto;
+  padding: 20px 20px 32px;
+}
+
+.panelTitle {
+  font-size: 17px;
+  font-weight: 700;
+  margin: 2px 0 3px;
+}
+
+.panelEn {
+  color: var(--pfc-ink-faint);
+  font-family: var(--pf-mono, monospace);
+  font-size: 10px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  margin-bottom: 12px;
+}
+
+.badges {
+  display: flex;
+  gap: 6px;
+  margin-bottom: 14px;
+  flex-wrap: wrap;
+}
+
+.badge {
+  font-family: var(--pf-mono, monospace);
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  padding: 3px 8px;
+  border: 1px solid var(--pfc-hair);
+  color: var(--pfc-ink-muted);
+}
+
+.badge[data-live="true"] {
+  color: var(--pfc-led);
+  border-color: var(--pfc-led-edge);
+}
+
+.badgeFam {
+  composes: badge;
+  border-color: transparent;
+  color: var(--pfc-on-led);
+  font-weight: 700;
+}
+
+.sec {
+  margin: 14px 0;
+}
+
+.secK {
+  font-family: var(--pf-mono, monospace);
+  font-size: 10px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--pfc-ink-faint);
+  margin-bottom: 5px;
+}
+
+.secV {
+  font-size: 13px;
+  line-height: 1.6;
+  color: var(--pfc-ink-2);
+}
+
+.knobBox {
+  border: 1px solid var(--pfc-led-edge);
+  background: var(--pfc-led-wash);
+  padding: 10px 12px;
+  font-size: 12.5px;
+  line-height: 1.55;
+  color: var(--pfc-led);
+}
+
+.riskBox {
+  color: var(--pfc-danger);
+  font-size: 12.5px;
+  line-height: 1.55;
+}
+
+.implBox {
+  font-family: var(--pf-mono, monospace);
+  font-size: 11.5px;
+  color: var(--pfc-ink-2);
+}
+
+.prompt {
+  font-family: var(--pf-mono, monospace);
+  font-size: 10.5px;
+  line-height: 1.55;
+  color: var(--pfc-ink-2);
+  background: var(--pfc-well);
+  border: 1px solid var(--pfc-hair);
+  padding: 12px;
+  white-space: pre-wrap;
+  max-height: 230px;
+  overflow-y: auto;
+  margin: 6px 0 0;
+}
+
+.copyBtn {
+  margin-top: 10px;
+  width: 100%;
+  padding: 10px;
+  font-size: 11px;
+  font-family: var(--pf-mono, monospace);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-weight: 600;
+  background: var(--pfc-led);
+  border: 1px solid var(--pfc-led);
+  color: var(--pfc-on-led);
+  cursor: pointer;
+  border-radius: 0;
+}
+
+.copyBtn:hover {
+  background: #f16c47;
+  border-color: #f16c47;
+}
+
+.copyBtn[data-done="true"] {
+  background: transparent;
+  color: var(--pfc-led);
+  border-color: var(--pfc-led-edge);
+}
+
+/* ── intro / legend ── */
+
+.howto {
+  font-size: 13px;
+  line-height: 1.8;
+  color: var(--pfc-ink-muted);
+}
+
+.howto p {
+  margin: 0;
+}
+
+.howto b {
+  color: var(--pfc-ink);
+  font-weight: 600;
+}
+
+.hr {
+  border: none;
+  border-top: 1px solid var(--pfc-hair);
+  margin: 14px 0;
+}
+
+.legendRow {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  font-size: 12.5px;
+  color: var(--pfc-ink-muted);
+  margin: 6px 0;
+}
+
+.legendDot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  flex: 0 0 auto;
+}
+
+.legendDot[data-status="verified"] {
+  background: #5ad7ff;
+  box-shadow: 0 0 6px #5ad7ff;
+}
+
+.legendDot[data-status="active"] {
+  background: #7ea4ff;
+  outline: 2px solid rgba(232, 85, 46, 0.4);
+  outline-offset: 2px;
+}
+
+.legendDot[data-status="hold"] {
+  background: rgba(90, 215, 255, 0.6);
+}
+
+.legendDot[data-status="unexplored"] {
+  background: transparent;
+  border: 1.5px dashed rgba(90, 215, 255, 0.53);
+}
+
+.legendDot[data-status="invented"] {
+  background: rgba(216, 210, 196, 0.25);
+  border: 1.5px dotted #d8d2c4;
+  box-shadow: 0 0 5px rgba(216, 210, 196, 0.5);
+}
+
+/* ── narrow screens: stack map over panel ── */
+
+@media (max-width: 900px) {
+  .body {
+    flex-direction: column;
+    height: auto;
+  }
+
+  .mapWrap {
+    height: 60vh;
+    min-height: 380px;
+  }
+
+  .panel {
+    flex: none;
+    border-left: none;
+    border-top: 1px solid var(--pfc-hair);
+    max-height: none;
+  }
+}

--- a/web/src/components/community/AtlasClient.tsx
+++ b/web/src/components/community/AtlasClient.tsx
@@ -1,0 +1,1060 @@
+"use client";
+
+// The pattern atlas — a zoomable 2D map of pattern-technique space.
+//
+// Two kinds of things live on it:
+//  · ENTRIES (lib/atlas/data.ts): technique hypotheses — verified continents,
+//    open frontier, invented experiments. Click one for a generation prompt.
+//  · PINS (atlas_pins table): actual published patterns, placed by their
+//    authors. They render as live tiles — the map slowly becomes territory.
+//
+// English is the default (the community is public); Korean is a per-browser
+// preference. The generation prompt itself is always English.
+//
+// Entry coordinates are taste hypotheses: drag in edit mode, export, bake the
+// JSON back into data.ts. Pin coordinates belong to their authors and save to
+// the database on drop.
+
+import Link from "next/link";
+import { useEffect, useMemo, useRef, useState, useSyncExternalStore } from "react";
+import { useRouter } from "next/navigation";
+import {
+  BLOBS,
+  ENTRIES,
+  ENTRY_BY_ID,
+  FAMILIES,
+  STATUSES,
+  buildPrompt,
+  type AtlasEntry,
+  type AtlasStatusId,
+} from "@/lib/atlas/data";
+import { knobSetupFromCode } from "@/lib/community/knobs";
+import { describeMatrixShape, matrixFromCode } from "@/lib/patternMatrix";
+import PatternCanvas from "./PatternCanvas";
+import SandboxPreview from "./SandboxPreview";
+import commStyles from "./Community.module.css";
+import styles from "./Atlas.module.css";
+
+// Plot geometry inside the 1000×640 viewBox — near full-bleed; the axis words
+// float over the map itself.
+const VB_W = 1000;
+const VB_H = 640;
+const MX = 10;
+const MY = 10;
+const W = VB_W - MX * 2;
+const H = VB_H - MY * 2;
+
+const sx = (x: number) => MX + (x / 100) * W;
+const sy = (y: number) => MY + H - (y / 100) * H;
+
+const LED = "#E8552E";
+const LANG_KEY = "pf-atlas-lang";
+const MIN_ZOOM = 1;
+const MAX_ZOOM = 8;
+/** Drop a pattern within this many viewBox px of an entry and it inherits
+ *  that entry's lineage — placing near a prompt IS pointing at it. */
+const LINK_RADIUS = 80;
+
+type Lang = "en" | "ko";
+type Filter = AtlasStatusId | "all";
+type Selection = { kind: "entry"; id: string } | { kind: "pin"; id: string } | null;
+
+export type AtlasPinData = {
+  patternId: string;
+  x: number;
+  y: number;
+  entryId: string | null;
+  title: string;
+  code: string;
+  userId: string;
+  username: string | null;
+  displayUsername: string | null;
+};
+
+const UI = {
+  en: {
+    tagline: "Experimental — a map for exploring more patterns.",
+    edit: "Edit layout",
+    editing: "Editing — drag points",
+    copyLayout: "Copy layout",
+    copiedLayout: "Copied (JSON)",
+    allChip: "All",
+    pinChip: "Pinned",
+    axisOrder: "ORDER →",
+    axisChaos: "→ CHAOS",
+    axisWire: "WIRE →",
+    axisField: "→ FIELD",
+    secTexture: "Texture",
+    secKnob: "Critical knob · phase transition",
+    secVert: "Vertical axis",
+    secRisk: "Caution",
+    secImpl: "Implementation",
+    secPrompt: "Exploration prompt — paste into your AI",
+    copyPrompt: "Copy prompt",
+    copiedPrompt: "Copied — to your AI, results into Pattern Lab",
+    introTitle: "A map of pattern space",
+    introSub: "Feeling → Prompt",
+    legendPin: "Pin — a published pattern, placed by its author",
+    pinBy: "by",
+    openPattern: "Open pattern ↗",
+    removePin: "Remove from the map",
+    moveHint: "Turn on [Edit layout] to drag this pin.",
+    placeBanner: (title: string) => `Placing “${title}” — click the map where it belongs`,
+    cancel: "Cancel",
+    zoomHint: "wheel to zoom · drag to pan · double-click to reset",
+    madeFrom: "Made from prompt",
+    linkNone: "— none —",
+    patternsFrom: "Patterns from this prompt",
+    knobs: "Knobs",
+    addPattern: "Add my pattern",
+    pickerHead: (n: number) => `Your patterns · newest first (${n})`,
+    pickerSearch: "Search by title…",
+  },
+  ko: {
+    tagline: "실험 기능 — 더 많은 패턴 탐구를 위한 지도.",
+    edit: "배치 편집",
+    editing: "편집 중 — 점을 끌기",
+    copyLayout: "배치 복사",
+    copiedLayout: "복사됨 (JSON)",
+    allChip: "전체",
+    pinChip: "핀",
+    axisOrder: "질서 ORDER →",
+    axisChaos: "→ 혼돈 CHAOS",
+    axisWire: "선 WIRE →",
+    axisField: "→ 장 FIELD",
+    secTexture: "질감",
+    secKnob: "급소 노브 · 위상전이",
+    secVert: "세로 축",
+    secRisk: "주의",
+    secImpl: "구현",
+    secPrompt: "탐사 프롬프트 (EN) — AI에 붙여넣기",
+    copyPrompt: "프롬프트 복사",
+    copiedPrompt: "복사됨 — AI에게, 결과는 Pattern Lab에",
+    introTitle: "패턴 생성 지도",
+    introSub: "Feeling → Prompt",
+    legendPin: "핀 — 작성자가 지도에 놓은 공개 패턴",
+    pinBy: "by",
+    openPattern: "패턴 열기 ↗",
+    removePin: "지도에서 내리기",
+    moveHint: "[배치 편집]을 켜면 이 핀을 끌 수 있다.",
+    placeBanner: (title: string) => `“${title}” 놓는 중 — 어울리는 자리를 클릭`,
+    cancel: "취소",
+    zoomHint: "휠 확대 · 드래그 이동 · 더블클릭 리셋",
+    madeFrom: "출신 프롬프트",
+    linkNone: "— 없음 —",
+    patternsFrom: "이 프롬프트에서 나온 패턴",
+    knobs: "노브",
+    addPattern: "내 패턴 올리기",
+    pickerHead: (n: number) => `내 패턴 · 최신순 (${n})`,
+    pickerSearch: "제목으로 검색…",
+  },
+} as const;
+
+export default function AtlasClient({
+  pins,
+  viewerId,
+  isAdmin,
+  myPatterns,
+}: {
+  pins: AtlasPinData[];
+  viewerId: string | null;
+  isAdmin: boolean;
+  /** The viewer's own public patterns not yet on the map — the picker. */
+  myPatterns: Array<{ id: string; title: string; code: string }>;
+}) {
+  const router = useRouter();
+  // Reading straight from the store (rather than syncing state in an effect)
+  // keeps the server's English markup and the browser's remembered choice
+  // from fighting during hydration.
+  const lang = useSyncExternalStore(subscribeLang, readLang, () => "en" as Lang);
+  const [positions, setPositions] = useState<Record<string, [number, number]>>(
+    () => Object.fromEntries(ENTRIES.map((e) => [e.id, [e.x, e.y] as [number, number]])),
+  );
+  // Local pin positions override the server rows while dragging.
+  const [pinPositions, setPinPositions] = useState<Record<string, [number, number]>>({});
+  const [selection, setSelection] = useState<Selection>(null);
+  const [filter, setFilter] = useState<Filter>("all");
+  const [editMode, setEditMode] = useState(false);
+  const [copied, setCopied] = useState(false);
+  const [exported, setExported] = useState(false);
+  const [view, setView] = useState({ k: 1, tx: 0, ty: 0 });
+  // "Add my pattern": pick from the toolbar, then click the map to drop.
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const [placing, setPlacing] = useState<{ id: string; title: string; code: string } | null>(null);
+  // While placing: the entry the cursor would link to (nearest within radius).
+  const [placingNear, setPlacingNear] = useState<string | null>(null);
+  // The picker lists your own patterns newest first, as thumbnails — you
+  // recognise your work by looking at it, not by reading titles.
+  const [pickerQuery, setPickerQuery] = useState("");
+
+  const svgRef = useRef<SVGSVGElement | null>(null);
+  const draggingEntryRef = useRef<string | null>(null);
+  const draggingPinRef = useRef<string | null>(null);
+  const panRef = useRef<{ px: number; py: number; tx: number; ty: number } | null>(null);
+  const dragMovedRef = useRef(false);
+
+
+
+  // Wheel zoom must preventDefault, which React's synthetic listener cannot —
+  // attach a real non-passive listener.
+  useEffect(() => {
+    const svg = svgRef.current;
+    if (!svg) return;
+    const onWheel = (ev: WheelEvent) => {
+      ev.preventDefault();
+      const point = toViewBox(svg, ev.clientX, ev.clientY);
+      if (!point) return;
+      setView((prev) => {
+        const k = clamp(prev.k * Math.exp(-ev.deltaY * 0.0016), MIN_ZOOM, MAX_ZOOM);
+        // Keep the world point under the cursor fixed while the scale changes.
+        const wx = (point.x - prev.tx) / prev.k;
+        const wy = (point.y - prev.ty) / prev.k;
+        return clampView({ k, tx: point.x - wx * k, ty: point.y - wy * k });
+      });
+    };
+    svg.addEventListener("wheel", onWheel, { passive: false });
+    return () => svg.removeEventListener("wheel", onWheel);
+  }, []);
+
+  const t = UI[lang];
+
+  const toggleLang = () => writeLang(lang === "en" ? "ko" : "en");
+
+  const entryName = (e: AtlasEntry) => (lang === "en" ? e.nmEn : e.nm);
+  const entryKnob = (e: AtlasEntry) => (lang === "en" ? e.knobEn : e.knob) ?? e.knobEn ?? e.knob;
+  const famLabel = (f: AtlasEntry["f"]) => (lang === "en" ? FAMILIES[f].labelEn : FAMILIES[f].label);
+  const statusLabel = (s: AtlasStatusId) => (lang === "en" ? STATUSES[s].labelEn : STATUSES[s].label);
+  const statusLegend = (s: AtlasStatusId) => (lang === "en" ? STATUSES[s].legendEn : STATUSES[s].legend);
+
+  const pinPos = (pin: AtlasPinData): [number, number] => pinPositions[pin.patternId] ?? [pin.x, pin.y];
+  // Fall back to the data coords: hot reloads keep old state while ENTRIES
+  // grows, and a missing id must never take the whole map down.
+  const entryPos = (e: AtlasEntry): [number, number] => positions[e.id] ?? [e.x, e.y];
+  const canEditPin = (pin: AtlasPinData) => isAdmin || (viewerId !== null && viewerId === pin.userId);
+
+  const selectedEntry =
+    selection?.kind === "entry" ? ENTRIES.find((e) => e.id === selection.id) ?? null : null;
+  const selectedPin =
+    selection?.kind === "pin" ? pins.find((p) => p.patternId === selection.id) ?? null : null;
+
+  /* ── coordinate plumbing ── */
+
+  const toDataCoords = (clientX: number, clientY: number): [number, number] | null => {
+    const svg = svgRef.current;
+    if (!svg) return null;
+    const point = toViewBox(svg, clientX, clientY);
+    if (!point) return null;
+    const wx = (point.x - view.tx) / view.k;
+    const wy = (point.y - view.ty) / view.k;
+    const x = Math.max(0, Math.min(100, ((wx - MX) / W) * 100));
+    const y = Math.max(0, Math.min(100, ((MY + H - wy) / H) * 100));
+    return [Math.round(x), Math.round(y)];
+  };
+
+  /** Nearest entry within LINK_RADIUS (perceptual/viewBox distance), else null. */
+  const nearestEntry = ([x, y]: [number, number]): string | null => {
+    let best: string | null = null;
+    let bestDist = LINK_RADIUS;
+    for (const entry of ENTRIES) {
+      const [ex, ey] = entryPos(entry);
+      const dist = Math.hypot(((ex - x) / 100) * W, ((ey - y) / 100) * H);
+      if (dist < bestDist) {
+        bestDist = dist;
+        best = entry.id;
+      }
+    }
+    return best;
+  };
+
+  /* ── pointer choreography: pan the world, drag entries, drag pins ── */
+
+  const onBackgroundDown = (ev: React.PointerEvent) => {
+    const svg = svgRef.current;
+    if (!svg) return;
+    const point = toViewBox(svg, ev.clientX, ev.clientY);
+    if (!point) return;
+    panRef.current = { px: point.x, py: point.y, tx: view.tx, ty: view.ty };
+    dragMovedRef.current = false;
+  };
+
+  const onMapPointerMove = (ev: React.PointerEvent) => {
+    const svg = svgRef.current;
+    if (!svg) return;
+
+    const entryId = draggingEntryRef.current;
+    if (entryId) {
+      const coords = toDataCoords(ev.clientX, ev.clientY);
+      if (!coords) return;
+      dragMovedRef.current = true;
+      setPositions((prev) => ({ ...prev, [entryId]: coords }));
+      return;
+    }
+
+    const pinId = draggingPinRef.current;
+    if (pinId) {
+      const coords = toDataCoords(ev.clientX, ev.clientY);
+      if (!coords) return;
+      dragMovedRef.current = true;
+      setPinPositions((prev) => ({ ...prev, [pinId]: coords }));
+      return;
+    }
+
+    // Placement mode: track which entry the cursor would inherit lineage from.
+    if (placing && !panRef.current) {
+      const coords = toDataCoords(ev.clientX, ev.clientY);
+      if (coords) setPlacingNear(nearestEntry(coords));
+    }
+
+    const pan = panRef.current;
+    if (pan) {
+      const point = toViewBox(svg, ev.clientX, ev.clientY);
+      if (!point) return;
+      if (Math.abs(point.x - pan.px) + Math.abs(point.y - pan.py) > 2) dragMovedRef.current = true;
+      setView((prev) =>
+        clampView({ k: prev.k, tx: pan.tx + (point.x - pan.px), ty: pan.ty + (point.y - pan.py) }),
+      );
+    }
+  };
+
+  const onMapPointerUp = () => {
+    const pinId = draggingPinRef.current;
+    if (pinId && dragMovedRef.current) {
+      const pin = pins.find((p) => p.patternId === pinId);
+      if (pin) void savePin(pin, pinPos(pin));
+    }
+    draggingEntryRef.current = null;
+    draggingPinRef.current = null;
+    panRef.current = null;
+    window.setTimeout(() => {
+      dragMovedRef.current = false;
+    }, 0);
+  };
+
+  const onMapClick = () => {
+    if (dragMovedRef.current) return;
+    // In placement mode the background rect's pointerup does the drop
+    // (the click event carries no coordinates here).
+    if (placing) return;
+    setSelection(null);
+  };
+
+  const onPlaceClick = (ev: React.PointerEvent) => {
+    if (!placing || dragMovedRef.current) return;
+    const coords = toDataCoords(ev.clientX, ev.clientY);
+    if (!coords) return;
+    void placePattern(placing.id, coords);
+  };
+
+  /* ── server writes ── */
+
+  const savePin = async (pin: AtlasPinData, [x, y]: [number, number]) => {
+    await fetch("/api/community/atlas", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ patternId: pin.patternId, x, y, entryId: pin.entryId }),
+    });
+    router.refresh();
+  };
+
+  const setPinLink = async (pin: AtlasPinData, entryId: string | null) => {
+    const [x, y] = pinPos(pin);
+    await fetch("/api/community/atlas", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ patternId: pin.patternId, x, y, entryId }),
+    });
+    router.refresh();
+  };
+
+  const placePattern = async (patternId: string, coords: [number, number]) => {
+    // Dropping NEAR a prompt point is pointing at it — the nearest entry
+    // within LINK_RADIUS becomes the lineage. Dropping in open sea links to
+    // nothing; the pin panel's select stays for corrections either way.
+    const entryId = nearestEntry(coords);
+    const res = await fetch("/api/community/atlas", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ patternId, x: coords[0], y: coords[1], entryId }),
+    });
+    if (res.ok) {
+      setPlacing(null);
+      setPlacingNear(null);
+      setSelection({ kind: "pin", id: patternId });
+      router.refresh();
+    }
+  };
+
+  const removePin = async (patternId: string) => {
+    await fetch("/api/community/atlas", {
+      method: "DELETE",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ patternId }),
+    });
+    setSelection(null);
+    setPinPositions((prev) => {
+      const next = { ...prev };
+      delete next[patternId];
+      return next;
+    });
+    router.refresh();
+  };
+
+  /* ── clipboard ── */
+
+  const copyText = async (text: string) => {
+    try {
+      await navigator.clipboard.writeText(text);
+    } catch {
+      const ta = document.createElement("textarea");
+      ta.value = text;
+      document.body.appendChild(ta);
+      ta.select();
+      document.execCommand("copy");
+      ta.remove();
+    }
+  };
+
+  const copyPrompt = async (entry: AtlasEntry) => {
+    await copyText(buildPrompt(entry));
+    setCopied(true);
+    window.setTimeout(() => setCopied(false), 2200);
+  };
+
+  const exportLayout = async () => {
+    await copyText(JSON.stringify(positions));
+    setExported(true);
+    window.setTimeout(() => setExported(false), 1800);
+  };
+
+  const query = pickerQuery.trim().toLowerCase();
+  const pickerList = myPatterns.filter(
+    (pattern) => query === "" || pattern.title.toLowerCase().includes(query),
+  );
+
+  const chipList: Array<[Filter, string]> = [
+    ["all", t.allChip],
+    ...(Object.keys(STATUSES) as AtlasStatusId[]).map(
+      (s) => [s, statusLabel(s)] as [Filter, string],
+    ),
+  ];
+
+  const worldTransform = `translate(${view.tx} ${view.ty}) scale(${view.k})`;
+  const inv = 1 / view.k;
+
+  return (
+    <div className={styles.atlas}>
+      <div className={styles.toolbar}>
+        <p className={styles.tagline}>
+          {t.tagline} <span className={styles.zoomHint}>{t.zoomHint}</span>
+        </p>
+        <div className={styles.toolbarSpacer} />
+        {myPatterns.length > 0 && (
+          <span className={styles.pickerWrap}>
+            <button
+              type="button"
+              className={styles.toolBtn}
+              data-on={pickerOpen || Boolean(placing)}
+              onClick={() => setPickerOpen((v) => !v)}
+            >
+              {t.addPattern}
+            </button>
+            {pickerOpen && (
+              <div className={styles.picker}>
+                <div className={styles.pickerHead}>{t.pickerHead(myPatterns.length)}</div>
+                {myPatterns.length > 8 && (
+                  <input
+                    type="search"
+                    className={styles.pickerSearch}
+                    placeholder={t.pickerSearch}
+                    value={pickerQuery}
+                    onChange={(ev) => setPickerQuery(ev.target.value)}
+                    autoFocus
+                  />
+                )}
+                <div className={styles.pickerGrid}>
+                  {pickerList.map((pattern) => (
+                    <button
+                      key={pattern.id}
+                      type="button"
+                      className={styles.pickerItem}
+                      title={pattern.title}
+                      onClick={() => {
+                        setPlacing(pattern);
+                        setPickerOpen(false);
+                      }}
+                    >
+                      <span className={styles.pickerTile}>
+                        <PatternCanvas
+                          code={pattern.code}
+                          title={pattern.title}
+                          className={styles.pinWell}
+                        />
+                      </span>
+                      <span className={styles.pickerCaption}>{pattern.title}</span>
+                    </button>
+                  ))}
+                </div>
+              </div>
+            )}
+          </span>
+        )}
+        <button type="button" className={styles.toolBtn} onClick={toggleLang}>
+          {lang === "en" ? "한국어" : "English"}
+        </button>
+        <button
+          type="button"
+          className={styles.toolBtn}
+          data-on={editMode}
+          onClick={() => setEditMode((v) => !v)}
+        >
+          {editMode ? t.editing : t.edit}
+        </button>
+        <button type="button" className={styles.toolBtn} onClick={exportLayout}>
+          {exported ? t.copiedLayout : t.copyLayout}
+        </button>
+      </div>
+
+      <div className={styles.body}>
+        <div className={styles.mapWrap} data-placing={Boolean(placing)}>
+          <div className={styles.chips}>
+            {chipList.map(([key, label]) => (
+              <button
+                key={key}
+                type="button"
+                className={styles.chip}
+                data-on={filter === key}
+                onClick={() => setFilter(key)}
+              >
+                {label}
+              </button>
+            ))}
+          </div>
+
+          {placing && (
+            <div className={styles.placeBanner}>
+              <span>
+                {t.placeBanner(placing.title)}
+                {placingNear && ENTRY_BY_ID.has(placingNear) && (
+                  <span className={styles.bannerLink}>
+                    {" "}→ {entryName(ENTRY_BY_ID.get(placingNear)!)}
+                  </span>
+                )}
+              </span>
+              <button
+                type="button"
+                className={styles.toolBtn}
+                onClick={() => {
+                  setPlacing(null);
+                  setPlacingNear(null);
+                }}
+              >
+                {t.cancel}
+              </button>
+            </div>
+          )}
+
+          <svg
+            ref={svgRef}
+            className={styles.map}
+            viewBox={`0 0 ${VB_W} ${VB_H}`}
+            aria-label={t.introTitle}
+            onPointerMove={onMapPointerMove}
+            onPointerUp={onMapPointerUp}
+            onPointerLeave={onMapPointerUp}
+            onClick={onMapClick}
+            onDoubleClick={() => setView({ k: 1, tx: 0, ty: 0 })}
+          >
+            <defs>
+              <filter id="atlasBlob" x="-60%" y="-60%" width="220%" height="220%">
+                <feGaussianBlur stdDeviation="16" />
+              </filter>
+            </defs>
+
+            {/* Background catcher: pans the world; in placement mode, drops the pattern. */}
+            <rect
+              x={0} y={0} width={VB_W} height={VB_H} fill="transparent"
+              onPointerDown={onBackgroundDown}
+              onPointerUp={onPlaceClick}
+            />
+
+            <g transform={worldTransform}>
+              <rect
+                x={MX} y={MY} width={W} height={H} fill="none"
+                className={styles.frame} pointerEvents="none"
+              />
+              <g className={styles.grid} pointerEvents="none">
+                {[1, 2, 3].map((i) => (
+                  <g key={i}>
+                    <line x1={MX + (W * i) / 4} y1={MY} x2={MX + (W * i) / 4} y2={MY + H} />
+                    <line x1={MX} y1={MY + (H * i) / 4} x2={MX + W} y2={MY + (H * i) / 4} />
+                  </g>
+                ))}
+              </g>
+
+              {BLOBS.map(([fam, cx, cy, rx, ry, rot]) => {
+                const color = FAMILIES[fam].color;
+                return (
+                  <g key={fam} pointerEvents="none">
+                    <ellipse
+                      cx={sx(cx)} cy={sy(cy)}
+                      rx={(rx / 100) * W} ry={(ry / 100) * H}
+                      fill={color} opacity={0.06} filter="url(#atlasBlob)"
+                      transform={`rotate(${rot} ${sx(cx)} ${sy(cy)})`}
+                    />
+                    <g transform={`translate(${sx(cx)} ${sy(cy + ry) - 8}) scale(${inv})`}>
+                      <text textAnchor="middle" fill={color} className={styles.famLabel}>
+                        {famLabel(fam)}
+                      </text>
+                    </g>
+                  </g>
+                );
+              })}
+
+              {/* Lineage threads: a pin hangs from the prompt that made it. */}
+              <g pointerEvents="none">
+                {pins.map((pin) => {
+                  if (!pin.entryId) return null;
+                  const entry = ENTRY_BY_ID.get(pin.entryId);
+                  if (!entry) return null;
+                  const [ex, ey] = entryPos(entry);
+                  const [px, py] = pinPos(pin);
+                  return (
+                    <line
+                      key={`thread-${pin.patternId}`}
+                      x1={sx(ex)} y1={sy(ey)} x2={sx(px)} y2={sy(py)}
+                      stroke={FAMILIES[entry.f].color}
+                      strokeOpacity={0.3}
+                      strokeDasharray="4 4"
+                      vectorEffect="non-scaling-stroke"
+                    />
+                  );
+                })}
+              </g>
+
+              {ENTRIES.filter((e) => filter === "all" || e.st === filter).map((e) => {
+                const [px, py] = entryPos(e);
+                const color = FAMILIES[e.f].color;
+                const dim = e.st === "unexplored" ? 0.45 : e.st === "hold" ? 0.6 : e.st === "invented" ? 0.8 : 1;
+                const dash = e.st === "unexplored" ? "2.5 2.5" : e.st === "invented" ? "1 3" : undefined;
+                const glow = e.st === "verified" ? 7 : e.st === "invented" ? 5 : 3;
+                const isSelected = selection?.kind === "entry" && selection.id === e.id;
+                return (
+                  <g
+                    key={e.id}
+                    role="button"
+                    tabIndex={0}
+                    aria-label={entryName(e)}
+                    className={styles.node}
+                    data-selected={isSelected}
+                    transform={`translate(${sx(px)} ${sy(py)}) scale(${inv})`}
+                    onPointerDown={(ev) => {
+                      if (!editMode) return;
+                      ev.preventDefault();
+                      ev.stopPropagation();
+                      draggingEntryRef.current = e.id;
+                      dragMovedRef.current = false;
+                    }}
+                    onClick={(ev) => {
+                      ev.stopPropagation();
+                      if (!dragMovedRef.current) setSelection({ kind: "entry", id: e.id });
+                    }}
+                    onKeyDown={(ev) => {
+                      if (ev.key === "Enter" || ev.key === " ") setSelection({ kind: "entry", id: e.id });
+                    }}
+                  >
+                    {placingNear === e.id && (
+                      <circle r={13} fill="none" stroke="#F4EFE6" strokeOpacity={0.8} strokeDasharray="3 3" />
+                    )}
+                    {e.st === "active" && (
+                      <circle r={11} fill="none" stroke={LED} className={styles.pulseRing} />
+                    )}
+                    <circle
+                      className={styles.core}
+                      r={6.5}
+                      fill={color}
+                      fillOpacity={dim}
+                      stroke={e.st === "verified" ? "none" : color}
+                      strokeOpacity={Math.min(1, dim + 0.2)}
+                      strokeDasharray={dash}
+                      strokeWidth={e.st === "verified" ? 0 : 1.4}
+                      style={{ filter: `drop-shadow(0 0 ${glow}px ${color})` }}
+                    />
+                    <text x={10} y={4} className={styles.nodeLabel}>{entryName(e)}</text>
+                  </g>
+                );
+              })}
+
+              {pins.map((pin) => {
+                const [px, py] = pinPos(pin);
+                const isSelected = selection?.kind === "pin" && selection.id === pin.patternId;
+                const draggable = editMode && canEditPin(pin);
+                return (
+                  <g
+                    key={pin.patternId}
+                    transform={`translate(${sx(px)} ${sy(py)}) scale(${inv})`}
+                  >
+                    <foreignObject x={-22} y={-44} width={44} height={102}>
+                      <div
+                        className={styles.pin}
+                        data-selected={isSelected}
+                        data-draggable={draggable}
+                        title={pin.title}
+                        onPointerDown={(ev) => {
+                          if (!draggable) return;
+                          ev.preventDefault();
+                          ev.stopPropagation();
+                          draggingPinRef.current = pin.patternId;
+                          dragMovedRef.current = false;
+                        }}
+                        onClick={(ev) => {
+                          ev.stopPropagation();
+                          if (!dragMovedRef.current) setSelection({ kind: "pin", id: pin.patternId });
+                        }}
+                      >
+                        <div className={styles.pinTile}>
+                          <PatternCanvas
+                            code={pin.code}
+                            title={pin.title}
+                            live
+                            className={styles.pinWell}
+                          />
+                        </div>
+                        <div className={styles.pinCaption}>{pin.title}</div>
+                      </div>
+                    </foreignObject>
+                  </g>
+                );
+              })}
+            </g>
+
+            {/* Axis words float over the map, outside the zooming world. */}
+            <g pointerEvents="none">
+              <text x={MX + 10} y={MY + H - 12} className={styles.axis}>{t.axisOrder}</text>
+              <text x={MX + W - 10} y={MY + H - 12} textAnchor="end" className={styles.axis}>
+                {t.axisChaos}
+              </text>
+              <text
+                x={MX + 16} y={MY + H - 34} className={styles.axis}
+                transform={`rotate(-90 ${MX + 16} ${MY + H - 34})`}
+              >{t.axisWire}</text>
+              <text
+                x={MX + 16} y={MY + 150} className={styles.axis}
+                transform={`rotate(-90 ${MX + 16} ${MY + 150})`}
+              >{t.axisField}</text>
+            </g>
+          </svg>
+        </div>
+
+        <aside className={styles.panel}>
+          {selectedPin ? (
+            <>
+              <h2 className={styles.panelTitle}>{selectedPin.title}</h2>
+              <div className={styles.panelEn}>
+                {t.pinBy} {selectedPin.displayUsername ?? selectedPin.username ?? "?"}
+              </div>
+
+              <section className={styles.sec}>
+                <div className={styles.secK}>{t.madeFrom}</div>
+                {canEditPin(selectedPin) ? (
+                  <select
+                    className={styles.fromSelect}
+                    value={selectedPin.entryId ?? ""}
+                    onChange={(ev) => void setPinLink(selectedPin, ev.target.value || null)}
+                  >
+                    <option value="">{t.linkNone}</option>
+                    {ENTRIES.map((entry) => (
+                      <option key={entry.id} value={entry.id}>
+                        {entryName(entry)}
+                      </option>
+                    ))}
+                  </select>
+                ) : selectedPin.entryId && ENTRY_BY_ID.has(selectedPin.entryId) ? (
+                  <button
+                    type="button"
+                    className={styles.fromChip}
+                    style={{
+                      borderColor: FAMILIES[ENTRY_BY_ID.get(selectedPin.entryId)!.f].color,
+                    }}
+                    onClick={() => setSelection({ kind: "entry", id: selectedPin.entryId! })}
+                  >
+                    {entryName(ENTRY_BY_ID.get(selectedPin.entryId)!)}
+                  </button>
+                ) : (
+                  <div className={styles.secV}>{t.linkNone}</div>
+                )}
+              </section>
+
+              {/* Keyed by pattern id: selecting another pin remounts the
+                  player, so its knobs start from that pattern's own defaults
+                  without an effect syncing them. */}
+              <PinPlayer
+                key={selectedPin.patternId}
+                code={selectedPin.code}
+                knobsLabel={t.knobs}
+              />
+
+              <div className={styles.badges}>
+                <span className={styles.badge}>
+                  x {pinPos(selectedPin)[0]} · y {pinPos(selectedPin)[1]}
+                </span>
+              </div>
+              <Link className={styles.openLink} href={`/community/p/${selectedPin.patternId}`}>
+                {t.openPattern}
+              </Link>
+              {canEditPin(selectedPin) && (
+                <>
+                  <p className={styles.moveHint}>{t.moveHint}</p>
+                  <button
+                    type="button"
+                    className={styles.removeBtn}
+                    onClick={() => void removePin(selectedPin.patternId)}
+                  >
+                    {t.removePin}
+                  </button>
+                </>
+              )}
+            </>
+          ) : selectedEntry ? (
+            <>
+              <h2 className={styles.panelTitle}>{entryName(selectedEntry)}</h2>
+              {selectedEntry.en && <div className={styles.panelEn}>{selectedEntry.en}</div>}
+              <div className={styles.badges}>
+                <span className={styles.badgeFam} style={{ background: FAMILIES[selectedEntry.f].color }}>
+                  {famLabel(selectedEntry.f)}
+                </span>
+                <span className={styles.badge} data-live={selectedEntry.st === "active"}>
+                  {statusLabel(selectedEntry.st)}
+                </span>
+                <span className={styles.badge}>
+                  x {entryPos(selectedEntry)[0]} · y {entryPos(selectedEntry)[1]}
+                </span>
+              </div>
+
+              <section className={styles.sec}>
+                <div className={styles.secK}>{t.secTexture}</div>
+                <div className={styles.secV}>{lang === "en" ? selectedEntry.texEn : selectedEntry.tex}</div>
+              </section>
+              <section className={styles.sec}>
+                <div className={styles.secK}>{t.secKnob}</div>
+                <div className={styles.knobBox}>{entryKnob(selectedEntry) ?? "—"}</div>
+              </section>
+              {(lang === "en" ? selectedEntry.vertEn : selectedEntry.vert) && (
+                <section className={styles.sec}>
+                  <div className={styles.secK}>{t.secVert}</div>
+                  <div className={styles.secV}>
+                    {lang === "en" ? selectedEntry.vertEn : selectedEntry.vert}
+                  </div>
+                </section>
+              )}
+              {(lang === "en" ? selectedEntry.riskEn : selectedEntry.risk) && (
+                <section className={styles.sec}>
+                  <div className={styles.secK}>{t.secRisk}</div>
+                  <div className={styles.riskBox}>
+                    {lang === "en" ? selectedEntry.riskEn : selectedEntry.risk}
+                  </div>
+                </section>
+              )}
+              {(lang === "en" ? selectedEntry.implEn : selectedEntry.impl) && (
+                <section className={styles.sec}>
+                  <div className={styles.secK}>{t.secImpl}</div>
+                  <div className={styles.implBox}>
+                    {lang === "en" ? selectedEntry.implEn : selectedEntry.impl}
+                  </div>
+                </section>
+              )}
+
+              {pins.some((pin) => pin.entryId === selectedEntry.id) && (
+                <section className={styles.sec}>
+                  <div className={styles.secK}>{t.patternsFrom}</div>
+                  <div className={styles.miniRow}>
+                    {pins
+                      .filter((pin) => pin.entryId === selectedEntry.id)
+                      .map((pin) => (
+                        <button
+                          key={pin.patternId}
+                          type="button"
+                          className={styles.miniItem}
+                          onClick={() => setSelection({ kind: "pin", id: pin.patternId })}
+                          title={pin.title}
+                        >
+                          <span className={styles.miniTile}>
+                            <PatternCanvas
+                              code={pin.code}
+                              title={pin.title}
+                              className={styles.pinWell}
+                            />
+                          </span>
+                          <span className={styles.miniCaption}>{pin.title}</span>
+                        </button>
+                      ))}
+                  </div>
+                </section>
+              )}
+
+              <section className={styles.sec}>
+                <div className={styles.secK}>{t.secPrompt}</div>
+                <pre className={styles.prompt}>{buildPrompt(selectedEntry)}</pre>
+                <button
+                  type="button"
+                  className={styles.copyBtn}
+                  data-done={copied}
+                  onClick={() => void copyPrompt(selectedEntry)}
+                >
+                  {copied ? t.copiedPrompt : t.copyPrompt}
+                </button>
+              </section>
+            </>
+          ) : (
+            <>
+              <h2 className={styles.panelTitle}>{t.introTitle}</h2>
+              <div className={styles.panelEn}>{t.introSub}</div>
+              <div className={styles.howto}>
+                {lang === "en" ? (
+                  <p>
+                    <b>Horizontal</b> runs order → chaos, <b>vertical</b> runs wire (trajectory) →
+                    field (mist). Find the feeling you want, <b>click the point</b>, and you get a
+                    complete generation prompt for that spot. Paste it into any AI, then paste the
+                    returned code into Pattern Lab.
+                  </p>
+                ) : (
+                  <p>
+                    <b>가로축</b>은 질서→혼돈, <b>세로축</b>은 선(궤적)→장(안개). 원하는 느낌의
+                    자리를 찾아 <b>점을 클릭</b>하면, 그 자리를 탐사하는 완성된 영어 생성
+                    프롬프트가 나온다. 복사해서 아무 AI에나 붙여넣고, 결과 코드를 Pattern Lab에
+                    PASTE.
+                  </p>
+                )}
+                <hr className={styles.hr} />
+                {(Object.keys(STATUSES) as AtlasStatusId[]).map((key) => (
+                  <div key={key} className={styles.legendRow}>
+                    <span className={styles.legendDot} data-status={key} />
+                    {statusLabel(key)} — {statusLegend(key)}
+                  </div>
+                ))}
+                <div className={styles.legendRow}>
+                  <span className={styles.legendTile} />
+                  {t.legendPin}
+                </div>
+                <hr className={styles.hr} />
+                {lang === "en" ? (
+                  <p>
+                    Off-continent <b>lenses</b> (post-processing you can lay over any point):
+                    schlieren (∇ render) · conformal warps (z², 1/z, log z) · depth weighting. One
+                    extra line in the prompt.
+                  </p>
+                ) : (
+                  <p>
+                    대륙 밖 <b>렌즈</b>(어느 점에든 얹는 후처리): 슐리렌(∇ 렌더) · 등각
+                    워프(z², 1/z, log z) · 깊이 가중. 프롬프트에 한 줄 추가하면 된다.
+                  </p>
+                )}
+                <hr className={styles.hr} />
+                {lang === "en" ? (
+                  <p>
+                    Every position is a <b>taste hypothesis</b>. Turn on [Edit layout], drag points
+                    where they belong, then [Copy layout] to export — that is how the map grows.
+                  </p>
+                ) : (
+                  <p>
+                    점의 위치는 전부 <b>취향 가설</b>이다. [배치 편집]을 켜고 끌어서 고친 뒤
+                    [배치 복사]로 내보내면 지도가 자란다.
+                  </p>
+                )}
+              </div>
+            </>
+          )}
+        </aside>
+      </div>
+    </div>
+  );
+}
+
+/* ── the pin player: a pattern running with its own knobs under it ── */
+
+function PinPlayer({ code, knobsLabel }: { code: string; knobsLabel: string }) {
+  const setup = useMemo(() => knobSetupFromCode(code), [code]);
+  const [values, setValues] = useState<number[]>(setup.values);
+  const rotated = describeMatrixShape(matrixFromCode(code)) === "landscape";
+
+  return (
+    <>
+      <div className={styles.panelCanvas}>
+        <div className={styles.playerWell}>
+          <div className={rotated ? commStyles.screenRotator : commStyles.screenUpright}>
+            <SandboxPreview code={code} knobValues={values} knobRanges={setup.ranges} running />
+          </div>
+        </div>
+      </div>
+
+      <section className={styles.sec}>
+        <div className={styles.secK}>{knobsLabel}</div>
+        {setup.labels.map((label, index) => {
+          const [min, max] = setup.ranges[index];
+          const value = values[index] ?? (min + max) / 2;
+          return (
+            <div key={label + index} className={styles.knobRow}>
+              <span className={styles.knobLabel}>{label}</span>
+              <input
+                type="range"
+                className={styles.knobInput}
+                min={min}
+                max={max}
+                step={(max - min) / 200 || 0.01}
+                value={value}
+                onChange={(ev) => {
+                  const next = [...values];
+                  next[index] = Number(ev.target.value);
+                  setValues(next);
+                }}
+              />
+              <span className={styles.knobVal}>{Number(value).toFixed(2)}</span>
+            </div>
+          );
+        })}
+      </section>
+    </>
+  );
+}
+
+/* ── helpers ── */
+
+/** The remembered reading language, as an external store: no effect, no
+ *  hydration fight. Server always renders English. */
+const langListeners = new Set<() => void>();
+
+function subscribeLang(onChange: () => void) {
+  langListeners.add(onChange);
+  window.addEventListener("storage", onChange); // other tabs
+  return () => {
+    langListeners.delete(onChange);
+    window.removeEventListener("storage", onChange);
+  };
+}
+
+function readLang(): Lang {
+  return window.localStorage.getItem(LANG_KEY) === "ko" ? "ko" : "en";
+}
+
+function writeLang(next: Lang) {
+  window.localStorage.setItem(LANG_KEY, next);
+  for (const listener of langListeners) listener();
+}
+
+function clamp(value: number, min: number, max: number) {
+  return Math.max(min, Math.min(max, value));
+}
+
+/** Keep the world covering the viewBox: no blank space slides into view. */
+function clampView(next: { k: number; tx: number; ty: number }) {
+  return {
+    k: next.k,
+    tx: clamp(next.tx, VB_W * (1 - next.k), 0),
+    ty: clamp(next.ty, VB_H * (1 - next.k), 0),
+  };
+}
+
+function toViewBox(svg: SVGSVGElement, clientX: number, clientY: number) {
+  const ctm = svg.getScreenCTM();
+  if (!ctm) return null;
+  return new DOMPoint(clientX, clientY).matrixTransform(ctm.inverse());
+}

--- a/web/src/components/community/CommunityNav.tsx
+++ b/web/src/components/community/CommunityNav.tsx
@@ -33,6 +33,13 @@ const SECTIONS = [
     match: (path: string) =>
       path.startsWith("/community/workshop") || path.startsWith("/community/t/"),
   },
+  {
+    href: "/community/atlas",
+    label: "Atlas",
+    // The other map: workshop charts the hardware's directions, this charts
+    // pattern-technique space — with a generation prompt on every point.
+    match: (path: string) => path.startsWith("/community/atlas"),
+  },
 ];
 
 export default function CommunityNav({

--- a/web/src/components/community/DeckDock.tsx
+++ b/web/src/components/community/DeckDock.tsx
@@ -67,6 +67,8 @@ const NO_PATTERNS_HERE = [
   "/community/reports",
   "/community/featured",
   "/community/territories",
+  // The atlas maps techniques, not collectable patterns.
+  "/community/atlas",
 ];
 
 function dockBelongs(pathname: string): boolean {

--- a/web/src/lib/atlas/data.ts
+++ b/web/src/lib/atlas/data.ts
@@ -1,0 +1,680 @@
+// Pattern Atlas — the map of pattern-technique space.
+//
+// A sibling of the workshop map: the workshop charts where the HARDWARE could
+// go (territories = project directions), this charts where PATTERNS could go.
+// Axes are feelings, not math: x = order → chaos, y = wire/trajectory → field.
+//
+// This module is the single source of truth, edited like the community seed
+// script — by hand, in code. Coordinates are taste hypotheses: reposition with
+// the page's edit mode, export, and bake the JSON back here.
+//
+// Localization: the page defaults to English (the community is public);
+// Korean lives in the base fields, English in the *En fields. The generation
+// prompt is English-only — it is written for AIs, not for readers.
+//
+// The generation prompt (BASE) mirrors Pattern Lab's COPY PROMPT assembly
+// (lib/gemini.ts: buildVariantCopyPrompt → buildTechGuide) verbatim, with the
+// atlas taste/craft directions layered where the lab puts VARIANT_*_DIRECTION.
+// If gemini.ts's wording changes, change it here too.
+
+export type AtlasFamilyId =
+  | "ink" | "waterfall" | "optics" | "advect"
+  | "feedback" | "pde" | "life" | "critical" | "invent";
+
+export type AtlasStatusId =
+  | "verified" | "active" | "hold" | "unexplored" | "invented";
+
+export type AtlasEntry = {
+  id: string;
+  /** Korean name. */
+  nm: string;
+  /** English name. */
+  nmEn: string;
+  /** Small-caps subtitle (language-neutral). */
+  en?: string;
+  f: AtlasFamilyId;
+  st: AtlasStatusId;
+  /** Data coords: x 0..100 (order→chaos), y 0..100 (wire→field). */
+  x: number;
+  y: number;
+  /** Texture — what the material looks like. */
+  tex: string;
+  texEn: string;
+  /** Critical knob and its phase transition (Korean display; English display reuses knobEn). */
+  knob?: string;
+  /** English critical-knob line — used both in the panel (EN) and in the prompt. */
+  knobEn?: string;
+  vert?: string;
+  vertEn?: string;
+  risk?: string;
+  riskEn?: string;
+  impl?: string;
+  implEn?: string;
+  /** Prompt subject line (English). */
+  topic?: string;
+  /** Prompt implementation hints (English). */
+  hints?: string[];
+};
+
+export const FAMILIES: Record<AtlasFamilyId, { label: string; labelEn: string; color: string }> = {
+  ink:       { label: "동역학계 잉크",    labelEn: "Dynamical-systems ink",      color: "#5ad7ff" },
+  waterfall: { label: "이력 폭포",        labelEn: "History waterfalls",         color: "#7ea4ff" },
+  optics:    { label: "광학 누적",        labelEn: "Optical accumulation",       color: "#ffce6b" },
+  advect:    { label: "필드 이류",        labelEn: "Field advection",            color: "#7fe0a0" },
+  feedback:  { label: "재귀 피드백",      labelEn: "Recursive feedback",         color: "#ff8ad4" },
+  pde:       { label: "PDE 물성",         labelEn: "PDE matter",                 color: "#ffa06b" },
+  life:      { label: "연속 생명",        labelEn: "Continuous life",            color: "#c9a0ff" },
+  critical:  { label: "임계 · 유체 (섬)", labelEn: "Criticality · fluids",       color: "#6be0d0" },
+  invent:    { label: "발명 실험",        labelEn: "Invented experiments",       color: "#d8d2c4" },
+};
+
+export const STATUSES: Record<AtlasStatusId, {
+  label: string; labelEn: string; legend: string; legendEn: string;
+}> = {
+  verified: {
+    label: "검증됨", labelEn: "Verified",
+    legend: "본토 — 실기기/취향 통과",
+    legendEn: "mainland — passed hardware and taste",
+  },
+  active: {
+    label: "탐사중", labelEn: "Exploring",
+    legend: "s01 — 기술검증 통과, 판정 대기",
+    legendEn: "s01 — passed tech verification, awaiting verdict",
+  },
+  hold: {
+    label: "유보", labelEn: "On hold",
+    legend: "평가 애매 — 재도전 가치",
+    legendEn: "ambiguous verdict — worth a second attempt",
+  },
+  unexplored: {
+    label: "미탐사", labelEn: "Uncharted",
+    legend: "해도에만 있는 땅",
+    legendEn: "land that exists only on the chart",
+  },
+  invented: {
+    label: "발명", labelEn: "Invented",
+    legend: "AI 창작 가설 — 실재하는 수학, 아직 아무도 안 밟은 땅",
+    legendEn: "AI-authored hypotheses — real mathematics nobody has walked yet",
+  },
+};
+
+/** Continent blobs: [family, cx, cy, rx, ry, rotationDeg] in data coords. */
+export const BLOBS: Array<[AtlasFamilyId, number, number, number, number, number]> = [
+  ["ink",       50, 27, 31, 14, -5],
+  ["waterfall", 63, 35, 24, 13,  7],
+  ["optics",    38, 58, 15, 11,  0],
+  ["advect",    58, 61, 15, 17,  0],
+  ["pde",       56, 77, 34, 11,  0],
+  ["life",      56, 74, 11,  7,  0],
+  ["feedback",  79, 59, 10,  8,  0],
+];
+
+export const ENTRIES: AtlasEntry[] = [
+  { id: "clifford", nm: "Clifford · De Jong 잉크", nmEn: "Clifford · De Jong ink", en: "STRANGE INK", f: "ink", st: "verified", x: 68, y: 22,
+    tex: "수십만 반복 궤적이 페이드 잉크 버퍼에 쌓여 만드는 필라멘트 레이스. 계수 모핑으로 접히고 펼쳐진다.",
+    texEn: "Hundreds of thousands of iterated orbits piling into a fading ink buffer — filament lace that folds and unfolds as the coefficients morph.",
+    knob: "사상 계수(a,b,c,d 중 하나) — 어트랙터의 위상 자체가 바뀌는 분기를 건넌다.",
+    knobEn: "one map coefficient (a, b, c, d) — it crosses bifurcations where the attractor's topology itself changes",
+    vert: "어트랙터를 세로로 세워 회전 투영, 긴 축을 따라 접히게.",
+    vertEn: "Stand the attractor upright under a rotating projection; let it fold along the long axis.",
+    risk: "계수 공간 대부분이 발산/점 붕괴. 검증된 유역을 시드로, 그 근방만 모핑.",
+    riskEn: "Most of coefficient space diverges or collapses. Seed a known-good basin and morph only nearby.",
+    topic: "Strange ink — orbits of a Clifford / De Jong style 2D iterated map accumulated into a fading ink buffer",
+    hints: ["accumulate thousands of points per frame: buf *= fade, buf[hit] += ink",
+            "morph coefficients gently around a known-good basin — most of coefficient space diverges or collapses",
+            "smoothstep tone curve on output"] },
+
+  { id: "gmira", nm: "Gumowski-Mira 잉크", nmEn: "Gumowski-Mira ink", en: "PETAL INK", f: "ink", st: "verified", x: 58, y: 28,
+    tex: "꽃잎·해양생물 같은 대칭 필라멘트가 뭉개지며 유기적 레이스가 된다.",
+    texEn: "Symmetric petal-like filaments smearing into organic lace.",
+    knob: "μ(비선형 항) — 대칭 꽃 ↔ 흩어진 혼돈 구름.",
+    knobEn: "mu (the nonlinearity) — symmetric petal lace ↔ scattered chaotic cloud",
+    topic: "Fading-ink orbit accumulation of the Gumowski-Mira map",
+    hints: ["ride the knob from the basin where symmetry survives into the basin where it collapses"] },
+
+  { id: "lorenz", nm: "3D 흐름 잉크 (Lorenz · Thomas)", nmEn: "3D flow ink (Lorenz · Thomas)", en: "FLOW INK", f: "ink", st: "verified", x: 63, y: 34,
+    tex: "3D 궤적의 회전 투영 + 깊이 가중 잉크 — 감긴 실타래가 숨쉬며 돈다.",
+    texEn: "Rotating projection of 3D trajectories with depth-weighted ink — a wound skein turning as it breathes.",
+    knob: "Lorenz ρ / Thomas b — 고정점 수렴 ↔ 혼돈의 경계를 건넌다.",
+    knobEn: "Lorenz rho / Thomas b — crosses the boundary between fixed-point convergence and chaos",
+    topic: "3D flow ink — Lorenz or Thomas attractor trajectories under a rotating projection with depth-weighted ink",
+    hints: ["clamp integration dt and reseed on divergence", "multiply ink intensity by depth for volume"] },
+
+  { id: "chirikov", nm: "표준사상 위상공간", nmEn: "Standard-map phase space", en: "KAM SEA", f: "ink", st: "verified", x: 47, y: 26,
+    tex: "KAM 섬들의 동심 레이스가 혼돈 바다에 잠식되는 위상공간의 초상.",
+    texEn: "Concentric lace of KAM islands being eaten by a chaotic sea — a portrait of phase space itself.",
+    knob: "K(킥 강도) — KAM 섬 보존 ↔ 붕괴. 교과서적 위상전이.",
+    knobEn: "K (kick strength) — KAM islands survive ↔ dissolve; a textbook phase transition",
+    topic: "Phase-space portrait of the Chirikov standard map — hundreds of initial conditions accumulated as ink (KAM islands in a chaotic sea)",
+    hints: ["sweep K roughly 0.5..5", "run hundreds of initial conditions in parallel for density"] },
+
+  { id: "harmono", nm: "하모노그래프", nmEn: "Harmonograph", en: "PENDULUM LACE", f: "ink", st: "verified", x: 18, y: 14,
+    tex: "감쇠 진동의 간섭 곡선 — 질서 쪽 끝단의 보석 세공.",
+    texEn: "Interference curves of damped oscillation — jewel work at the order end of the map.",
+    knob: "Detune(주파수비 어긋남) — 닫힌 리사주 ↔ 세차하는 나선 띠.",
+    knobEn: "detune (frequency-ratio offset) — closed Lissajous figures ↔ precessing spiral bands",
+    risk: "질서 끝단이라 5분 서사가 약함 — 모핑 필수.",
+    riskEn: "Weak five-minute narrative at the order end — morphing is mandatory.",
+    topic: "Damped harmonograph curves accumulated into fading ink",
+    hints: ["this sits at the order end of the map — morphing is mandatory or it freezes into a dead picture"] },
+
+  { id: "sprott", nm: "미사용 어트랙터 군도", nmEn: "Uncharted attractor archipelago", en: "UNCHARTED ATTRACTORS", f: "ink", st: "unexplored", x: 74, y: 30,
+    tex: "Ikeda · Tinkerbell · Svensson · Aizawa · Sprott 수십 종 — 각각 결이 다른 필라멘트.",
+    texEn: "Ikeda · Tinkerbell · Svensson · Aizawa · dozens of Sprott systems — each with a different filament grain.",
+    knob: "각 계의 급소 계수 (사전 스캔으로 좋은 유역부터 찾기).",
+    knobEn: "that system's own critical coefficient — scan for good basins first",
+    topic: "Pick one unused attractor (Ikeda map, Tinkerbell, Svensson, Aizawa, or a Sprott flow) and render it as fading orbit ink",
+    hints: ["scan several candidates quickly; keep only filament textures that differ clearly from Clifford/De Jong"] },
+
+  { id: "flame", nm: "프랙탈 플레임", nmEn: "Fractal flame", en: "FRACTAL FLAME", f: "ink", st: "hold", x: 52, y: 42,
+    tex: "variation 블렌드로 비선형 왜곡된 IFS — 빛나는 깃털/연기 필라멘트.",
+    texEn: "An IFS warped by blended nonlinear variations — glowing feather and smoke filaments.",
+    knob: "variation 가중치 블렌드 — 형태 문법 자체가 바뀐다.",
+    knobEn: "variation weight blend — the form grammar itself changes",
+    risk: "한 번 시도, 평가 애매. variation 폭을 넓혀 재도전할 가치.",
+    riskEn: "Tried once, verdict ambiguous. Worth retrying with a much wider variation set.",
+    topic: "Fractal flame — an IFS with blended nonlinear variations, accumulated as log-density ink",
+    hints: ["log-density tone mapping is what makes flames glow"] },
+
+  { id: "caustic", nm: "파면 굴절 커스틱", nmEn: "Refraction caustics", en: "POOLSIDE", f: "optics", st: "verified", x: 40, y: 58,
+    tex: "굴절된 광자들이 착지점에 누적되어 만드는 그물빛 — 가짜 패턴이 아닌 실제 광학량.",
+    texEn: "Photons refracted through a wavefront, accumulated where they land — real optics, not a faked pattern.",
+    knob: "depth(초점거리) — 퍼진 일렁임 ↔ 날카로운 그물 특이점.",
+    knobEn: "depth (focal distance) — soft shimmer ↔ sharp caustic web singularities",
+    topic: "Refraction caustics — photons passed through a slowly morphing wavefront, accumulated where they land",
+    hints: ["thousands of photons per frame", "build the wavefront from a sum of slow low-frequency noises"] },
+
+  { id: "mirror", nm: "반사 커스틱 · 중력 렌즈", nmEn: "Reflection caustics · gravity lens", en: "FOLDED LIGHT", f: "optics", st: "unexplored", x: 46, y: 64,
+    tex: "곡면 거울/질량장이 접는 빛 — 커스틱의 형제, 더 이질적인 접힘(fold/cusp).",
+    texEn: "Light folded by curved mirrors or a mass field — sibling of caustics with stranger folds and cusps.",
+    knob: "곡률/질량 분포 — 커스틱 가지가 태어나고 합쳐지는 전이.",
+    knobEn: "curvature / mass distribution — caustic folds and cusps are born and merge",
+    topic: "Reflection caustics off a curved mirror, or gravitational-lens style deflection — photon landing accumulation" },
+
+  { id: "interf", nm: "이동 광원 간섭 누적", nmEn: "Slow interference accumulation", en: "SLOW INTERFERENCE", f: "optics", st: "unexplored", x: 30, y: 52,
+    tex: "천천히 움직이는 광원들의 위상 간섭이 시간으로 쌓이는 모아레 장.",
+    texEn: "Phase interference of slowly moving sources, accumulated over time into a drifting moiré field.",
+    knob: "광원 수/파장비 — 정상파 격자 ↔ 유동 간섭.",
+    knobEn: "source count / wavelength ratio — standing-wave lattice ↔ drifting interference",
+    risk: "'단순 파동 간섭' 클리셰와 한 끗 차이 — 누적과 모핑으로만 차별화된다.",
+    riskEn: "One step from the plain-wave-interference cliché — only accumulation and morphing set it apart.",
+    topic: "Slowly moving wave sources whose interference accumulates over time into a drifting moiré field",
+    hints: ["differentiate from the cliché ripple demo through accumulation and slow morphing — never a static interference shot"] },
+
+  { id: "gale", nm: "모핑 벡터장 이류", nmEn: "Morphing-field advection", en: "GALE INK", f: "advect", st: "verified", x: 55, y: 68,
+    tex: "보이지 않는 입자들이 남기는 유선 잉크 — 바람의 질감.",
+    texEn: "Streamline ink left behind by invisible particles — the texture of wind.",
+    knob: "curl 비율 0↔1 — 층류 결 ↔ 난류 소용돌이 전이.",
+    knobEn: "curl ratio 0↔1 — laminar grain ↔ turbulent swirl transition",
+    topic: "Gale ink — invisible particles advected through a morphing vector field, leaving only streamline ink",
+    hints: ["particles must never read as objects: short lifetimes, ink trails only"] },
+
+  { id: "physarum", nm: "Physarum 점균", nmEn: "Physarum slime", en: "SLIME NETWORK", f: "advect", st: "verified", x: 61, y: 42,
+    tex: "페로몬 장을 따라 자기조직되는 수송망 — 살아있는 잎맥 웹.",
+    texEn: "A transport web self-organizing along a pheromone field — living leaf veins.",
+    knob: "sense angle / reach — 망의 굵기·분기 밀도가 위상 변화.",
+    knobEn: "sensor angle / sensor reach — the network's thickness and branching density shift phase",
+    topic: "A Physarum transport network — agents plus a pheromone trail field, self-organizing into living vein webs",
+    hints: ["thousands of agents + a diffusing, decaying trail grid"] },
+
+  { id: "mphysarum", nm: "다종 점균", nmEn: "Two-species slime", en: "TERRITORY WAR", f: "advect", st: "unexplored", x: 66, y: 47,
+    tex: "서로 밀어내는 두 페로몬 종의 영토 전쟁 — 경계 필라멘트가 요동.",
+    texEn: "A territorial war between two mutually repelling pheromone species — the boundary filaments quiver.",
+    knob: "종간 반발 계수 — 공존 ↔ 영토 분리 전이.",
+    knobEn: "cross-species repulsion — coexistence ↔ territorial segregation",
+    topic: "Two-species Physarum with mutually repelling pheromone fields — a territorial war of transport networks" },
+
+  { id: "smoke", nm: "curl noise 연기", nmEn: "Curl-noise smoke", en: "RISING SMOKE", f: "advect", st: "unexplored", x: 62, y: 78,
+    tex: "비압축 curl 장 + 부력 — 솔버 없이 피어오르는 연기 기둥.",
+    texEn: "A divergence-free curl field plus buoyancy — smoke columns rising without a solver.",
+    knob: "부력/난류 스케일 — 층류 기둥 ↔ 말려 올라가는 난류.",
+    knobEn: "buoyancy / turbulence scale — laminar column ↔ curling turbulence",
+    vert: "상승 자체가 주인공 — 세로 프레임과 천생연분.",
+    vertEn: "Rising itself is the protagonist — born for the tall frame.",
+    topic: "Rising smoke — a curl-noise (divergence-free) velocity field plus buoyancy advecting a density field upward",
+    hints: ["no solver needed: the curl of a noise potential is already incompressible"] },
+
+  { id: "lic", nm: "LIC 유선 직물", nmEn: "LIC streamline fabric", en: "LINE INTEGRAL CONVOLUTION", f: "advect", st: "unexplored", x: 43, y: 50,
+    tex: "벡터장 전체를 노이즈로 문질러 얻는 조밀한 유선 직물 — 철가루 자기장의 질감. 플로우필드 클리셰의 비클리셰 상위호환. (연구 수입)",
+    texEn: "Noise smeared along an entire vector field — a dense woven streamline fabric, the iron-filings texture. The non-cliché upgrade of the flow field. (research import)",
+    knob: "장의 위상 구조(소용돌이 수/배치) — 결이 갈라지는 임계.",
+    knobEn: "the field's topology (number and placement of vortices) — where the grain tears apart",
+    risk: "픽셀당 유선 적분 수십 스텝 — ESP32 예산 주의.",
+    riskEn: "Tens of integration steps per pixel — mind the ESP32 budget.",
+    topic: "Line Integral Convolution — smear noise along a morphing vector field into a dense woven streamline fabric",
+    hints: ["budget: integrate a low-res field with interpolation; the per-pixel streamline integral is the expensive part",
+            "scroll the noise phase over time so the fabric flows"] },
+
+  { id: "ouroboros", nm: "재귀 피드백", nmEn: "Recursive feedback", en: "OUROBOROS", f: "feedback", st: "hold", x: 76, y: 62,
+    tex: "프레임 전체가 회전+줌+워프를 거쳐 자기 위에 재합성 — 무한 터널의 물질화.",
+    texEn: "The whole frame re-composited onto itself through rotate + zoom + warp — an infinite tunnel made material.",
+    knob: "zoom=1 경계 — 수렴 ↔ 폭주의 칼날 위.",
+    knobEn: "the zoom≈1 boundary — the knife edge between convergence and blow-up",
+    risk: "단독 평가는 애매했음. 교배 기계로서 더 가치.",
+    riskEn: "Ambiguous on its own; more valuable as a crossbreeding machine.",
+    topic: "Recursive frame feedback — the whole frame re-composited onto itself through rotate + zoom + warp" },
+
+  { id: "hybrid", nm: "피드백 교배", nmEn: "Feedback crossbreed", en: "CROSSBREED", f: "feedback", st: "unexplored", x: 82, y: 56,
+    tex: "검증된 소스(커스틱·잉크)를 피드백 기계에 씨앗으로 — 소스의 질감이 재귀로 증폭된다.",
+    texEn: "A proven source (caustic ink, attractor ink) fed as the seed of the feedback machine — its texture amplified by recursion.",
+    knob: "피드백 게인 × 소스 강도 — 소스 지배 ↔ 재귀 지배.",
+    knobEn: "feedback gain × source strength — source-dominated ↔ recursion-dominated",
+    topic: "A feedback crossbreed — feed a proven source (caustic ink, attractor ink) as the seed of a rotate+zoom+warp frame feedback" },
+
+  { id: "cgl", nm: "CGL 결함 난류", nmEn: "CGL defect turbulence", en: "BOILING", f: "pde", st: "verified", x: 86, y: 72,
+    tex: "나선 결함들이 태어나고 소멸하는 끓는 장 — '끓는 것'의 정수.",
+    texEn: "Spiral defects born and dying across a boiling field — the essence of 'the boiling one'.",
+    knob: "α·β — Benjamin-Feir 임계선을 건너는 결함 난류 전이.",
+    knobEn: "alpha·beta — crossing the Benjamin-Feir line into defect turbulence",
+    topic: "Complex Ginzburg-Landau spiral-defect turbulence, rendering |A|",
+    hints: ["pick regimes with local drama (defects) — uniform activity reads as grey mush",
+            "guard with an amplitude ceiling + reseed"] },
+
+  { id: "fhn", nm: "FitzHugh-Nagumo", nmEn: "FitzHugh-Nagumo", en: "EXCITABLE", f: "pde", st: "hold", x: 71, y: 66,
+    tex: "흥분파 전선이 쓸고 지나가는 매질 — '뛰는 것'.",
+    texEn: "An excitable medium swept by wavefronts — 'the beating one'.",
+    knob: "흥분성 임계 — 파 소멸 ↔ 나선파 ↔ 난류 breakup.",
+    knobEn: "excitability threshold — wave death ↔ stable spirals ↔ turbulent breakup",
+    risk: "전선만 보이면 저밀도 — 유보였음. breakup 레짐 위주로 재도전.",
+    riskEn: "Lone fronts read as low density — held. Retry in the breakup regime.",
+    topic: "A FitzHugh-Nagumo excitable medium in its spiral-wave breakup regime",
+    hints: ["only the breakup regime has enough density; lone traveling fronts read as low-density props"] },
+
+  { id: "sh", nm: "Swift-Hohenberg", nmEn: "Swift-Hohenberg", en: "FREEZING", f: "pde", st: "hold", x: 27, y: 72,
+    tex: "줄무늬/육각 패턴이 굳어가는 장 — '굳는 것'.",
+    texEn: "Stripes and hexagons hardening into place — 'the freezing one'.",
+    knob: "r(분기 파라미터) — 균질 ↔ 패턴 형성 임계.",
+    knobEn: "r (bifurcation parameter) — homogeneous ↔ patterned; ride near onset",
+    risk: "정적이 되기 쉬움 — 결함 동역학 위주로만.",
+    riskEn: "Freezes into a still picture easily — defect dynamics only.",
+    topic: "Swift-Hohenberg pattern formation, focused on crawling defect dynamics near onset",
+    hints: ["stay near onset where defects crawl — deep in the patterned phase it freezes into a dead picture"] },
+
+  { id: "cahn", nm: "Cahn-Hilliard 상분리", nmEn: "Cahn-Hilliard separation", en: "SPINODAL", f: "pde", st: "unexplored", x: 38, y: 80,
+    tex: "기름과 물이 갈라지며 굵어지는 미로 — 성장·병합의 서사가 내장돼 있다.",
+    texEn: "Oil and water unmixing into a coarsening labyrinth — a narrative of growth and merging built into the physics.",
+    knob: "혼합비 — 미로(스피노달) ↔ 방울(핵생성) 위상.",
+    knobEn: "mixture ratio — labyrinth (spinodal) ↔ droplet (nucleation) morphology",
+    topic: "Cahn-Hilliard spinodal decomposition — two phases separating and coarsening, a built-in narrative of growth and merging",
+    hints: ["4th-order PDE: use semi-implicit or spectral stepping",
+            "if spectral on a real field: enforce Hermitian symmetry every step (hard-won lesson — roundoff ghosts grow exponentially otherwise)"] },
+
+  { id: "ising", nm: "Ising 어닐링", nmEn: "Ising annealing", en: "CRITICAL DOMAINS", f: "pde", st: "unexplored", x: 46, y: 86,
+    tex: "자화 도메인이 온도에 따라 얼고 녹는 통계역학의 장.",
+    texEn: "Magnetization domains freezing and melting with temperature — statistical mechanics as a field.",
+    knob: "T(온도) — 임계점 근방의 프랙탈 요동이 하이라이트.",
+    knobEn: "temperature T — the critical point's fractal flicker is the highlight",
+    topic: "Ising-model annealing — magnetization domains freezing and melting with temperature, fractal fluctuations near criticality",
+    hints: ["checkerboard update for parallel-friendly sweeps",
+            "render local magnetization averages, not raw spins (raw spins are pixel noise)"] },
+
+  { id: "schrod", nm: "Schrödinger 파속", nmEn: "Schrödinger packet", en: "QUANTUM CAUSTICS", f: "pde", st: "unexplored", x: 56, y: 82,
+    tex: "복소 파동함수 |ψ|²의 간섭·터널링·산란 — 양자 커스틱.",
+    texEn: "|ψ|² of a complex wavefunction — interference, tunneling, scattering. Quantum caustics.",
+    knob: "퍼텐셜 지형 — 속박 ↔ 산란 전이.",
+    knobEn: "the potential landscape — bound ↔ scattering transition",
+    topic: "2D Schrödinger wave-packet evolution rendered as |psi|² — interference, tunneling, scattering",
+    hints: ["split-step spectral method", "use norm conservation as the divergence guard"] },
+
+  { id: "lineage", nm: "Lineage — KS 폭포", nmEn: "Lineage — KS waterfall", en: "KURAMOTO-SIVASHINSKY", f: "waterfall", st: "active", x: 58, y: 38,
+    tex: "화염면 혼돈의 계보도 — 세포가 태어나고 합쳐지고 갈라지는 직조가 아래로 흐른다.",
+    texEn: "A genealogy of flame-front chaos — cells born, merging and splitting, woven downward.",
+    knob: "Domain(L)=16..64 — 동결 기둥 ↔ 세포 병합 ↔ 땋임 난류.",
+    knobEn: "domain length L = 16..64 — frozen columns ↔ breathing cell merges ↔ braided turbulence",
+    impl: "_temp/exploration/s01-waterfall/lineage.js · 기술검증 통과, 판정 대기",
+    implEn: "_temp/exploration/s01-waterfall/lineage.js · passed tech verification, awaiting verdict",
+    topic: "A vertical history waterfall of 1D Kuramoto-Sivashinsky flame-front chaos — newest row on top, ancestry scrolling down",
+    hints: ["spectral IMEX + Hermitian projection every step — roundoff otherwise grows a non-Hermitian ghost that blows up every ~300 time units",
+            "an N=64 dealiased grid only resolves dissipation up to L≈64"] },
+
+  { id: "blight", nm: "Blight — CML 간헐성", nmEn: "Blight — CML intermittency", en: "DIRECTED PERCOLATION", f: "waterfall", st: "active", x: 76, y: 42,
+    tex: "어두운 층류 들판을 밝은 난류 레이스가 잠식 — 감염 전선의 폭포.",
+    texEn: "Bright turbulent lace eating through a dark laminar field — a waterfall of infection fronts.",
+    knob: "Chaos(a)=1.44..2.0 — 층류 ↔ 퍼콜레이션 ↔ 전면 난류.",
+    knobEn: "map coefficient a = 1.44..2.0 — laminar ↔ percolating fronts ↔ full turbulence (directed-percolation-like)",
+    impl: "_temp/exploration/s01-waterfall/blight.js · 기술검증 통과, 판정 대기",
+    implEn: "_temp/exploration/s01-waterfall/blight.js · passed tech verification, awaiting verdict",
+    topic: "A waterfall of coupled-map-lattice spatiotemporal intermittency, rendered by the recurrence distance |x(t) - x(t-2)|",
+    hints: ["render the recurrence distance, not spatial roughness — the laminar zigzag dithers into 1px stripes otherwise",
+            "a slow EMA plus 3-tap smoothing fuses period-2 flicker into continuous filaments"] },
+
+  { id: "logistic", nm: "로지스틱 분기 스캔", nmEn: "Logistic bifurcation scan", en: "BIFURCATION FALLS", f: "waterfall", st: "unexplored", x: 66, y: 20,
+    tex: "r을 훑으며 흘러내리는 분기 다이어그램 — 갈라지는 궤도 밀도의 폭포.",
+    texEn: "The bifurcation diagram flowing down as r scans — a waterfall of splitting orbit density.",
+    knob: "r 중심/폭 — 주기배가 계단 ↔ 혼돈 띠 ↔ 주기 창.",
+    knobEn: "r center / width — period-doubling staircase ↔ chaos bands ↔ periodic windows",
+    risk: "분기도는 교과서 이미지 — 살아있는 스캔 + 궤도 잉크로만 차별화됨.",
+    riskEn: "The diagram is a textbook image — only a living, scanning, ink-dense waterfall earns its place.",
+    topic: "A logistic-map bifurcation waterfall — each row a histogram of orbit density while the scanned r range drifts and breathes",
+    hints: ["the bifurcation diagram is a textbook image: it only earns its place as a living, scanning, ink-dense waterfall"] },
+
+  { id: "kdv", nm: "KdV 솔리톤 궤적", nmEn: "KdV soliton worldlines", en: "SOLITON WORLDLINES", f: "waterfall", st: "unexplored", x: 22, y: 24,
+    tex: "솔리톤들이 서로를 통과하는 세로 월드라인 직조.",
+    texEn: "Solitons passing through one another — a weave of vertical worldlines.",
+    knob: "분산 계수 — 솔리톤 분해 ↔ 파열.",
+    knobEn: "dispersion coefficient — soliton decomposition ↔ breakdown",
+    risk: "월드라인이 셀 수 있는 선으로 보일 위험 — 밀도 확보가 관건 (뻔함 필터 2번 경계).",
+    riskEn: "Worldlines risk being countable lines — density is the whole game.",
+    topic: "KdV soliton worldlines woven downward — solitons passing through each other in a vertical history waterfall",
+    hints: ["danger: countable worldlines — keep enough solitons and ink that it reads as weave, not lines"] },
+
+  { id: "cgl1d", nm: "1D CGL 폭포", nmEn: "1D CGL waterfall", en: "PHASE DEFECT FALLS", f: "waterfall", st: "unexplored", x: 81, y: 47,
+    tex: "1차원 위상 결함들의 생멸이 흘러내리는 시공간 얼룩.",
+    texEn: "Phase defects born and dying as spacetime stains flowing down the frame.",
+    knob: "α·β — 위상 난류 ↔ 결함 난류.",
+    knobEn: "alpha·beta — phase turbulence ↔ defect turbulence",
+    topic: "A vertical waterfall of 1D complex Ginzburg-Landau — phase defects born and dying as spacetime stains",
+    hints: ["complex field: use an amplitude ceiling as the divergence guard"] },
+
+  { id: "lenia", nm: "Lenia", nmEn: "Lenia", en: "CONTINUOUS LIFE", f: "life", st: "unexplored", x: 60, y: 72,
+    tex: "연속 커널 CA — 부드러운 생명 형태가 헤엄치는 장.",
+    texEn: "The continuous-kernel cellular automaton — soft life forms swimming as a field.",
+    knob: "커널 반경 / 성장함수 중심·폭 — 종(species)이 바뀌는 파라미터 공간.",
+    knobEn: "kernel radius / growth-function center and width — the parameter space where species change",
+    risk: "'생명체'가 개체로 보이는 순간 사망 — 군집/장 스케일 레짐으로만.",
+    riskEn: "The moment a creature is countable it dies — colony/field-scale regimes only.",
+    topic: "Lenia, the continuous cellular automaton — tuned to colony/field-scale regimes (tissues and blooms, never a single creature)",
+    hints: ["separable or small kernels to fit the ESP32 convolution budget",
+            "if it reads as one countable creature the pattern is dead — stay at colony/field scale"] },
+
+  { id: "nca", nm: "Neural CA", nmEn: "Neural CA", en: "LEARNED RULES", f: "life", st: "unexplored", x: 52, y: 76,
+    tex: "학습된 국소 규칙이 씨앗에서 텍스처를 길러냄 — 규칙 vs 학습의 단층선 위. (연구 수입)",
+    texEn: "A learned local rule growing texture from a seed — sitting on the rules-vs-learning fault line. (research import)",
+    knob: "학습 후엔 급소가 약함 — 노이즈 주입/스텝률 정도. 급소 노브 요건과 긴장 관계.",
+    knobEn: "inherently weak after training — noise injection / step rate; in tension with the critical-knob rule",
+    risk: "오프라인 학습 필요 + ESP32 추론 예산 — 장기 후보.",
+    riskEn: "Needs offline training plus an ESP32 inference budget — a long shot.",
+    topic: "Neural CA texture growth — train the local update rule offline, bake the small weights into the pattern code",
+    hints: ["long shot: training happens outside; inference must fit a tiny net within the per-frame budget"] },
+
+  { id: "fluid", nm: "Stable Fluids 잉크", nmEn: "Stable Fluids ink", en: "REAL FLUID", f: "critical", st: "unexplored", x: 70, y: 86,
+    tex: "속도장이 스스로 진화(이류·압력투영)하며 잉크를 실어나름 — 소용돌이의 실제 상호작용.",
+    texEn: "A velocity field evolving itself (advection, pressure projection) while carrying ink — vortices that truly interact.",
+    knob: "점성 / vorticity confinement — 끈적한 흐름 ↔ 격렬한 난류.",
+    knobEn: "viscosity / vorticity confinement — sticky flow ↔ violent turbulence",
+    topic: "Stable Fluids — a coarse self-evolving velocity field (semi-Lagrangian advection + pressure projection) carrying a full-res ink density",
+    hints: ["a 32×64 velocity grid carrying 64×128 ink is enough", "a few Jacobi iterations of pressure projection suffice"] },
+
+  { id: "sandpile", nm: "Abelian 사태", nmEn: "Abelian avalanches", en: "SELF-ORGANIZED CRITICALITY", f: "critical", st: "unexplored", x: 79, y: 52,
+    tex: "임계 격자의 사태 연쇄 파면 — 멱법칙: 잔반짝임 속 가끔 화면을 삼키는 대붕괴.",
+    texEn: "Cascade fronts of a critical lattice — power law: small flickers, and occasionally a collapse that swallows the screen.",
+    knob: "낙사율/소산 — 아임계 ↔ 자기조직 임계.",
+    knobEn: "drop rate / dissipation — subcritical ↔ self-organized criticality",
+    topic: "An Abelian sandpile — render the cascading avalanche FRONTS as brightness, never individual grains",
+    hints: ["render avalanche wavefronts with fade; hide the raw lattice values",
+            "power-law sizes: mostly small flickers, occasionally a screen-swallowing collapse"] },
+
+  { id: "dla", nm: "DLA 응집 확률장", nmEn: "DLA probability field", en: "AGGREGATION FIELD", f: "critical", st: "unexplored", x: 52, y: 33,
+    tex: "확산 응집을 개체 없는 확률장으로 — 서리 가지가 자라는 장.",
+    texEn: "Diffusive aggregation as an object-free probability field — frost branches growing as a field.",
+    knob: "부착 확률 / DBM η — 성긴 가지 ↔ 조밀 덩어리 (연속 조절).",
+    knobEn: "sticking probability / DBM eta — sparse branches ↔ dense clumps, continuously",
+    risk: "입자가 보이면 실패 (Hoarfrost의 교훈) — 장 형태로만.",
+    riskEn: "Fails the moment particles show (the Hoarfrost lesson) — field form only.",
+    topic: "DLA / dielectric-breakdown growth as an object-free aggregation probability field",
+    hints: ["field rendering only — visible walker particles killed this once before"] },
+
+  // ── Invented experiments — AI-authored hypotheses (real mechanisms, unverified) ──
+
+  { id: "cascade", nm: "Cascade — 셸 난류", nmEn: "Cascade — shell turbulence", en: "SHELL-MODEL TURBULENCE", f: "invent", st: "invented", x: 79, y: 35,
+    tex: "세로축이 공간이 아니라 '스케일'이다: 맨 위가 큰 소용돌이, 아래로 갈수록 잔결 — 난류 에너지가 옥타브 사다리를 타고 쏟아지는 폭포. 간헐적 버스트가 위에서 아래로 번개처럼 전파된다.",
+    texEn: "The vertical axis is SCALE, not space: big eddies on top, fine grain below — turbulent energy pouring down an octave ladder, intermittent bursts propagating downward like lightning.",
+    knob: "레이놀즈(강제/점성비) — 층류 트리클 ↔ 간헐 캐스케이드 폭발.",
+    knobEn: "Reynolds number (forcing amplitude / viscosity) — laminar trickle ↔ intermittent avalanche cascade",
+    vert: "스케일 사다리 자체가 세로 구도 — 행마다 특징 주파수가 2배씩 늘어 자기유사 직조가 된다.",
+    vertEn: "The scale ladder IS the composition — feature frequency doubles per band, a self-similar weave.",
+    risk: "셸 모델을 시각화한 전례가 거의 없음 — 행 간 위상 연결을 잘 못 지으면 줄무늬 나열로 보일 수 있다.",
+    riskEn: "Almost no precedent for visualizing shell models — weak phase linking between bands could read as stacked stripes.",
+    topic: "A turbulence energy cascade made visible — a shell model of turbulence (Sabra/GOY, ~24 complex ODEs, one per wavenumber octave) where the vertical axis IS scale: top rows render the large-scale shells, bottom rows the fine scales, each row textured at its shell's wavenumber; intermittent bursts cascade downward",
+    hints: ["integrate a Sabra shell model with k_n = 2^n, ~20-24 shells, forcing on the first 2-3 shells, viscosity term -nu*k_n^2*u_n; complex u_n, dt small and clamped",
+            "render row band for shell n as v(x) = |u_n| * (0.5 + 0.5*sin(k_n * x / width + arg(u_n))) — the phase makes each octave a moving texture",
+            "normalize each shell by an EMA of its own |u_n| so deep shells stay visible; guard with isFinite + amplitude ceiling"] },
+
+  { id: "kneaded", nm: "Kneaded — 휘저어진 반응장", nmEn: "Kneaded — stirred reaction field", en: "STRANGE EIGENMODE", f: "invent", st: "invented", x: 68, y: 73,
+    tex: "반응-확산 무늬가 혼돈 흐름에 반죽된다 — 나선이 실처럼 늘여지고 접히고, 반응이 다시 뭉친다. 두 검증 대륙(PDE × 필드 이류)의 교배.",
+    texEn: "Reaction-diffusion kneaded by a chaotic flow — spirals stretched into threads, folded, and re-formed by the reaction. A crossbreed of two verified continents (PDE × advection).",
+    knob: "담쾰러 수(반응속도/젓기속도) — 나선 생존 ↔ 스트리에이션(실무늬) ↔ 완전 혼합 소멸.",
+    knobEn: "Damkoehler number (reaction rate vs stirring rate) — spirals survive ↔ sheared striations ↔ mixed to death",
+    topic: "A reaction field kneaded by a chaotic flow — Gray-Scott (or FitzHugh-Nagumo) reaction-diffusion whose concentration fields are advected each step by a smooth time-morphing vector field; the competition between stirring and reacting produces persistent striated 'strange eigenmode' textures",
+    hints: ["alternate: one semi-Lagrangian advection step of both concentrations, then one reaction-diffusion step",
+            "keep the flow divergence-free (curl of a slow noise potential) so nothing drains or piles up",
+            "Gray-Scott around f=0.03..0.06, k~0.06 as the reactive backbone; advection speed is the other half of the critical ratio"] },
+
+  { id: "curtain", nm: "Phase Curtain — 상전이 커튼", nmEn: "Phase Curtain — graded criticality", en: "GRADED CRITICALITY", f: "invent", st: "invented", x: 50, y: 80,
+    tex: "제어 파라미터를 세로로 기울여 화면 자체가 상도표의 단면이 된다: 위는 얼고 아래는 끓는데, 그 사이 임계 띠가 프랙탈로 반짝인다. 노브가 그 임계선을 위아래로 민다.",
+    texEn: "Tilt the control parameter along the height and the screen becomes a slice of the phase diagram: frozen above, boiling below, the critical band scintillating between. The knob slides that horizon.",
+    knob: "임계 띠의 위치(파라미터 전역 오프셋) — 상전이 자체가 풍경으로 걸려 있고, 노브가 지평선을 옮긴다.",
+    knobEn: "global offset of the graded control parameter — where in the frame the phase boundary sits",
+    vert: "세로축 = 제어 파라미터 축. 1:2 프레임의 가장 정직한 사용법.",
+    vertEn: "Vertical axis = control-parameter axis. The most honest use of the 1:2 frame.",
+    topic: "A phase transition hung on screen as a curtain — an Ising lattice (or CGL) whose control parameter is GRADED along the vertical axis: ordered and frozen at the top, boiling disorder at the bottom, the critical band scintillating between them; the knob shifts the gradient so the phase boundary sweeps up and down the frame",
+    hints: ["Ising version: per-row temperature T(y) = Tc * (0.6 + offset + 0.8 * y/height), checkerboard Metropolis sweeps, render local magnetization averaged over a small neighborhood (raw spins are noise)",
+            "keep the gradient gentle so the critical band spans 20-30 rows of fractal flicker",
+            "morph by slowly tilting/curving the iso-parameter lines so the curtain waves"] },
+
+  { id: "creep", nm: "Creep — 디피닝 전선", nmEn: "Creep — depinning front", en: "DEPINNING AVALANCHES", f: "invent", st: "invented", x: 70, y: 36,
+    tex: "고정핀 무질서 속을 끌려가는 탄성 전선의 역사 — 멈춤(어둠) 위로 사태처럼 번지는 미끄러짐(빛)의 대륙들. 문턱에서는 크래클링, 그 위에서는 거친 활주.",
+    texEn: "The history of an elastic front dragged through pinning disorder — continents of slip (light) flaring over stillness (dark). Crackling at threshold, rough sliding above it.",
+    knob: "구동력 F — 핀 고정(정적) ↔ 임계 크래클링 ↔ 연속 활주의 디피닝 전이.",
+    knobEn: "driving force F across the depinning threshold — pinned stillness ↔ critical crackling ↔ continuous rough sliding",
+    topic: "A vertical history waterfall of an elastic front creeping through quenched pinning disorder — each row records the 1D front's LOCAL VELOCITY (bright = slipping avalanche, dark = pinned); below threshold the field crackles in power-law patches, above it slides as a rough front",
+    hints: ["simple automaton: front height h(x) + frozen random pin-strength map; a site advances when F + elastic pull (discrete laplacian of h) exceeds its local pin strength; each advance destabilizes neighbors -> avalanches",
+            "render per-row the recent-advance activity (EMA of advances), not h itself",
+            "sample pin strengths from a seeded RNG grid that scrolls with the front so disorder never repeats"] },
+
+  { id: "rogue", nm: "Rogue — 변조 불안정 폭포", nmEn: "Rogue — modulational instability", en: "NLS BREATHERS", f: "invent", st: "invented", x: 54, y: 21,
+    tex: "고요한 반송파가 스스로 불안정해져 숨쉬는 파속(breather)들로 갈라지고, 아주 가끔 화면을 찢는 섬광(로그 웨이브)이 터진다 — 어둠 기반, 드문 대사건의 통계.",
+    texEn: "A calm carrier destabilizing into a gas of breathing wave packets — and, rarely, a rogue flash that tears the screen. Dark-founded; the statistics of rare great events.",
+    knob: "비선형/분산 비 — 안정 반송파 ↔ breather 가스 ↔ 로그 섬광 통계.",
+    knobEn: "nonlinearity-to-dispersion ratio across the modulational-instability threshold — stable carrier ↔ breather gas ↔ rogue-flash statistics",
+    risk: "복소장 스펙트럴 — 발산 가드는 노름 보존으로. 섬광 빈도 튜닝이 관건 (너무 잦으면 번쩍임 공해).",
+    riskEn: "Complex spectral field — guard with norm conservation. Tuning flash frequency is the craft (too frequent = strobe pollution).",
+    topic: "A vertical history waterfall of the 1D nonlinear Schroedinger equation in its modulational-instability regime — a calm carrier wave breaking into a gas of breathers, with rare rogue-wave flashes; rendered as |psi|^2",
+    hints: ["split-step spectral: half linear step in k-space (dispersion), full nonlinear phase rotation exp(i*g*|psi|^2*dt) in real space, half linear again",
+            "divergence guard = norm conservation (total |psi|^2 must stay constant; renormalize or reseed on drift)",
+            "soft-knee tone so rogue peaks read as flashes without crushing the breather texture underneath"] },
+
+  { id: "tongues", nm: "Locked Tongues — 악마의 계단", nmEn: "Locked Tongues — devil's staircase", en: "ARNOLD TONGUES", f: "invent", st: "invented", x: 33, y: 63,
+    tex: "결합된 원사상 격자의 모드록 영토들 — 회전수가 유리수에 잠긴 평평한 판(플래토)들이 모자이크를 이루고, 판의 경계에서 위상 미끄러짐이 필라멘트로 새어나온다. 톤 플래토가 물리 그 자체.",
+    texEn: "Mode-locked territories of a coupled circle-map lattice — flat plateaus locked to rational winding numbers, phase slips leaking through the seams as filaments. Tonal plateaus as physics itself.",
+    knob: "킥 강도 K — 준주기 바다 ↔ 혀(tongue)들의 확장 ↔ 겹침 혼돈.",
+    knobEn: "kick strength K — quasiperiodic sea ↔ widening Arnold tongues ↔ overlapping chaos; the devil's staircase becomes visible territory",
+    topic: "A mosaic of mode-locking — a lattice of coupled circle maps (theta -> theta + Omega - (K/2pi)*sin(2pi*theta) + weak neighbor coupling) where Omega is graded smoothly across space; mode-locked domains form flat tonal plateaus separated by phase-slip filament seams",
+    hints: ["render the local winding rate (EMA of theta increments), softly quantized — locked domains become literal tonal plateaus, slips become bright seams",
+            "grade Omega along y so the tongues stack vertically; morph the gradient slowly",
+            "K around 0.8..1.2 is where the staircase is richest; keep neighbor coupling weak (0.05..0.2)"] },
+
+  { id: "vortexglass", nm: "Vortex Glass — 위상 유리", nmEn: "Vortex Glass — phase glass", en: "KURAMOTO LATTICE", f: "invent", st: "invented", x: 58, y: 53,
+    tex: "제각기 다른 고유진동수의 진동자 격자가 동기화를 두고 다툰다 — 위상 소용돌이(결함)들이 생멸하는 유리질 직조. 위상 기울기만 렌더하면 결함 필라멘트가 어둠 위로 떠오른다.",
+    texEn: "A lattice of oscillators with quenched random frequencies fighting over synchrony — a glassy weave where phase vortices are born and annihilate. Render only the phase gradient and the defect filaments float over darkness.",
+    knob: "결합 강도 K — 비동기 유리 ↔ 결함의 희박한 춤 ↔ 전면 동기(죽은 균질). 임계 바로 아래가 가장 살아있다.",
+    knobEn: "coupling strength K across the synchronization transition — desynchronized glass ↔ sparse defect dance ↔ dead uniform sync (live just below critical)",
+    topic: "A 2D lattice of Kuramoto phase oscillators with quenched random natural frequencies, rendered as the magnitude of the phase gradient — vortex defects wander, pair-create and annihilate in a glassy weave",
+    hints: ["theta_i += dt * (omega_i + K * sum over 4 neighbors of sin(theta_j - theta_i)); omega_i from a seeded gaussian, frozen",
+            "render |grad theta| (each difference wrapped to [-pi, pi]) smoothed by an EMA — defect cores glow, synced domains go dark",
+            "grade the omega spread along y so the defect population drifts vertically"] },
+
+  { id: "ftle", nm: "FTLE — 흐름의 뼈대", nmEn: "FTLE — the flow's skeleton", en: "LAGRANGIAN SKELETON", f: "invent", st: "invented", x: 51, y: 57,
+    tex: "바람(벡터장)의 보이지 않는 골격 — 이웃한 추적자들이 얼마나 찢어지는지(늘임률)를 렌더하면 흐름이 갈라지는 능선이 유령 필라멘트로 떠오른다. Gale Ink의 X-레이. (연구 수입 + 변형)",
+    texEn: "The invisible skeleton of the wind — render how violently neighboring tracers tear apart, and the ridges where the flow splits surface as ghost filaments. An X-ray of gale ink. (research import + twist)",
+    knob: "적분 지평 T — 부드러운 그라디언트 ↔ 날카로운 프랙탈 능선. curl 비율은 골격 자체를 재편한다.",
+    knobEn: "integration horizon T — soft gradients ↔ sharp fractal ridges; the flow's curl ratio independently restructures the whole skeleton",
+    topic: "The hidden skeleton of a morphing flow — finite-time Lyapunov exponents: for each grid point, integrate a tiny cross of tracers through the vector field for a short horizon and render the log of their separation growth; ridges of stretching appear as ghost filaments that reorganize as the flow morphs",
+    hints: ["per-pixel-per-frame is too dear for ESP32 — compute FTLE on a half-resolution grid with few substeps, update a fraction of rows each frame, interpolate in draw",
+            "reuse the same morphing curl-noise field as a gale-ink flow; FTLE is its X-ray",
+            "log-scale the exponent, EMA it, then stretch to 0..1 with a running min/max"] },
+
+  { id: "crease", nm: "Creasefall — 충격파 계보", nmEn: "Creasefall — shock genealogy", en: "BURGERS SHOCKS", f: "invent", st: "invented", x: 42, y: 34,
+    tex: "매끈한 파형이 스스로 가팔라져 주름(충격파)이 되고, 주름들이 서로를 삼키며 굵어지는 계보가 흘러내린다 — KS의 사촌이지만 셀 대신 '접힘'의 역사.",
+    texEn: "Smooth waves steepening into creases that swallow one another and thicken — KS's cousin, but a history of folds instead of cells.",
+    knob: "점성 ν — 유리처럼 매끈한 물결 ↔ 면도날 주름들의 병합 캐스케이드.",
+    knobEn: "viscosity nu — glassy smooth waves ↔ razor-crease merging cascade",
+    topic: "A vertical history waterfall of the 1D Burgers equation — smooth waves steepen into shock creases that collide and merge, an inverse cascade of folds flowing down the frame; render a blend of u and its gradient so creases read as bright seams",
+    hints: ["upwind or semi-implicit finite differences are enough (Burgers is tame); gentle random low-wavenumber forcing keeps it alive",
+            "render u as the soft body plus |du/dx| (normalized) as bright crease seams",
+            "shock mergers are the narrative — keep forcing gentle so mergers stay readable"] },
+
+  { id: "chladni", nm: "Chladni 고유모드 모핑", nmEn: "Chladni eigenmode morphing", en: "STANDING WAVE MODES", f: "pde", st: "unexplored", x: 22, y: 48,
+    tex: "판 진동의 고유모드들 사이를 연속 보간 — 마디선 그물이 접히고 재배열된다. 재현이 아니라 추상 정상파의 기하.",
+    texEn: "Continuous interpolation between plate-vibration eigenmodes — the web of nodal lines folds and rearranges. Not a depiction: the geometry of abstract standing waves.",
+    knob: "모드 지수쌍 (m,n)의 사다리 위치 — 단계마다 마디선 위상이 재배열되는 전이.",
+    knobEn: "position along the (m,n) eigenmode ladder — the nodal topology rearranges at every step",
+    risk: "정지 상태로 두면 죽은 그림 — 연속 보간과 느린 회전 모핑이 필수.",
+    riskEn: "Static modes are a dead picture — continuous interpolation and slow rotation are mandatory.",
+    topic: "Morphing Chladni figures — continuously interpolating between plate-vibration eigenmodes (sums of standing waves), rendering the near-nodal regions as bright filament webs",
+    hints: ["rectangular-plate eigenmodes are cheap: combinations of cos(m*pi*x)*cos(n*pi*y); blend two or three adjacent (m,n) pairs and morph the blend weights on incommensurate periods",
+            "render v from 1 - |field|, sharpened around the zero crossings, so the nodal lines glow",
+            "grade the mode index along y for a vertical ladder of complexity"] },
+
+  { id: "invasion", nm: "침투 퍼콜레이션", nmEn: "Invasion percolation", en: "WEAKEST-PATH INVASION", f: "critical", st: "unexplored", x: 55, y: 47,
+    tex: "동결 무질서 격자에서 항상 가장 약한 이웃만 뚫고 번지는 침투 — 확산 없는 프랙탈 손가락, 임계가 내장된 성장. (연구 수입)",
+    texEn: "An invasion that always breaks the weakest neighboring site of a frozen disorder field — fractal fingers without diffusion; growth with criticality built in. (research import)",
+    knob: "무질서 상관길이 / 트래핑 규칙 — 가는 프랙탈 손가락 ↔ 뭉툭한 압축 전선.",
+    knobEn: "disorder correlation length / trapping rule — thin fractal fingers ↔ blunt compact fronts",
+    topic: "Invasion percolation — a front that always advances through the weakest site of a quenched random resistance field, rendered as an object-free invasion-age field",
+    hints: ["keep a frontier set; each step invade the minimum-resistance frontier site (a small heap, or a periodic min-scan, is fine at this scale)",
+            "render invasion AGE as tone — the freshly invaded glows, old territory fades; never individual sites",
+            "smooth the resistance field spatially for the correlation-length knob"] },
+
+  { id: "billiard", nm: "Billiard — 속삭임 회랑의 붕괴", nmEn: "Billiard — whispering gallery collapse", en: "CHAOTIC RAY INK", f: "invent", st: "invented", x: 40, y: 23,
+    tex: "천천히 변형되는 공동(원↔스타디움) 속에서 광선 수천 개가 반사하며 잉크를 쌓는다 — 가지런한 회랑 커스틱이 혼돈 얼룩으로 무너지는 과정 그 자체.",
+    texEn: "Thousands of rays reflecting inside a slowly deforming cavity (circle ↔ stadium), accumulating ink — orderly whispering-gallery caustics collapsing into chaotic smear.",
+    knob: "경계 변형량 — 원(가적분: 고리 커스틱) ↔ 스타디움(혼돈: 에르고딕 얼룩). 실재하는 적분가능성 전이.",
+    knobEn: "boundary deformation — circle (integrable: ring caustics) ↔ stadium (chaotic: ergodic smear); a genuine integrability transition",
+    topic: "Chaotic billiard ray ink — thousands of specular rays bouncing inside a slowly morphing closed cavity, accumulating into a fading ink buffer; deform the boundary from circle toward stadium to cross the integrable-to-chaotic transition",
+    hints: ["parameterize the boundary as a smooth radius function r(theta) and reflect rays off the local normal",
+            "in the circle, rays conserve angular momentum and weave ring caustics; deformation destroys the invariant and the ink goes ergodic",
+            "a few thousand short ray segments per frame; fade buffer + smoothstep as usual"] },
+
+  { id: "chimera", nm: "Chimera — 반쪽 동기화", nmEn: "Chimera — half-synchronized", en: "COEXISTING ORDER AND CHAOS", f: "invent", st: "invented", x: 46, y: 57,
+    tex: "완전히 동일한 진동자들이 스스로 질서 진영과 혼돈 진영으로 갈라진다 — 매끈한 위상 비단과 끓는 비동기 띠가 한 화면에 공존하고, 그 경계가 배회한다.",
+    texEn: "Perfectly identical oscillators spontaneously splitting into an ordered camp and a chaotic camp — smooth phase silk and boiling incoherence coexisting on one screen, their border wandering.",
+    knob: "결합 반경 / 위상 지연 α — 전면 동기 ↔ 키메라 공존 ↔ 전면 비동기.",
+    knobEn: "coupling range / phase lag alpha — full sync ↔ chimera coexistence ↔ full incoherence",
+    topic: "A chimera state — a ring or lattice of identical phase oscillators with nonlocal coupling and a phase lag, spontaneously splitting into coexisting coherent and incoherent regions; render local coherence so the two camps and their wandering border are the picture",
+    hints: ["nonlocal coupling: each oscillator couples to neighbors within radius R via sin(theta_j - theta_i - alpha); alpha slightly below pi/2 is chimera country",
+            "render the local order parameter (|mean of e^(i*theta)| over a small window) — silk vs boil",
+            "a 1D ring rendered as a history waterfall also works beautifully"] },
+
+  { id: "fpu", nm: "FPU — 유령 회귀", nmEn: "FPU — ghost recurrence", en: "FERMI-PASTA-ULAM", f: "invent", st: "invented", x: 33, y: 28,
+    tex: "비선형 사슬에 부은 에너지가 모드들로 흩어졌다가, 오랜 방황 끝에 유령처럼 처음 형태로 되돌아온다 — 흩어짐과 회귀의 긴 호흡이 폭포로 흐른다.",
+    texEn: "Energy poured into a nonlinear chain scatters across its modes — then, after a long wander, returns like a ghost to its original shape. The long breath of dispersal and recurrence, flowing as a waterfall.",
+    knob: "비선형 강도 β — 완전 회귀 ↔ 준회귀 ↔ 열화(에르고딕)의 문턱.",
+    knobEn: "nonlinearity beta — clean recurrence ↔ partial recurrence ↔ the thermalization threshold",
+    topic: "Fermi-Pasta-Ulam-Tsingou recurrence as a vertical history waterfall — a nonlinear oscillator chain seeded in its lowest mode, energy spreading through the spectrum and ghost-returning; render the displacement field, or the per-mode energies as vertical bands",
+    hints: ["a chain of 32-64 masses with quadratic/cubic coupling (alpha/beta FPU); leapfrog integration, total energy as the divergence guard",
+            "seed the lowest mode and let the recurrence be the narrative — its period is the slow heartbeat",
+            "two renders both work: the displacement waterfall, or mode-energy bands (a small scale-ladder like a mini cascade)"] },
+
+  { id: "resonance", nm: "Resonance — 노이즈가 그리는 신호", nmEn: "Resonance — noise draws the signal", en: "STOCHASTIC RESONANCE", f: "invent", st: "invented", x: 44, y: 70,
+    tex: "문턱 아래 숨은 희미한 형상이, 노이즈를 알맞게 부으면 떠오르고 지나치면 다시 익사한다 — 노이즈가 최적일 때만 그림이 존재하는 역설의 장.",
+    texEn: "A faint shape hidden below threshold surfaces when just enough noise is poured on, and drowns again in excess — a field where the picture exists only at the optimal noise. The paradox is the material.",
+    knob: "노이즈 진폭 — 침묵 ↔ 공명(형상 출현) ↔ 익사. 비단조 급소 노브.",
+    knobEn: "noise amplitude — silence ↔ resonance (the shape surfaces) ↔ drowned; a non-monotonic critical knob",
+    topic: "Stochastic resonance as a field — a lattice of bistable wells driven by a weak subthreshold spatial signal plus tunable noise; at the optimal noise the hidden shape surfaces in the flip statistics, below and above it dissolves",
+    hints: ["per cell an overdamped double well: dx/dt = x - x^3 + weak slow spatial signal + noise; render an EMA of the state",
+            "let the hidden signal itself morph slowly (large smooth abstract blobs) so the surfacing picture is alive",
+            "bonus curtain: sweep the noise amplitude along y so a resonant band glows mid-frame"] },
+
+  { id: "choke", nm: "Choke — 배타 수송 충격파", nmEn: "Choke — exclusion shockwaves", en: "ASEP BOUNDARY PHASES", f: "invent", st: "invented", x: 78, y: 24,
+    tex: "한 방향으로만 흐르는 배타 입자들의 밀도장 — 정체 충격파가 흐름을 거슬러 기어오르고 희박파가 부채꼴로 펴진다. 입자는 안 보이고 밀도의 지층만 흐른다.",
+    texEn: "The density field of one-way excluding particles — jam shockwaves crawling upstream, rarefaction fans spreading. No particles visible, only strata of density flowing.",
+    knob: "주입/배출률 — 저밀도 / 고밀도 / 최대류 상을 가르는 실제 경계 상전이 (1차 전이 포함).",
+    knobEn: "injection/extraction rates — the boundary-driven phase diagram (low-density / high-density / maximal-current, with a genuine first-order line)",
+    topic: "A boundary-driven exclusion process (ASEP) rendered as a coarse-grained density field flowing down the frame — jam shocks climbing against the flow, rarefaction fans, and boundary-rate phase transitions",
+    hints: ["simulate a 1D ASEP with random sequential updates per row-time and render coarse-grained density as a history waterfall — never individual particles",
+            "alpha (inject) and beta (extract) span the phase diagram: alpha<beta<0.5 low density, beta<alpha<0.5 high density with a wandering shock, both >0.5 maximal current",
+            "smooth the density over a few sites plus an EMA so the strata read as material"] },
+];
+
+/* ── Generation prompt (mirrors Pattern Lab's COPY PROMPT assembly) ─────── */
+
+const BASE = `I am writing custom LED patterns in JavaScript for a Patternflow 64x128 LED matrix web preview.
+
+Frame — the pattern is drawn into a 64 × 128 pixel grid: 64 wide (x = 0..63) and 128 tall (y = 0..127). It is TALLER than it is wide (1:2.00). Compose for a tall frame — a design meant for a wide frame will read as cramped and over-zoomed here. Lay the composition, bands, and motion out for these proportions.
+
+Subject — explore ONE system deeply: __TOPIC__
+
+Create exactly 3 distinct standalone patterns exploring this subject. They must differ genuinely — a different regime, a different accumulation or rendering of the same system — not the same pattern with different constants.
+
+Very important output rules:
+- Return exactly 3 separate JavaScript code blocks.
+- Each code block must be a complete standalone Patternflow pattern.
+- Do not combine the 3 patterns into one file.
+- Do not add a mode selector, preset array, switch statement, or any code that contains multiple patterns in one output.
+- Do not write wrapper text inside the code blocks.
+- Put a short pattern name before each code block.
+- Do not include nested triple backticks inside any code block.
+
+Required API for every pattern:
+- export function setup(params) {}
+- export function update(dt, input, params) {}
+- export function draw(display, params, time) {}
+- Use input.knobValues as the primary control API. input.knobValues is an array of 4 absolute knob values after the min/max ranges are applied.
+- Declare the ranges your 4 knobs want with ONE comment line near the top of the file, exactly this format:
+  // @knobs Folds=3..12, Speed=0.1..10, Zoom=2..17, Contrast=0.1..1
+  (exactly 4 comma-separated entries, Name=min..max, short names). Pattern Lab parses this line, renames the on-screen knobs, and sets their min/max automatically — the user can then retune any range and your pattern follows, because you read the values back through input.knobValues.
+- Read input.knobValues[i] directly as the parameter value (matching your @knobs ranges). Do NOT read input.knobNormalized and remap it with baked constants such as 3 + kn[0] * 9 — that disconnects Pattern Lab's range editor (the user's min/max edits stop doing anything). input.knobNormalized is acceptable only for a truly unitless 0..1 blend where any range would mean the same thing.
+- Keep input.knobDeltas only as compatibility fallback if needed.
+- Optional: each knob also has a push button. input.btnPressed[i] is true only on the frame it is pressed (edge); input.btnHeld[i] is true while it is held down. Use these for momentary actions like reset, freeze, cycle, or trigger. Do not use long-press or mode-switching; that is a reserved system gesture.
+- IMPORTANT: input is passed ONLY to update(dt, input, params). draw's signature is draw(display, params, time) with NO input argument — params.input does not exist. To read knob or button values inside draw, use params.knobValues / params.knobNormalized / params.knobDeltas / params.btnPressed / params.btnHeld (the harness mirrors the latest input onto params every frame), or stash whatever you need on params during update. Never read input.* or params.input.* inside draw.
+- Use display.width and display.height in loops. Never hardcode the frame's pixel dimensions inside draw() — the same pattern is run at other resolutions, and a hardcoded size crops or zooms it.
+- Declare the frame you composed for with ONE comment line near the top of the file, exactly this format:
+  // @matrix 64x128
+  Use exactly the dimensions given above. Pattern Lab reads this line to set the preview resolution, and the firmware uses it to map the pattern onto the physical panel.
+- Write each pixel with display.setValue(x, y, v) — EXACTLY three arguments, where v is a single number from 0.0 to 1.0. Do NOT call display.setPixel anywhere.
+- Use only plain JavaScript and Math.*. No browser APIs, DOM APIs, imports, async code, external libraries, dynamic evaluation, or per-pixel allocations.
+
+Creative control mapping:
+- It is okay to keep one knob as animation speed, preferably Knob 2, if that suits the pattern.
+- Do not keep all four knobs as the same old hue/speed/mode/frequency template unless it is genuinely the best fit.
+- Redesign the controls creatively for each pattern. Examples: cell size, symmetry fold, glitch amount, palette split, trail length, scanline spacing, pulse width, inversion threshold, rotation, warp depth, density, edge thickness, phase offset, bloom-like gain, or motif selection.
+- Each pattern should have a slightly different control personality. The controls should reveal the unique idea of that pattern.
+- Include a short comment near setup() or update() naming what the 4 knobs do for that specific pattern.
+
+Value-field direction (IMPORTANT — there is NO color in this pattern):
+- The pattern outputs only a scalar value field via display.setValue(x, y, v). Color is applied OUTSIDE the pattern by a user-controlled color ramp that maps v = 0..1 to colors.
+- Do NOT compute any colors, palettes, hues, RGB values, or hsvToRgb helpers anywhere. No color logic at all — pour all effort into geometry, structure, and motion.
+- Treat v as the pattern's tonal value and design the field so it reads well under ANY ramp:
+  - Use the full 0..1 range every frame: some pixels near 0, some near 1.
+  - Build deliberate tonal structure tied to the geometry: edges, bands, plateaus, gradients driven by distance, phase, cell id, density, or masks.
+  - Value contrast is your only material — sharp boundaries, layered levels, and clear figure/ground separation matter more than in RGB mode.
+  - Avoid uniform mid-grey mush (everything hovering near 0.5) and avoid pure binary output unless the idea is intentionally hard-edged.
+- Knobs must control geometry/motion/structure, never color (no hue knobs — color belongs to the ramp).
+
+Rendering craft — most attempts die here, read carefully:
+- update() is called as update(dt, input, params) — there is NO time argument in update. Referencing one gives undefined, and one undefined variable turns the whole field into NaN = a permanently black screen. Build your own clock instead: params.t = 0 in setup, params.t += dt at the top of update, and use params.t wherever the simulation needs absolute time. (draw does receive time, but keep all simulation clocking in update.)
+- NaN passes straight through Math.min/Math.max clamps, and NaN > x is always false — so a naive divergence check never fires on a NaN-poisoned field. Make every divergence guard isFinite-based: if any sampled value fails isFinite(v), reseed immediately.
+- The first frame must already be alive. Run enough warmup iterations / prefill inside setup() that the developed texture is visible immediately. Never start from an empty field that slowly fills in.
+- Never write raw physical magnitudes to v. Track a running amplitude estimate (e.g., an EMA of the per-frame max) and normalize through it, then shape the tone with smoothstep (t*t*(3-2*t)). Unnormalized output is how screens end up all-black (values far below 1) or all-white (clipped).
+- Accumulation buffers need decay: buf *= fade every frame, then add ink. Without decay the buffer saturates to solid white within seconds.
+- Cover the whole frame: width is 64 (x = 0..63), height is 128 (y = 0..127). If content appears only as a thin band while the rest stays empty, you have a transposed buffer or a wrong loop bound — this is the single most common failure.
+- Simulate in the display's own orientation. Internal buffers are 64 wide × 128 tall (index = y * 64 + x), matching // @matrix 64x128. Do NOT build a 128×64 landscape simulation and rotate or remap it inside draw() — no axis swaps, no dispX = y tricks. If you catch yourself writing const w = 128, h = 64, stop: swap them. (Most LED-matrix code online is landscape; this device stands tall.)
+- Choose @knobs ranges so the pattern is at its best near the MIDDLE of every range, with nobody touching anything. Knob extremes may be calm or violent; the default position is the show.
+- Simulations must sit in their interesting regime at those defaults — use the canonical parameter values from the hints below when given; do not invent your own.
+
+Taste direction (settled by experiment on this device — treat as hard constraints, on top of everything above):
+- No countable objects. Thousands of accumulated operations must read as one continuous "material". The moment dots/creatures/cars can be counted, the pattern is dead.
+- No depiction of real things — only abstract mathematics moving on its own.
+- Refining "creative control mapping" above: Knob 1 must grip a real coefficient of the underlying equation (the critical knob) — turning it must cross a phase transition or bifurcation, not just restyle. Knob 3 = density/scale, knob 4 = fade/persistence (wire ↔ smoke) have worked well.
+- Morphing: let secondary coefficients breathe slowly on incommensurate periods so that five minutes in it is not the same picture. The autonomous morphing must NOT ride the critical coefficient itself — pumping it injects energy and can blow the system up; morph through harmless axes (time compression, render transforms).
+- The long vertical axis is the protagonist: falling, rising, columns, history scrolling downward.
+- Reliability: clamp dt (~0.1 max), detect divergence and auto-reseed, use a seeded RNG instead of Math.random, allocate every buffer in setup, attach helper functions to params as closures (survives layer flattening), and stay ESP32-friendly (tens of thousands of operations per frame).
+- Each pattern must declare in its first comment: "critical knob = ___, turning it crosses ___ ↔ ___".
+- Discard any idea that fails these rules — output only survivors. If you cannot execute and test the code, mark the pattern "UNVERIFIED".`;
+
+export function buildPrompt(entry: AtlasEntry): string {
+  let prompt = BASE.replace("__TOPIC__", entry.topic ?? entry.nmEn);
+  const extra: string[] = [];
+  if (entry.knobEn) extra.push(`Critical-knob candidate: ${entry.knobEn}`);
+  if (entry.hints) extra.push(...entry.hints);
+  if (extra.length > 0) {
+    prompt += `\n\nSubject-specific hints:\n${extra.map((h) => `- ${h}`).join("\n")}`;
+  }
+  return prompt;
+}
+
+/** Fast lookup for validation and panels. */
+export const ENTRY_BY_ID: ReadonlyMap<string, AtlasEntry> = new Map(
+  ENTRIES.map((entry) => [entry.id, entry]),
+);

--- a/web/src/lib/community/queries.ts
+++ b/web/src/lib/community/queries.ts
@@ -1,6 +1,7 @@
 import { and, desc, eq, inArray, isNull, ne, sql } from "drizzle-orm";
 import { getDb } from "./db";
 import {
+  atlasPins,
   comments,
   deckPatterns,
   decks,
@@ -606,6 +607,30 @@ export async function listPresence(): Promise<PresencePerson[]> {
     .from(presence)
     .innerJoin(user, eq(presence.userId, user.id))
     .orderBy(presence.updatedAt);
+}
+
+/**
+ * Patterns placed on the atlas (/community/atlas), with enough of the pattern
+ * row to render a live tile. Only public patterns appear — an unlisted work is
+ * link-only everywhere else, and a spot on the shared map would un-unlist it.
+ */
+export async function listAtlasPins() {
+  return getDb()
+    .select({
+      patternId: atlasPins.patternId,
+      x: atlasPins.x,
+      y: atlasPins.y,
+      entryId: atlasPins.entryId,
+      title: patterns.title,
+      code: patterns.code,
+      userId: patterns.userId,
+      ...authorFields,
+    })
+    .from(atlasPins)
+    .innerJoin(patterns, eq(atlasPins.patternId, patterns.id))
+    .innerJoin(user, eq(patterns.userId, user.id))
+    .where(eq(patterns.visibility, "public"))
+    .orderBy(atlasPins.updatedAt);
 }
 
 /**

--- a/web/src/lib/community/schema.ts
+++ b/web/src/lib/community/schema.ts
@@ -393,6 +393,31 @@ export const presence = sqliteTable("presence", {
 });
 
 /**
+ * A pattern placed on the atlas — the map of pattern-technique space
+ * (/community/atlas). One pin per pattern, placed and moved by the pattern's
+ * author (or a moderator). Coordinates are the atlas's own 0..100 data space:
+ * x = order → chaos, y = wire → field.
+ *
+ * This is deliberately NOT presence and NOT a territory pin: it says "this
+ * work lives at this spot of pattern space", nothing about people or threads.
+ */
+export const atlasPins = sqliteTable("atlas_pins", {
+  patternId: text("pattern_id")
+    .primaryKey()
+    .references(() => patterns.id, { onDelete: "cascade" }),
+  x: integer("x").notNull(),
+  y: integer("y").notNull(),
+  /**
+   * The atlas entry (technique point in lib/atlas/data.ts) whose prompt this
+   * pattern was explored from — its lineage on the map, drawn as a thread.
+   * Set by the author: dropping a pattern near a point adopts it, and the pin
+   * panel can retarget it. Null = placed in open water, tied to nothing.
+   */
+  entryId: text("entry_id"),
+  updatedAt: integer("updated_at", { mode: "timestamp" }).notNull(),
+});
+
+/**
  * A thread. Lives in a territory — the board no longer has an "everything"
  * list, because a question about a direction belongs next to that direction.
  *


### PR DESCRIPTION
A new community section: **`/community/atlas`**, sibling to the workshop map.
The workshop charts where the *hardware* could go; this charts where *patterns*
could go.

## What is on the map

**49 technique points.** Verified continents (strange ink, caustics, advection,
CGL), the open frontier, and AI-invented hypotheses — shell-model cascades,
graded criticality curtains, depinning avalanches, chimera states. Click one and
you get a complete English generation prompt for that spot: Pattern Lab's own
COPY PROMPT assembly (`lib/gemini.ts`) plus this project's settled taste rules
and the rendering craft learned the hard way — `update()` has no `time` argument,
NaN slips through `Math.min/max` clamps so guards must be `isFinite`, buffers are
portrait-native, physical magnitudes get normalized before they reach `v`.

**Pins.** Published patterns their authors place on the map, drawn as live tiles.
Selecting one opens a real player: a sandboxed run with the pattern's own
`@knobs` as sliders under it.

Axes are feelings, not maths: x = order → chaos, y = wire (trajectory) → field
(mist). Wheel zooms, drag pans, double-click resets.

## Lineage

Deliberate, never inferred from code. Dropping a pattern near a prompt point
adopts that point (nearest within radius, previewed while you place); the pin
panel can retarget or clear it. Linked pins hang from their prompt by a dashed
thread, and the entry panel lists what came out of it.

Placing happens on the map — the publish flow is untouched, and the picker shows
your own public patterns newest-first as thumbnails (you recognise your work by
looking at it).

## Shape of the change

- `atlas_pins` table (migrations 0017/0018) + `listAtlasPins`
- `/api/community/atlas` — GET/POST/DELETE, author-or-moderator writes, mirroring
  the presence route's shape
- `lib/atlas/data.ts` — the entries and prompt assembly, edited by hand like the
  seed script; coordinates are taste hypotheses that edit mode drags and
  `[Copy layout]` exports back
- The dock hides itself here (techniques are not collectable patterns)

English by default with a Korean toggle; prompts stay English because they are
written for models, not readers.

Verified: typecheck, lint (0 errors), production build, and the map/panels/player
exercised in the browser. Placement and drag-to-save need a signed-in session, so
those paths are code-reviewed rather than clicked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)