### PR TITLE
Type the MQTT broker in, instead of compiling it into everyone

### DIFF
--- a/firmware/patternflow/patternflow.ino
+++ b/firmware/patternflow/patternflow.ino
@@ -142,6 +142,10 @@ void setup() {
   // device that has never been told otherwise never dials a broker.
   PatternflowMqtt::setRole(
       (PatternflowMqtt::Role)prefs.getUChar("mqtt_role", PatternflowMqtt::ROLE_OFF));
+  // And the broker itself, typed in on the same page. Left at the compiled-in
+  // defaults (empty, unless someone set PF_MQTT_* in their secrets header)
+  // when nothing has been saved.
+  PatternflowMqtt::loadConfig();
 
   // Start Wi-Fi non-blocking: boot does NOT wait for the join. OSC, OTA,
   // and the audio-react server are started from the connect edge in loop()

--- a/firmware/patternflow/src/core_mqtt.h
+++ b/firmware/patternflow/src/core_mqtt.h
@@ -44,6 +44,7 @@
 
 #if PF_MQTT_ENABLED
 #include <WiFi.h>
+#include <Preferences.h>
 #include "pubsubclient/PubSubClient.h"
 #endif
 
@@ -99,7 +100,28 @@ inline IPAddress brokerIp;
 inline bool brokerResolved = false;
 inline uint8_t failures = 0;
 
-inline bool hasBroker() { return PF_MQTT_HOST[0] != '\0'; }
+// ── Broker settings, entered on /mqtt and kept in NVS ────────────────────
+//
+// Typed in rather than compiled in, for the same reason Wi-Fi is: a broker
+// is per-owner, and the alternative is either everybody sharing one set of
+// credentials in the public source or nobody having a broker at all. The
+// PF_MQTT_* macros remain as build-time defaults for people who do want to
+// bake their own in; anything saved here wins over them.
+//
+// Sizes are deliberate — this is internal DRAM, which is the scarce thing on
+// this board (see the measurements in net_config.h). 176 bytes total.
+constexpr size_t HOST_BYTES = 64;
+constexpr size_t USER_BYTES = 32;
+constexpr size_t PASS_BYTES = 48;
+constexpr size_t PREFIX_BYTES = 32;
+
+inline char cfgHost[HOST_BYTES] = PF_MQTT_HOST;
+inline char cfgUser[USER_BYTES] = PF_MQTT_USER;
+inline char cfgPass[PASS_BYTES] = PF_MQTT_PASS;
+inline char cfgPrefix[PREFIX_BYTES] = PF_MQTT_PREFIX;
+inline uint16_t cfgPort = PF_MQTT_PORT;
+
+inline bool hasBroker() { return cfgHost[0] != '\0'; }
 
 // Back off as failures pile up: a broker that is down stays down, and each
 // attempt costs the loop up to CONNECT_TIMEOUT_MS.
@@ -141,11 +163,11 @@ inline const char* stateText() {
 }
 
 inline void topicKnob(char* buf, size_t n, int index) {
-  snprintf(buf, n, "%s/knob/%d", PF_MQTT_PREFIX, index + 1);
+  snprintf(buf, n, "%s/knob/%d", cfgPrefix, index + 1);
 }
 
 inline void topicPattern(char* buf, size_t n) {
-  snprintf(buf, n, "%s/pattern", PF_MQTT_PREFIX);
+  snprintf(buf, n, "%s/pattern", cfgPrefix);
 }
 
 inline bool topicIsPattern(const char* topic) {
@@ -270,7 +292,7 @@ inline void ensureClientId() {
 
 inline void subscribeAll() {
   char topic[48];
-  snprintf(topic, sizeof(topic), "%s/knob/+", PF_MQTT_PREFIX);
+  snprintf(topic, sizeof(topic), "%s/knob/+", cfgPrefix);
   client.subscribe(topic);
   topicPattern(topic, sizeof(topic));
   client.subscribe(topic);
@@ -281,14 +303,14 @@ inline void subscribeAll() {
 // Do it once and hand it the address.
 inline bool resolveBroker() {
   if (brokerResolved) return true;
-  if (brokerIp.fromString(PF_MQTT_HOST)) {
+  if (brokerIp.fromString(cfgHost)) {
     brokerResolved = true;
     return true;
   }
-  if (WiFi.hostByName(PF_MQTT_HOST, brokerIp) == 1) {
+  if (WiFi.hostByName(cfgHost, brokerIp) == 1) {
     brokerResolved = true;
     Serial.printf("[MQTT] %s resolved to %s\n",
-                  PF_MQTT_HOST, brokerIp.toString().c_str());
+                  cfgHost, brokerIp.toString().c_str());
     return true;
   }
   setError("cannot resolve broker");
@@ -318,11 +340,11 @@ inline bool tryConnect() {
     if (++failures == 0) failures = RERESOLVE_AFTER;  // never wrap to "healthy"
     return false;
   }
-  client.setServer(brokerIp, PF_MQTT_PORT);
+  client.setServer(brokerIp, cfgPort);
 
   bool ok;
-  if (PF_MQTT_USER[0] != '\0') {
-    ok = client.connect(clientId, PF_MQTT_USER, PF_MQTT_PASS);
+  if (cfgUser[0] != '\0') {
+    ok = client.connect(clientId, cfgUser, cfgPass);
   } else {
     ok = client.connect(clientId);
   }
@@ -340,7 +362,7 @@ inline bool tryConnect() {
   failures = 0;
   setError("");
   Serial.printf("[MQTT] connected as %s (%s) to %s:%d\n",
-                clientId, roleName(role), PF_MQTT_HOST, PF_MQTT_PORT);
+                clientId, roleName(role), cfgHost, cfgPort);
   if (role == ROLE_SUBSCRIBER) {
     // Forget remote baselines: the retained snapshot about to arrive is
     // what we resync against.
@@ -374,11 +396,94 @@ inline Role currentRole() { return role; }
 inline bool isCompiledIn() { return true; }
 inline bool isConnected() { return client.connected(); }
 inline const char* error() { return lastError; }
-inline const char* host() { return PF_MQTT_HOST; }
-inline uint16_t port() { return PF_MQTT_PORT; }
-inline const char* user() { return PF_MQTT_USER; }
-inline const char* prefix() { return PF_MQTT_PREFIX; }
+inline const char* host() { return cfgHost; }
+inline uint16_t port() { return cfgPort; }
+inline const char* user() { return cfgUser; }
+inline const char* prefix() { return cfgPrefix; }
+/** Whether a password is set — the value itself never leaves the device. */
+inline bool hasPassword() { return cfgPass[0] != '\0'; }
 inline const char* lastPatternName() { return lastPattern; }
+
+// ── Settings persistence ─────────────────────────────────────────────────
+
+inline void copyField(char* dest, size_t size, const char* src) {
+  if (!src) src = "";
+  strncpy(dest, src, size - 1);
+  dest[size - 1] = '\0';
+}
+
+/**
+ * Load saved settings over the compiled-in defaults.
+ *
+ * Each key is read only if it exists, so a device that has saved a host but
+ * never touched the prefix keeps the built-in prefix rather than being handed
+ * an empty string.
+ */
+inline void loadConfig() {
+  Preferences prefs;
+  if (!prefs.begin("patternflow", true)) return;
+  if (prefs.isKey("mq_host")) prefs.getString("mq_host", cfgHost, sizeof(cfgHost));
+  if (prefs.isKey("mq_user")) prefs.getString("mq_user", cfgUser, sizeof(cfgUser));
+  if (prefs.isKey("mq_pass")) prefs.getString("mq_pass", cfgPass, sizeof(cfgPass));
+  if (prefs.isKey("mq_prefix")) prefs.getString("mq_prefix", cfgPrefix, sizeof(cfgPrefix));
+  if (prefs.isKey("mq_port")) cfgPort = prefs.getUShort("mq_port", cfgPort);
+  prefs.end();
+}
+
+/** Drop the connection so the next attempt uses the new settings. */
+inline void applyConfigChange() {
+  brokerResolved = false;
+  failures = 0;
+  lastReconnectMs = 0;
+  lastError[0] = '\0';
+  for (int i = 0; i < 4; ++i) haveKnob[i] = false;
+  if (client.connected()) client.disconnect();
+}
+
+/**
+ * Save what was entered on /mqtt.
+ *
+ * A null password means "leave it alone", which is what lets the page show a
+ * form without ever having been sent the current one — the field arrives
+ * empty and an empty field must not wipe a working login. Clearing is a
+ * separate, explicit act (see the clear route).
+ */
+inline void saveConfig(const char* newHost, uint16_t newPort, const char* newUser,
+                       const char* newPass, const char* newPrefix) {
+  copyField(cfgHost, sizeof(cfgHost), newHost);
+  copyField(cfgUser, sizeof(cfgUser), newUser);
+  copyField(cfgPrefix, sizeof(cfgPrefix), newPrefix);
+  cfgPort = newPort ? newPort : 1883;
+  if (newPass) copyField(cfgPass, sizeof(cfgPass), newPass);
+
+  Preferences prefs;
+  if (prefs.begin("patternflow", false)) {
+    prefs.putString("mq_host", cfgHost);
+    prefs.putString("mq_user", cfgUser);
+    prefs.putString("mq_prefix", cfgPrefix);
+    prefs.putUShort("mq_port", cfgPort);
+    if (newPass) prefs.putString("mq_pass", cfgPass);
+    prefs.end();
+  }
+  applyConfigChange();
+}
+
+/** Forget the broker entirely, including the password. */
+inline void clearConfig() {
+  cfgHost[0] = '\0';
+  cfgUser[0] = '\0';
+  cfgPass[0] = '\0';
+  cfgPort = 1883;
+  Preferences prefs;
+  if (prefs.begin("patternflow", false)) {
+    prefs.remove("mq_host");
+    prefs.remove("mq_user");
+    prefs.remove("mq_pass");
+    prefs.remove("mq_port");
+    prefs.end();
+  }
+  applyConfigChange();
+}
 
 inline void lastKnobsCopy(long out[4]) {
   for (int i = 0; i < 4; ++i) out[i] = lastKnobs[i];
@@ -393,7 +498,7 @@ inline void begin() {
   lastReconnectMs = 0;
   if (hasBroker()) {
     Serial.printf("[MQTT] ready — broker %s:%d  page /mqtt\n",
-                  PF_MQTT_HOST, PF_MQTT_PORT);
+                  cfgHost, cfgPort);
   } else {
     Serial.println("[MQTT] compiled in, no broker set — see /mqtt");
   }

--- a/firmware/patternflow/src/core_mqtt_http.h
+++ b/firmware/patternflow/src/core_mqtt_http.h
@@ -81,6 +81,12 @@ inline void sendStatus(int code) {
   json += PatternflowMqtt::isConnected() ? "true" : "false";
   json += ",\"configured\":";
   json += PatternflowMqtt::hasBroker() ? "true" : "false";
+  // Whether a password is set, never the password. The page shows an empty
+  // field either way and sending it back would put a credential on the
+  // network on every poll for no benefit — nothing on the page needs to
+  // read it, only to replace it.
+  json += ",\"hasPassword\":";
+  json += PatternflowMqtt::hasPassword() ? "true" : "false";
   json += ",\"knobs\":[";
   for (int i = 0; i < 4; ++i) {
     if (i) json += ',';
@@ -128,6 +134,52 @@ inline void handlePost() {
   sendStatus(200);
 }
 
+/**
+ * Save the broker settings typed on /mqtt.
+ *
+ * The password is the only field with a rule of its own: it is never sent to
+ * the page, so the form always posts it empty unless somebody typed a new
+ * one. An empty field therefore means "unchanged", not "blank it" — clearing
+ * is what the separate forget button is for. Without that, opening the page
+ * and pressing Save would silently drop a working login.
+ */
+inline void handleConfig() {
+  PatternflowPatternsHttp::noteConsoleApiCall();
+
+  String host = server().hasArg("host") ? server().arg("host") : String();
+  host.trim();
+
+  long port = server().hasArg("port") ? server().arg("port").toInt() : 1883;
+  if (port <= 0 || port > 65535) {
+    server().send(400, "application/json",
+                  "{\"ok\":false,\"error\":\"port must be 1-65535\"}");
+    return;
+  }
+
+  String user = server().hasArg("user") ? server().arg("user") : String();
+  user.trim();
+  String prefix = server().hasArg("prefix") ? server().arg("prefix") : String();
+  prefix.trim();
+  if (prefix.length() == 0) prefix = "patternflow";
+
+  const bool sentPassword = server().hasArg("pass") && server().arg("pass").length() > 0;
+  String pass = sentPassword ? server().arg("pass") : String();
+
+  PatternflowMqtt::saveConfig(host.c_str(), (uint16_t)port, user.c_str(),
+                              sentPassword ? pass.c_str() : nullptr, prefix.c_str());
+  sendStatus(200);
+}
+
+inline void handleForget() {
+  PatternflowPatternsHttp::noteConsoleApiCall();
+  PatternflowMqtt::clearConfig();
+  // A forgotten broker with a role still set would retry an empty host
+  // forever, so the role goes back to Off with it.
+  PatternflowMqtt::setRole(PatternflowMqtt::ROLE_OFF);
+  persistRole(PatternflowMqtt::ROLE_OFF);
+  sendStatus(200);
+}
+
 inline void begin() {
   if (initialized) return;
   if (WiFi.status() != WL_CONNECTED) return;
@@ -135,6 +187,8 @@ inline void begin() {
   server().on("/mqtt", HTTP_GET, handleIndex);
   server().on("/api/mqtt", HTTP_GET, handleGet);
   server().on("/api/mqtt", HTTP_POST, handlePost);
+  server().on("/api/mqtt/config", HTTP_POST, handleConfig);
+  server().on("/api/mqtt/forget", HTTP_POST, handleForget);
 
   initialized = true;
   Serial.printf("[MQTT-HTTP] role picker http://%s/mqtt\n",

--- a/firmware/patternflow/src/mqtt_index.h
+++ b/firmware/patternflow/src/mqtt_index.h
@@ -57,6 +57,29 @@ font-size:12px;color:var(--muted);line-height:1.45;display:none}
 .banner code{font-family:var(--mono);font-size:11px;color:var(--ink)}
 #msg{margin-top:12px;font-family:var(--mono);font-size:11px;min-height:16px}
 #msg.err{color:var(--led)}#msg.good{color:var(--ok)}
+/* Broker form. Labels sit beside their field on a desktop and stack on a
+   phone, which is where this page is most likely to be opened — the board is
+   across the room and the address is on a sticker. */
+#cfg{margin:0 0 14px}
+.field{display:flex;align-items:center;gap:12px;padding:6px 0}
+.field label{flex:0 0 74px;font-size:13px;color:var(--muted)}
+.field input{flex:1;min-width:0;font:inherit;font-family:var(--mono);font-size:12px;
+padding:7px 9px;background:var(--panel);color:var(--ink);
+border:1px solid var(--rule);border-radius:2px}
+.field input:focus{outline:none;border-color:var(--led)}
+.field input::placeholder{color:var(--faint)}
+.actions{display:flex;flex-wrap:wrap;align-items:center;gap:10px;margin-top:10px}
+.save,.forget{font:inherit;font-size:12px;padding:6px 12px;border-radius:2px;cursor:pointer}
+.save{border:1px solid var(--led);background:var(--led);color:var(--panel);font-weight:600}
+.save:disabled{opacity:.5;cursor:default}
+.forget{border:1px solid var(--rule);background:none;color:var(--muted)}
+.forget:hover{border-color:var(--led);color:var(--led)}
+#cfgmsg{margin:0}
+#cfgmsg.err{color:var(--led)}#cfgmsg.good{color:var(--ok)}
+@media(max-width:420px){
+.field{display:block}
+.field label{display:block;margin-bottom:4px}
+.field input{width:100%;box-sizing:border-box}}
 footer{margin-top:32px;padding-top:12px;border-top:1px solid var(--rule);
 font-family:var(--mono);font-size:11px;color:var(--faint)}
 a{color:var(--muted)}
@@ -72,9 +95,8 @@ font-family:var(--mono);font-size:11px;letter-spacing:.04em}
 
 <section>
   <h2>Role</h2>
-  <div class="banner" id="unset">No broker is configured in this build, so nothing will connect
-    whichever role you pick. Set <code>PF_MQTT_HOST</code> (and user / password if the broker
-    wants them) in <code>patternflow_secrets.h</code> and reflash.</div>
+  <div class="banner" id="unset">No broker set yet, so nothing will connect whichever role you
+    pick. Fill in <b>Broker</b> below — it is saved on the device, not in the firmware.</div>
   <div class="roles">
     <button class="role" id="r-off" data-role="off"><b>Off</b><p>Disconnect from the broker. Knobs stay local.</p></button>
     <button class="role" id="r-publisher" data-role="publisher"><b>Publisher</b><p>Send the four knob values and the current pattern name.</p></button>
@@ -88,11 +110,29 @@ font-family:var(--mono);font-size:11px;letter-spacing:.04em}
 
 <section>
   <h2>Broker</h2>
+  <!-- Typed in here rather than compiled into the firmware, so a broker
+       address and its login never travel in a public image. Saved on this
+       device; a reflash keeps them. -->
+  <form id="cfg" autocomplete="off">
+    <div class="field"><label for="f-host">Host</label>
+      <input id="f-host" name="host" placeholder="broker.example.com or 192.168.1.10" maxlength="63"></div>
+    <div class="field"><label for="f-port">Port</label>
+      <input id="f-port" name="port" type="number" min="1" max="65535" value="1883"></div>
+    <div class="field"><label for="f-user">User</label>
+      <input id="f-user" name="user" placeholder="leave empty for anonymous" maxlength="31"></div>
+    <div class="field"><label for="f-pass">Password</label>
+      <input id="f-pass" name="pass" type="password" placeholder="unchanged" maxlength="47"></div>
+    <div class="field"><label for="f-prefix">Prefix</label>
+      <input id="f-prefix" name="prefix" placeholder="patternflow" maxlength="31"></div>
+    <div class="actions">
+      <button type="submit" class="save" id="save">Save broker</button>
+      <button type="button" class="forget" id="forget">Forget</button>
+      <span class="note" id="cfgmsg"></span>
+    </div>
+  </form>
+  <p class="note">The password is stored on the device and never sent back to this page —
+    leave it empty to keep the one already saved.</p>
   <dl>
-    <div class="row"><dt>Host</dt><dd id="host">-</dd></div>
-    <div class="row"><dt>Port</dt><dd id="port">-</dd></div>
-    <div class="row"><dt>User</dt><dd id="user">-</dd></div>
-    <div class="row"><dt>Prefix</dt><dd id="prefix">-</dd></div>
     <div class="row"><dt>State</dt><dd id="state">-</dd></div>
   </dl>
 </section>
@@ -114,13 +154,27 @@ font-family:var(--mono);font-size:11px;letter-spacing:.04em}
 function $(i){return document.getElementById(i)}
 function say(t,cls){$('msg').textContent=t;$('msg').className=cls||''}
 
+// The form is filled once, and again only after a save. This page polls
+// every two seconds, and a poll that writes into the inputs would erase
+// whatever was half-typed — so once the fields are populated the status
+// updates leave them alone.
+var cfgFilled=false;
+function fillConfig(d){
+  $('f-host').value=d.host||'';
+  $('f-port').value=d.port||1883;
+  $('f-user').value=d.user||'';
+  $('f-prefix').value=d.prefix||'';
+  // Never populated: the device does not send it back. The placeholder says
+  // which of the two empty-field meanings applies.
+  $('f-pass').value='';
+  $('f-pass').placeholder=d.hasPassword?'unchanged':'none set';
+  cfgFilled=true;
+}
+
 function paint(d){
   var prefix=d.prefix||'patternflow';
   $('st').textContent=d.connected?'connected':(d.state||'offline');
-  $('host').textContent=d.host||'(not set)';
-  $('port').textContent=d.port||'-';
-  $('user').textContent=d.user||'(anonymous)';
-  $('prefix').textContent=prefix;
+  if(!cfgFilled)fillConfig(d);
   $('state').textContent=d.state||'-';
   // Only red when it is actually trying and failing: "off" and an
   // unconfigured build are resting states, not faults.
@@ -157,6 +211,43 @@ Array.prototype.forEach.call(document.querySelectorAll('.role'),function(btn){
       }).catch(function(){say('no reply from device','err')});
   };
 });
+
+function cfgSay(t,cls){var e=$('cfgmsg');e.textContent=t;e.className='note'+(cls?' '+cls:'')}
+
+$('cfg').onsubmit=function(ev){
+  ev.preventDefault();
+  var host=$('f-host').value.trim();
+  if(!host){cfgSay('a host is required — or press Forget','err');return}
+  cfgSay('saving…');
+  $('save').disabled=true;
+  // The password rides only when something was typed. An empty field means
+  // "keep what is stored", so sending it would blank a working login.
+  var body='host='+encodeURIComponent(host)+
+    '&port='+encodeURIComponent($('f-port').value||1883)+
+    '&user='+encodeURIComponent($('f-user').value.trim())+
+    '&prefix='+encodeURIComponent($('f-prefix').value.trim());
+  if($('f-pass').value)body+='&pass='+encodeURIComponent($('f-pass').value);
+  fetch('/api/mqtt/config',{method:'POST',
+    headers:{'Content-Type':'application/x-www-form-urlencoded'},body:body})
+    .then(function(r){return r.json()}).then(function(d){
+      $('save').disabled=false;
+      if(d.ok===false){cfgSay(d.error||'could not save','err');return}
+      cfgSay('saved — reconnecting','good');
+      fillConfig(d);
+      paint(d);
+    }).catch(function(){$('save').disabled=false;cfgSay('no reply from device','err')});
+};
+
+$('forget').onclick=function(){
+  if(!confirm('Forget this broker, including the saved password?'))return;
+  cfgSay('clearing…');
+  fetch('/api/mqtt/forget',{method:'POST'})
+    .then(function(r){return r.json()}).then(function(d){
+      cfgSay('broker forgotten','good');
+      fillConfig(d);
+      paint(d);
+    }).catch(function(){cfgSay('no reply from device','err')});
+};
 
 load();
 setInterval(load,2000);


### PR DESCRIPTION
@SimonePDA's proposal, built:

> let's add in the MQTT page the input fields for the Broker, user and the password, so that is not available in the Github files

**`/mqtt` gains host, port, user, password and prefix**, kept in NVS the same way Wi-Fi already is. Nothing about a broker is in the source or in a release image any more. The `PF_MQTT_*` macros survive as build-time defaults for anyone who does want to bake their own in; saved values win over them.

**The password has the only rule worth stating.** It is never sent to the page — status carries `hasPassword` instead, the field always renders empty, and an empty field on save means *unchanged*, not *blank*. Without that, opening the page and pressing Save would quietly destroy a working login. Clearing is the separate **Forget** button, which also drops the role to Off so a forgotten broker is not retried forever.

The form fills once and after a save, never on the two-second status poll — which would otherwise erase whatever was half-typed.

Costs **176 bytes** of internal DRAM (the four buffers; measured 87,720 → 87,896).

### Verified on hardware

| | |
| :--- | :--- |
| password absent from `/api/mqtt` (checked against the real value) | PASS |
| `hasPassword: true` reported instead | PASS |
| host / port / user / prefix save | PASS |
| empty password field keeps the stored one | PASS |
| **settings survive a reboot — and a firmware reflash** | PASS |
| blank host leaves the device unconfigured | PASS |
| Forget clears host, password and role | PASS |
| console still serves `/mqtt` and `/api/patterns` afterwards | PASS |
| **device reconnects using NVS values — `state=connected`** | PASS |

The final check is the one that matters: settings entered through the API, stored in NVS, and the board connected to a real broker with them — not with the compiled-in macros.

Also exercised through the real page (extracted from the firmware header rather than copied) against a mock device, which covered the form behaviour a raw API test cannot: the poll not clobbering half-typed input, and mobile stacking without overflow.

Note: Simone said he was going to make this change too — worth a word with him so it does not land twice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)