### PR TITLE
chore: cutting a release stops pinging the whole Discord

### DIFF
--- a/.github/workflows/discord-notify.yml
+++ b/.github/workflows/discord-notify.yml
@@ -1,19 +1,21 @@
 name: Discord notify
 
-# Posts to Discord via webhooks when:
-#   - new commits land on main   → #dev-log   (DISCORD_WEBHOOK_DEV)
-#   - a GitHub release published  → #announcements (DISCORD_WEBHOOK_ANNOUNCE)
-# Set both secrets under Settings → Secrets and variables → Actions.
-# If a secret is missing, that job no-ops instead of failing.
+# Posts to Discord via webhook when new commits land on main → #dev-log
+# (DISCORD_WEBHOOK_DEV). Set the secret under Settings → Secrets and variables
+# → Actions; if it is missing the job no-ops instead of failing.
+#
+# Releases used to post to #announcements from here, with an @here. Removed:
+# cutting a release is a housekeeping act as often as it is news — a tag that
+# just catches the manifest up does not deserve a room-wide ping, and having
+# to think about who gets woken up is a reason not to tag things. Announcing a
+# release is now a deliberate, human act. Restore from git history if that
+# ever turns out to be the wrong trade.
 on:
   push:
     branches: [main]
-  release:
-    types: [published]
 
 jobs:
   commits:
-    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
       - name: Post commits to #dev-log
@@ -43,42 +45,6 @@ jobs:
                 color: 0x5865f2,
                 footer: { text: repo },
                 timestamp: new Date().toISOString(),
-              }],
-            };
-
-            const res = await fetch(webhook, {
-              method: "POST",
-              headers: { "Content-Type": "application/json" },
-              body: JSON.stringify(payload),
-            });
-            if (!res.ok) core.setFailed(`Discord responded ${res.status}: ${await res.text()}`);
-
-  release:
-    if: github.event_name == 'release'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Post release to #announcements
-        uses: actions/github-script@v7
-        env:
-          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_ANNOUNCE }}
-        with:
-          script: |
-            const webhook = process.env.DISCORD_WEBHOOK;
-            if (!webhook) { core.info("DISCORD_WEBHOOK not set — skipping."); return; }
-
-            const r = context.payload.release;
-            const repo = `${context.repo.owner}/${context.repo.repo}`;
-            const body = (r.body || "").trim().slice(0, 3500) || "_No release notes._";
-
-            const payload = {
-              content: "@here",
-              embeds: [{
-                title: `🚀 ${r.name || r.tag_name}`,
-                description: body,
-                url: r.html_url,
-                color: 0x57f287,
-                footer: { text: repo },
-                timestamp: r.published_at,
               }],
             };
 


### PR DESCRIPTION
Publishing a GitHub release posted to Discord's #announcements with an `@here`. That turns tagging into a decision about who to wake up — and most releases are housekeeping, like the one about to catch the flasher manifest up to a version that already shipped.

The commits-to-#dev-log job stays. Announcing a release is a human act now; the removed job is in git history if that turns out to be the wrong trade.

Merging this **before** cutting v3.3.0 and v3.4.0, so those two tags don't fire two room-wide pings on the way out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)