### PR TITLE
docs: the message broadcast is the design, not a leak

### DIFF
--- a/firmware/patternflow/net_config.h
+++ b/firmware/patternflow/net_config.h
@@ -228,9 +228,17 @@
 #define PF_MQTT_MESSAGE_DURATION_MS 10000
 #endif
 // Topic root: <prefix>/knob/1..4, <prefix>/pattern and <prefix>/message.
+//
+// A banner is a BROADCAST — every panel subscribed on this prefix shows it.
+// That is the design, not a leak (@SimonePDA, who runs the shared broker):
+// the topic list is fixed and short precisely so a broker can be locked to
+// it, and a per-device topic like <prefix>/<id>/message would need a
+// wildcard ACL, which is the thing that lets anyone invent topics. Broadcast
+// is what a tight ACL costs, and for "tell the panels something" it is also
+// what you want.
+//
 // Give each panel its own prefix when several share a broker and should NOT
-// mirror each other — and note that on a SHARED broker the default prefix
-// means every panel on it sees every banner.
+// mirror each other.
 #ifndef PF_MQTT_PREFIX
 #define PF_MQTT_PREFIX "patternflow"
 #endif

--- a/firmware/patternflow/src/core_mqtt.h
+++ b/firmware/patternflow/src/core_mqtt.h
@@ -127,6 +127,11 @@ inline uint16_t cfgPort = PF_MQTT_PORT;
 // for a few seconds. Receive-only: a panel never publishes here, so the
 // sender is Home Assistant, a script, or somebody with MQTT Explorer open.
 //
+// Deliberately a broadcast — every panel on the prefix shows it. There is no
+// per-device topic on purpose: addressing one panel would need a wildcard in
+// the broker's ACL, and a fixed topic list is what keeps a shared broker
+// from becoming somewhere anyone can invent topics.
+//
 // Shown per receipt rather than held. A retained payload — which is how you
 // would leave a note for a panel that is currently off — otherwise comes
 // back on every reconnect and every reboot, and a banner you cannot clear by

--- a/firmware/patternflow/src/mqtt_index.h
+++ b/firmware/patternflow/src/mqtt_index.h
@@ -108,7 +108,8 @@ font-family:var(--mono);font-size:11px;letter-spacing:.04em}
     The choice survives a reboot.</p>
   <p class="note">Publish to <code id="msgtopic">patternflow/message</code> and the text appears
     over the running pattern for ten seconds — any connected role, empty payload clears it.
-    On a broker shared with other people, every panel using this prefix sees it.</p>
+    It is a <b>broadcast</b>: every panel subscribed on this prefix shows it. Use your own
+    prefix if you want messages that only reach your own panels.</p>
 </section>
 
 <section>


### PR DESCRIPTION
I wrote the shared-broker broadcast up as an open hazard and proposed a per-device topic as the fix. @SimonePDA:

> The idea is that the banner appears on all panels that are subscribed on mqtt. It is a broadcast. As the topics are locked to avoid abuse, there is no "per user id" topic — by choice.

His reasoning beats my suggestion. Addressing one panel needs a wildcard in the broker's ACL, and a wildcard is precisely what lets anyone invent topics on a broker shared with strangers. The short fixed topic list is the thing being defended; broadcast is what it costs. **My proposed fix would have loosened the ACL to solve a problem that was not one.**

Comments in `net_config.h`, `core_mqtt.h` and the `/mqtt` page updated to say so. They still tell people every panel on the prefix sees the message — that is worth knowing — but as a description of the feature rather than a warning about it, with "use your own prefix" as the answer for anyone who wants messages that stay home.

No behaviour change; compiles at 1,336,319 bytes with DRAM unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)