### PR TITLE
perf(web): the wall does not animate on phones

### DIFF
--- a/web/src/app/pattern-lab/PatternLab.module.css
+++ b/web/src/app/pattern-lab/PatternLab.module.css
@@ -334,6 +334,10 @@
   font-family: var(--font-jetbrains), monospace;
   font-size: 12px;
   line-height: 1.5;
+  /* A runtime error carries the failing source line on its own line below the
+     message; without this the newline collapses and the two run together. */
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
 }
 
 .controls {

--- a/web/src/components/community/PatternCard.tsx
+++ b/web/src/components/community/PatternCard.tsx
@@ -211,6 +211,7 @@ export default function PatternCard({
   // on the device least able to hold them.
   const [warm, setWarm] = useState(false);
   useEffect(() => {
+    if (!interactive) return; // a phone never plays, so it never boots one
     const el = thumbRef.current;
     if (!el) return;
     const warmObserver = new IntersectionObserver(
@@ -233,38 +234,16 @@ export default function PatternCard({
     };
   }, [interactive]);
 
-  // ── On screen, playing ──
-  // A phone has no hover, and asking for a gesture first (hold, tap, whatever)
-  // means the feature has to be advertised before anybody meets it. So the
-  // wall simply plays: a card runs while it is actually on screen and pauses
-  // the moment it leaves. That bounds the cost to what the screen can show —
-  // measured at 375x812, three columns of 109x257 cards, about nine to twelve
-  // at once — rather than to how far the feed has been scrolled.
+  // ── Playing ──
+  // Desktop plays on hover: one card at a time, the cursor says which, and
+  // because it is asked for it overrides a reduced-motion preference.
   //
-  // Paused, not unmounted: leaving the iframe up means scrolling back is
-  // instant, and a paused sandbox costs nothing per frame. Unmounting is the
-  // cool observer's job, further out.
-  const [onScreen, setOnScreen] = useState(false);
-  useEffect(() => {
-    if (interactive) return; // the desktop's cue is the cursor
-    const el = thumbRef.current;
-    if (!el) return;
-    const observer = new IntersectionObserver(
-      (entries) => {
-        const last = entries[entries.length - 1];
-        if (last) setOnScreen(last.isIntersecting);
-      },
-      // No margin: "on screen" means on screen. A card half out of frame is
-      // still worth playing, hence a zero threshold rather than a fraction.
-      { rootMargin: "0px", threshold: 0 },
-    );
-    observer.observe(el);
-    return () => observer.disconnect();
-  }, [interactive]);
-
-  // Someone who has asked the OS for less motion has asked for less of this.
-  const stillPreferred = useMediaQuery("(prefers-reduced-motion: reduce)");
-  const playing = interactive ? isHovered : onScreen && !stillPreferred;
+  // A phone does not play at all. The wall used to run every card that was on
+  // screen — nine to twelve sandboxes at 375x812 — which is nine to twelve
+  // whole documents rendering 60fps canvases on the device least able to
+  // afford it, and it dropped frames while scrolling. The still is the card
+  // there; tapping through to the pattern is where it moves.
+  const playing = interactive && isHovered;
 
   // Initial static thumbnail
   useEffect(() => {
@@ -402,10 +381,10 @@ export default function PatternCard({
             <div className={styles.cardThumbNote}>{failed ? "render error" : "rendering…"}</div>
           )}
 
-          {/* Live sandbox, booted while the card is near the viewport so that
-              a hover — or, on a phone, simply scrolling it into frame —
-              plays instantly rather than after a document load. */}
-          {warm && (
+          {/* Live sandbox, booted while the card is near the viewport so a
+              hover plays instantly rather than after a document load. Desktop
+              only: on a phone the card is the still. */}
+          {interactive && warm && (
             <SandboxPreview
               code={item.code}
               knobValues={knobValues}

--- a/web/src/lib/patternHarness.ts
+++ b/web/src/lib/patternHarness.ts
@@ -379,6 +379,67 @@ function normalizePatternCode(code: string) {
     .replace(/\bexport\s+function\b/g, "function");
 }
 
+// ── Error locations ─────────────────────────────────────────────────────────
+// A pattern that throws used to report the message and nothing else. "Cannot
+// read properties of undefined (reading '0')" is unactionable on its own, and
+// badly misleading in the common case: a typed array returns `undefined` for an
+// out-of-range read instead of throwing, that `undefined` turns the arithmetic
+// into NaN, and the NaN only throws later when it is used as an index — tens of
+// lines from the mistake. One author read that message as "the harness cannot
+// handle 2D arrays" and abandoned a working pattern. The stack knows the line;
+// this digs it back out and quotes the source.
+
+/** The wrapper's leading newline + `"use strict";` sit above user line 1. */
+const WRAPPER_LINES_BEFORE_CODE = 2;
+
+// `new Function` prepends its own signature lines, and how many is an engine
+// detail — measure it once rather than hard-code a guess that breaks silently.
+let functionPreambleLines: number | null = null;
+
+function stackLocation(error: unknown): { line: number; column: number } | null {
+  const stack = error instanceof Error ? error.stack : null;
+  if (!stack) return null;
+  // V8/Safari report `<anonymous>:12:5`; Firefox reports `Function:12:5`.
+  const match = stack.match(/(?:<anonymous>|Function|eval):(\d+):(\d+)/);
+  if (!match) return null;
+  return { line: Number(match[1]), column: Number(match[2]) };
+}
+
+function getFunctionPreambleLines(): number {
+  if (functionPreambleLines !== null) return functionPreambleLines;
+  functionPreambleLines = 2;
+  try {
+    new Function("throw new Error('probe');")();
+  } catch (error) {
+    // The probe throws from body line 1, so whatever line the stack reports is
+    // exactly the preamble height plus one.
+    const location = stackLocation(error);
+    if (location) functionPreambleLines = location.line - 1;
+  }
+  return functionPreambleLines;
+}
+
+/**
+ * Message plus, when the stack allows it, the pattern's own line number and the
+ * source of that line. Falls back to the bare message — a syntax error carries
+ * no usable frame, and a wrong line number would be worse than none.
+ */
+export function describePatternError(error: unknown, code: string | null): string {
+  const message = error instanceof Error ? error.message : String(error);
+  if (!code) return message;
+
+  const location = stackLocation(error);
+  if (!location) return message;
+
+  const line = location.line - getFunctionPreambleLines() - WRAPPER_LINES_BEFORE_CODE;
+  const sourceLines = code.split("\n");
+  if (line < 1 || line > sourceLines.length) return message;
+
+  const source = sourceLines[line - 1].trim();
+  const quoted = source.length > 80 ? `${source.slice(0, 79)}…` : source;
+  return `${message}\nline ${line}: ${quoted}`;
+}
+
 export function compilePatternCode(code: string): PatternModule {
   const normalized = normalizePatternCode(code);
   const wrapper = `
@@ -415,6 +476,7 @@ export class PatternRuntime {
   private rampLUTA: Uint8Array | null = null; // 256×4 RGBA (setValue path)
   private module: PatternModule | null = null;
   private params: PatternParams = {};
+  private source: string | null = null;
   private display: PatternDisplay;
 
   constructor(width = PATTERN_MATRIX_WIDTH, height = PATTERN_MATRIX_HEIGHT) {
@@ -482,6 +544,9 @@ export class PatternRuntime {
   }
 
   public loadCode(code: string): PatternRenderResult {
+    // Kept so a throw from update()/draw() can quote the line too, not just the
+    // one that setup() died on.
+    this.source = code;
     try {
       this.module = compilePatternCode(code);
       this.params = {};
@@ -490,10 +555,7 @@ export class PatternRuntime {
       return { ok: true };
     } catch (error) {
       this.module = null;
-      return {
-        ok: false,
-        error: error instanceof Error ? error.message : String(error),
-      };
+      return { ok: false, error: describePatternError(error, code) };
     }
   }
 
@@ -537,10 +599,7 @@ export class PatternRuntime {
       }
       return { ok: true };
     } catch (error) {
-      return {
-        ok: false,
-        error: error instanceof Error ? error.message : String(error),
-      };
+      return { ok: false, error: describePatternError(error, this.source) };
     }
   }
 

--- a/web/src/lib/patternHarness.ts
+++ b/web/src/lib/patternHarness.ts
@@ -477,6 +477,10 @@ export class PatternRuntime {
   private module: PatternModule | null = null;
   private params: PatternParams = {};
   private source: string | null = null;
+  // Why the last load failed. Retained because the render loop keeps calling
+  // renderFrame afterwards, and a generic "No pattern loaded." would otherwise
+  // overwrite the one message that says what actually went wrong.
+  private loadError: string | null = null;
   private display: PatternDisplay;
 
   constructor(width = PATTERN_MATRIX_WIDTH, height = PATTERN_MATRIX_HEIGHT) {
@@ -552,16 +556,21 @@ export class PatternRuntime {
       this.params = {};
       this.data.fill(0);
       this.module.setup?.(this.params);
+      this.loadError = null;
       return { ok: true };
     } catch (error) {
       this.module = null;
-      return { ok: false, error: describePatternError(error, code) };
+      this.loadError = describePatternError(error, code);
+      return { ok: false, error: this.loadError };
     }
   }
 
   public renderFrame(dt: number, time: number, input: PatternInput): PatternRenderResult {
     if (!this.module) {
-      return { ok: false, error: "No pattern loaded." };
+      // A pattern that threw inside setup() leaves nothing to render, and the
+      // caller redraws every frame. Keep answering with the reason it failed
+      // rather than the symptom.
+      return { ok: false, error: this.loadError ?? "No pattern loaded." };
     }
 
     try {


### PR DESCRIPTION
Three commits that were stacked on `dev` after #290 merged.

**perf(web): the wall does not animate on phones** — the wall ran a sandbox for
every card that was on screen. At 375x812 that is nine to twelve whole documents
driving 60fps canvases on the device least able to afford it, and scrolling
dropped frames. Phones now get the still, and no iframe is booted at all —
nothing plays, so there is nothing to warm. Tapping through to the pattern is
where it moves.

Desktop is untouched: hover still boots and plays one card, and because hover is
asked for it still overrides a reduced-motion preference.

Measured on the wall — 375x812: 40 cards, 39 stills, **0 sandboxes** (was ~9-12
live). 1280: unchanged, 9 booted on load.

Also carries two error-reporting fixes made earlier on this branch:

- report the line a pattern threw on, not just the message
- keep the load error instead of replacing it with "No pattern loaded."

Verified: typecheck, lint (0 errors), and both viewports exercised in the
browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)