### PR TITLE
MQTT message banner, and the wildcard subscribe that never worked

### DIFF
--- a/firmware/patternflow/net_config.h
+++ b/firmware/patternflow/net_config.h
@@ -221,8 +221,16 @@
 #ifndef PF_MQTT_PASS
 #define PF_MQTT_PASS ""
 #endif
-// Topic root: <prefix>/knob/1..4 and <prefix>/pattern. Give each panel its
-// own prefix when several share a broker and should NOT mirror each other.
+// How long a banner published to <prefix>/message stays on the panel.
+// Counted from each receipt, so a new message restarts it and a retained one
+// shows once per connect rather than sticking forever.
+#ifndef PF_MQTT_MESSAGE_DURATION_MS
+#define PF_MQTT_MESSAGE_DURATION_MS 10000
+#endif
+// Topic root: <prefix>/knob/1..4, <prefix>/pattern and <prefix>/message.
+// Give each panel its own prefix when several share a broker and should NOT
+// mirror each other — and note that on a SHARED broker the default prefix
+// means every panel on it sees every banner.
 #ifndef PF_MQTT_PREFIX
 #define PF_MQTT_PREFIX "patternflow"
 #endif

--- a/firmware/patternflow/patternflow.ino
+++ b/firmware/patternflow/patternflow.ino
@@ -587,6 +587,45 @@ void drawSelectingMode() {
   PatternflowUiText::useDefaultFont();
 }
 
+// A banner from <prefix>/message, over whatever is running.
+//
+// Contributed by @SimonePDA. Drawn on top rather than instead of the pattern:
+// the pattern keeps animating underneath, so a message is an interruption you
+// can read and wait out, not a mode you have to leave.
+//
+// Uses the same wrapped-name helper the SELECT screen does, so a long message
+// breaks the same way a long pattern name does — the panel is 64 px wide in
+// portrait, which is about ten characters a line.
+void drawMqttMessageOverlay() {
+#if PF_MQTT_ENABLED
+  if (!PatternflowMqtt::overlayActive()) return;
+
+  char text[PatternflowMqtt::MESSAGE_BYTES];
+  asciiFold(PatternflowMqtt::overlayMessage(), text, sizeof(text));
+  if (!text[0]) return;
+
+  // Portrait, like every other overlay; the caller is drawing in landscape.
+  dma_display->setRotation(1);
+  const int screenW = dma_display->width();
+  const int screenH = dma_display->height();
+
+  // A dim plate behind the words. Without it the message sits on top of a
+  // bright pattern and is unreadable exactly when it matters most.
+  int16_t x1, y1;
+  uint16_t tw, th;
+  PatternflowUiText::boundsWith(PatternflowUiText::useNameFont, text, &x1, &y1, &tw, &th);
+  const int plateH = th + 24;
+  const int plateY = (screenH - plateH) / 2;
+  dma_display->fillRect(0, plateY, screenW, plateH, dma_display->color565(0, 0, 0));
+  dma_display->drawRect(0, plateY, screenW, plateH, pfLedC());
+
+  PatternflowUiText::drawWrappedName(text, screenH / 2,
+                                     dma_display->color565(255, 255, 255));
+  PatternflowUiText::useDefaultFont();
+  dma_display->setRotation(0);
+#endif
+}
+
 void readInputFrame(InputFrame& input) {
   static long prevKnobs[4] = {0, 0, 0, 0};
 
@@ -1036,6 +1075,7 @@ void loop() {
     pausedDirty = true;
     updateActivePattern(dt, input);
     drawActivePattern();
+    drawMqttMessageOverlay();
 
     if (contentNoticeTimer > 0.0f) {
       drawContentNotice();

--- a/firmware/patternflow/patternflow.ino
+++ b/firmware/patternflow/patternflow.ino
@@ -613,14 +613,14 @@ void drawMqttMessageOverlay() {
   // bright pattern and is unreadable exactly when it matters most.
   int16_t x1, y1;
   uint16_t tw, th;
-  PatternflowUiText::boundsWith(PatternflowUiText::useNameFont, text, &x1, &y1, &tw, &th);
+  PatternflowUiText::boundsWith(PatternflowUiText::useMessageFont, text, &x1, &y1, &tw, &th);
   const int plateH = th + 24;
   const int plateY = (screenH - plateH) / 2;
   dma_display->fillRect(0, plateY, screenW, plateH, dma_display->color565(0, 0, 0));
   dma_display->drawRect(0, plateY, screenW, plateH, pfLedC());
 
-  PatternflowUiText::drawWrappedName(text, screenH / 2,
-                                     dma_display->color565(255, 255, 255));
+  PatternflowUiText::drawWrappedMessage(text, screenH / 2,
+                                       dma_display->color565(255, 255, 255));
   PatternflowUiText::useDefaultFont();
   dma_display->setRotation(0);
 #endif

--- a/firmware/patternflow/src/core_mqtt.h
+++ b/firmware/patternflow/src/core_mqtt.h
@@ -121,6 +121,20 @@ inline char cfgPass[PASS_BYTES] = PF_MQTT_PASS;
 inline char cfgPrefix[PREFIX_BYTES] = PF_MQTT_PREFIX;
 inline uint16_t cfgPort = PF_MQTT_PORT;
 
+// ── Message banner (@SimonePDA) ──────────────────────────────────────────
+//
+// Anything published to <prefix>/message is drawn over the running pattern
+// for a few seconds. Receive-only: a panel never publishes here, so the
+// sender is Home Assistant, a script, or somebody with MQTT Explorer open.
+//
+// Shown per receipt rather than held. A retained payload — which is how you
+// would leave a note for a panel that is currently off — otherwise comes
+// back on every reconnect and every reboot, and a banner you cannot clear by
+// power-cycling is a fault, not a feature.
+constexpr size_t MESSAGE_BYTES = 80;
+inline char overlayText[MESSAGE_BYTES] = {};
+inline uint32_t overlayUntilMs = 0;
+
 inline bool hasBroker() { return cfgHost[0] != '\0'; }
 
 // Back off as failures pile up: a broker that is down stays down, and each
@@ -168,6 +182,16 @@ inline void topicKnob(char* buf, size_t n, int index) {
 
 inline void topicPattern(char* buf, size_t n) {
   snprintf(buf, n, "%s/pattern", cfgPrefix);
+}
+
+inline void topicMessage(char* buf, size_t n) {
+  snprintf(buf, n, "%s/message", cfgPrefix);
+}
+
+inline bool topicIsMessage(const char* topic) {
+  char expected[48];
+  topicMessage(expected, sizeof(expected));
+  return topic && strcmp(topic, expected) == 0;
 }
 
 inline bool topicIsPattern(const char* topic) {
@@ -242,8 +266,42 @@ inline void applyRemotePattern(const char* name) {
   if (index >= 0) pendingPatternIdx = index;
 }
 
+/**
+ * Show a banner, or clear it.
+ *
+ * An empty payload clears — which is also how you retract a retained one, so
+ * "publish empty with retain" both wipes the topic and takes the banner off
+ * every panel watching it.
+ */
+inline void applyRemoteMessage(const char* text) {
+  if (!text || !text[0]) {
+    overlayText[0] = '\0';
+    overlayUntilMs = 0;
+    return;
+  }
+  snprintf(overlayText, sizeof(overlayText), "%s", text);
+  overlayUntilMs = millis() + PF_MQTT_MESSAGE_DURATION_MS;
+}
+
+inline bool overlayActive() {
+  if (!overlayText[0]) return false;
+  // millis() wraps after ~49 days; the subtraction is what makes that safe.
+  if ((int32_t)(millis() - overlayUntilMs) >= 0) {
+    overlayText[0] = '\0';
+    return false;
+  }
+  return true;
+}
+
+inline const char* overlayMessage() { return overlayText; }
+
+/** Milliseconds left on the banner, for the console. */
+inline uint32_t overlayRemainingMs() {
+  if (!overlayActive()) return 0;
+  return overlayUntilMs - millis();
+}
+
 inline void onMessage(char* topic, uint8_t* payload, unsigned int length) {
-  if (role != ROLE_SUBSCRIBER) return;
   char body[96];
   unsigned int n = length < sizeof(body) - 1 ? length : sizeof(body) - 1;
   memcpy(body, payload, n);
@@ -251,6 +309,17 @@ inline void onMessage(char* topic, uint8_t* payload, unsigned int length) {
   while (n && (body[n - 1] == '\n' || body[n - 1] == '\r' || body[n - 1] == ' ')) {
     body[--n] = '\0';
   }
+
+  // Before the subscriber gate on purpose: a banner is worth having on a
+  // one-panel setup, where the panel is the publisher and Home Assistant is
+  // the only thing talking back. Mirroring knobs is the part that only makes
+  // sense as a subscriber.
+  if (topicIsMessage(topic)) {
+    applyRemoteMessage(body);
+    return;
+  }
+
+  if (role != ROLE_SUBSCRIBER) return;
 
   if (topicIsPattern(topic)) {
     applyRemotePattern(body);
@@ -290,12 +359,29 @@ inline void ensureClientId() {
            (unsigned)((mac >> 24) & 0xFFFFFF));
 }
 
+// Each knob topic by name, rather than one `knob/+` subscription.
+//
+// A wildcard needs the broker to grant the wildcard. An ACL written as the
+// exact list of topics a device may touch — which is how you would lock down
+// a broker shared with strangers, and how @SimonePDA's is configured —
+// refuses `patternflow/knob/+` outright, and the failure is silent: the
+// device connects, reports "connected", and simply never receives a knob.
+// Four subscriptions cost four small packets once per connect.
+inline void subscribeMessage() {
+  char topic[48];
+  topicMessage(topic, sizeof(topic));
+  client.subscribe(topic);
+}
+
 inline void subscribeAll() {
   char topic[48];
-  snprintf(topic, sizeof(topic), "%s/knob/+", cfgPrefix);
-  client.subscribe(topic);
+  for (int i = 0; i < 4; ++i) {
+    topicKnob(topic, sizeof(topic), i);
+    client.subscribe(topic);
+  }
   topicPattern(topic, sizeof(topic));
   client.subscribe(topic);
+  subscribeMessage();
 }
 
 // A literal address costs nothing to "resolve"; a hostname costs a blocking
@@ -370,6 +456,10 @@ inline bool tryConnect() {
     subscribeAll();
   } else if (role == ROLE_PUBLISHER) {
     publishSnapshot();
+    // A publisher subscribes to exactly one thing: banners. It mirrors
+    // nobody's knobs, but there is no reason it should not be able to be
+    // told something.
+    subscribeMessage();
   }
   return true;
 }

--- a/firmware/patternflow/src/core_mqtt_http.h
+++ b/firmware/patternflow/src/core_mqtt_http.h
@@ -54,11 +54,30 @@ inline void persistRole(PatternflowMqtt::Role role) {
   prefs.end();
 }
 
+// Escaped, because not every value here is ours any more. The banner text
+// arrives from whoever can publish to <prefix>/message, and a single quote
+// character in it would otherwise end the string early and hand the console a
+// JSON parse error — which looks like the device being broken rather than
+// somebody having typed an apostrophe. Pattern names get the same treatment;
+// they come from a community and nothing stops one containing a quote.
 inline void appendJsonString(String& json, const char* key, const char* value) {
   json += "\"";
   json += key;
   json += "\":\"";
-  json += value ? value : "";
+  for (const char* p = value; p && *p; ++p) {
+    const unsigned char c = (unsigned char)*p;
+    if (c == '"' || c == '\\') {
+      json += '\\';
+      json += (char)c;
+    } else if (c < 0x20) {
+      // Control characters are not legal raw in a JSON string. None of them
+      // mean anything on a 64px panel, so they become spaces rather than
+      // \u00xx escapes nobody will read.
+      json += ' ';
+    } else {
+      json += (char)c;
+    }
+  }
   json += "\",";
 }
 
@@ -74,6 +93,7 @@ inline void sendStatus(int code) {
   appendJsonString(json, "user", PatternflowMqtt::user());
   appendJsonString(json, "prefix", PatternflowMqtt::prefix());
   appendJsonString(json, "pattern", PatternflowMqtt::lastPatternName());
+  appendJsonString(json, "message", PatternflowMqtt::overlayMessage());
   appendJsonString(json, "error", PatternflowMqtt::error());
   json += "\"port\":";
   json += PatternflowMqtt::port();
@@ -87,6 +107,10 @@ inline void sendStatus(int code) {
   // read it, only to replace it.
   json += ",\"hasPassword\":";
   json += PatternflowMqtt::hasPassword() ? "true" : "false";
+  // The banner currently on the panel, so the page can show what a message
+  // did without anyone having to be in the room.
+  json += ",\"messageMs\":";
+  json += PatternflowMqtt::overlayRemainingMs();
   json += ",\"knobs\":[";
   for (int i = 0; i < 4; ++i) {
     if (i) json += ',';

--- a/firmware/patternflow/src/core_ui_text.h
+++ b/firmware/patternflow/src/core_ui_text.h
@@ -30,6 +30,7 @@
 #include <Arduino.h>
 #include "core_display.h"   // brings in the panel type
 #include <Fonts/TomThumb.h>
+#include <Fonts/Org_01.h>
 
 // Owned by the sketch.
 extern MatrixPanel_I2S_DMA* dma_display;
@@ -40,6 +41,8 @@ namespace PatternflowUiText {
 // from touching. The built-in font is 7 px tall; TomThumb is 6.
 constexpr int NAME_PITCH = 9;
 constexpr int CHROME_PITCH = 7;
+// Org_01 is 8 px tall and sits tight; 9 keeps stacked lines apart.
+constexpr int MESSAGE_PITCH = 9;
 // Three lines is 27 px — about a fifth of the portrait screen, which is as
 // much as the SELECT overlay can give up without burying the live preview it
 // exists to show. At ~10 characters a line that is 30 characters, more than
@@ -51,6 +54,14 @@ constexpr size_t LINE_BUF = 48;
 // The stock 5x7. Legibility beats density here: see the note at the top.
 inline void useNameFont() {
   dma_display->setFont();
+  dma_display->setTextSize(1);
+}
+
+// Org_01 — about twice the characters per line. Only the message banner
+// uses it; see drawWrappedMessage for why that is not a contradiction of the
+// note at the top of this file.
+inline void useMessageFont() {
+  dma_display->setFont(&Org_01);
   dma_display->setTextSize(1);
 }
 
@@ -95,15 +106,16 @@ inline void drawChromeLine(const char* text, int yTop, uint16_t color) {
 //
 // A single word too wide to fit is drawn in the chrome font instead of being
 // clipped: smaller and still readable beats half a word.
-inline int drawWrappedName(const char* name, int yMiddle, uint16_t color) {
+inline int drawWrapped(void (*chooseFont)(), int pitch, const char* name,
+                       int yMiddle, uint16_t color) {
   const int maxW = dma_display->width() - 4;
   int16_t x1, y1;
   uint16_t w, h;
 
-  boundsWith(useNameFont, name, &x1, &y1, &w, &h);
+  boundsWith(chooseFont, name, &x1, &y1, &w, &h);
   if ((int)w <= maxW) {
-    drawLine(useNameFont, name, yMiddle - NAME_PITCH / 2, color);
-    return NAME_PITCH;
+    drawLine(chooseFont, name, yMiddle - pitch / 2, color);
+    return pitch;
   }
 
   char buf[NAME_BUF];
@@ -128,7 +140,7 @@ inline int drawWrappedName(const char* name, int yMiddle, uint16_t color) {
       if (*p == ' ') lastSpace = p;
       char saved = p[1];
       p[1] = '\0';
-      boundsWith(useNameFont, lineStart, &x1, &y1, &w, &h);
+      boundsWith(chooseFont, lineStart, &x1, &y1, &w, &h);
       p[1] = saved;
       if ((int)w > maxW) break;
       p++;
@@ -148,12 +160,33 @@ inline int drawWrappedName(const char* name, int yMiddle, uint16_t color) {
     cursor = (*cut == ' ') ? cut + 1 : cut;
   }
 
-  int blockH = nLines * NAME_PITCH;
+  int blockH = nLines * pitch;
   int startY = yMiddle - blockH / 2;
   for (int i = 0; i < nLines; i++) {
-    drawLine(useNameFont, lines[i], startY + i * NAME_PITCH, color);
+    drawLine(chooseFont, lines[i], startY + i * pitch, color);
   }
   return blockH;
+}
+
+/** Pattern names and OS text: the stock 5x7, chosen for legibility. */
+inline int drawWrappedName(const char* name, int yMiddle, uint16_t color) {
+  return drawWrapped(useNameFont, NAME_PITCH, name, yMiddle, color);
+}
+
+/**
+ * A banner from <prefix>/message, in Org_01.
+ *
+ * The denser font, deliberately, and only here. A pattern name is one or two
+ * words you glance at and must recognise, which is why the SELECT screen
+ * stayed on the stock 5x7 after Org_01 was tried and found to blur at this
+ * pixel pitch. A message is a sentence somebody wrote to be read, so fitting
+ * it wins over per-character crispness — "Dinner is ready" at ~20 characters
+ * a line is one line here and three in the stock font.
+ *
+ * @SimonePDA asked for this font for exactly that reason.
+ */
+inline int drawWrappedMessage(const char* text, int yMiddle, uint16_t color) {
+  return drawWrapped(useMessageFont, MESSAGE_PITCH, text, yMiddle, color);
 }
 
 }  // namespace PatternflowUiText

--- a/firmware/patternflow/src/mqtt_index.h
+++ b/firmware/patternflow/src/mqtt_index.h
@@ -106,6 +106,9 @@ font-family:var(--mono);font-size:11px;letter-spacing:.04em}
   <p class="note">Pick one panel as publisher and another as subscriber to keep them in sync.
     Values are retained on the broker, so a subscriber that joins late still catches up.
     The choice survives a reboot.</p>
+  <p class="note">Publish to <code id="msgtopic">patternflow/message</code> and the text appears
+    over the running pattern for ten seconds — any connected role, empty payload clears it.
+    On a broker shared with other people, every panel using this prefix sees it.</p>
 </section>
 
 <section>
@@ -141,6 +144,7 @@ font-family:var(--mono);font-size:11px;letter-spacing:.04em}
   <h2>Last values</h2>
   <dl>
     <div class="row"><dt>Pattern</dt><dd id="pat">-</dd></div>
+    <div class="row"><dt>Banner</dt><dd id="banner">-</dd></div>
     <div class="row"><dt>K1</dt><dd id="k1">-</dd></div>
     <div class="row"><dt>K2</dt><dd id="k2">-</dd></div>
     <div class="row"><dt>K3</dt><dd id="k3">-</dd></div>
@@ -182,9 +186,15 @@ function paint(d){
     (d.role==='off'||!d.configured?'':'bad');
   $('unset').style.display=d.configured?'none':'block';
   $('pat').textContent=d.pattern||'-';
+  // Counts down while it is on the panel, so you can tell a banner that just
+  // arrived from one that is about to go.
+  $('banner').textContent=d.messageMs>0
+    ?(d.message||'(blank)')+'  ·  '+Math.ceil(d.messageMs/1000)+'s'
+    :'-';
   var k=d.knobs||[0,0,0,0];
   for(var i=0;i<4;i++)$('k'+(i+1)).textContent=k[i];
-  $('topics').textContent=prefix+'/knob/1..4  ·  '+prefix+'/pattern';
+  $('topics').textContent=prefix+'/knob/1..4  ·  '+prefix+'/pattern  ·  '+prefix+'/message';
+  $('msgtopic').textContent=prefix+'/message';
   ['off','publisher','subscriber'].forEach(function(r){
     var el=$('r-'+r);
     if(el)el.className='role'+(d.role===r?' on':'');


### PR DESCRIPTION
Builds @SimonePDA's `/message` note. Publish to `<prefix>/message` and the text is drawn over the running pattern for ten seconds; an empty payload clears it. Receive-only — a panel never publishes here.

### Verified on hardware

Tested against a throwaway local broker on a private prefix, **not** the shared one: its ACL pins the `patternflow` user to `patternflow/*` with no wildcards, so there is no private prefix available there — and test banners on the shared prefix would appear on every other person's panel, which is the hazard this feature raises.

| | |
| :--- | :--- |
| banner appears, counts down | PASS |
| a new message restarts the ten seconds | PASS (3.2s left → 9.2s) |
| empty payload clears immediately | PASS |
| **retained payload expires anyway** | PASS — broker still holds it, panel drops it |
| shows again on reconnect, fresh ten seconds | PASS |
| empty retained retracts it for good | PASS |
| quotes and a backslash survive the console JSON | PASS |

### Two bugs found on the way

**`knob/+` never worked against a locked-down broker.** A wildcard needs the broker to grant the wildcard, and an ACL written as the explicit list of permitted topics — which is how Simone's now is — refuses it silently: connected, reporting connected, never receiving a knob. Now four named subscriptions, confirmed in the broker log:

```
SUBSCRIBE pftest/knob/1 .. /4    ← individually
SUBSCRIBE pftest/pattern
SUBSCRIBE pftest/message
```

**The status JSON had no escaping.** Survivable while every value came from our own registry; a banner is arbitrary text from whoever can publish, and one quote would have ended the string early and handed the console a parse error that reads as a broken device. Escaped now, pattern names included.

### Notes

**Any connected role**, per his design note 2 — a publisher subscribes to exactly this one topic, because a one-panel setup has the panel publishing and Home Assistant as the only thing talking back.

**Org_01 for the banner only**, as he asked. The wrapper is font-parameterised rather than duplicated, and SELECT keeps the stock 5×7 it was moved to. Feedback after looking at it on the panel: it works, but the font reads *a bit poor* — offered here as data for Simone rather than as a change, since he asked for it specifically and may have a better one in mind.

**Still open, and a decision rather than a patch:** with the default prefix, every panel on a shared broker sees every banner. Stated plainly on `/mqtt` and in `net_config.h`; the fixes would be a per-device topic (`<prefix>/<clientId>/message`) or pushing people to unique prefixes, which the new runtime settings make practical.

Costs 88 bytes of internal DRAM (87,896 → 87,984).

🤖 Generated with [Claude Code](https://claude.com/claude-code)