### PR TITLE
Power clamp, and the console-lag culprit

### DIFF
--- a/firmware/patternflow/abi/pf_params.h
+++ b/firmware/patternflow/abi/pf_params.h
@@ -23,12 +23,18 @@
 #include <math.h>
 #include <stdint.h>
 
-#include "pf_abi.h"
+// Deliberately NOT including pf_abi.h: the firmware reaches this header
+// through src/core_params.h while pf_abi.h arrives by another path, and the
+// two spellings defeat its include guard. The macro is all that is needed,
+// and every route that matters already sets it — pf_abi.h when a module
+// builds, -D from build_module.py when it targets the older host. This
+// default is what the firmware itself, which always has the fields, gets.
+#ifndef PF_ABI_MODULE_VERSION
+#define PF_ABI_MODULE_VERSION 2
+#endif
 
 // PF_ABI_MODULE_VERSION >= 2 means "this build's host has the absolute
-// fields". pf_abi.h defaults it to 2 (firmware, and any module build that
-// did not ask otherwise); build_module.py passes 1 when targeting the older
-// host. Kept as one named test so no helper below can drift from the rest.
+// fields". Kept as one named test so no helper below can drift from the rest.
 #if PF_ABI_MODULE_VERSION >= 2
 #define PF_PARAMS_HAS_ABSOLUTE 1
 #else

--- a/firmware/patternflow/patternflow.ino
+++ b/firmware/patternflow/patternflow.ino
@@ -10,6 +10,9 @@
 #include "src/core_ota.h"
 #include "src/core_audio_ws.h"
 #include "src/core_web_update.h"
+// Reads the demand the display driver measured while blitting, so it comes
+// after core_display.h and before anything that sets brightness.
+#include "src/core_power.h"
 #include "pattern_registry.h"
 // After the registry: the pattern manager serves and mutates that list.
 #include "src/core_patterns_http.h"
@@ -44,6 +47,10 @@ float contentNoticeTimer = 0.0f;
 // which state you were in.) Value persists in NVS.
 Preferences prefs;
 uint8_t currentBrightness = DEFAULT_BRIGHTNESS;
+// What the panel is actually running at. Equal to currentBrightness unless the
+// power clamp is holding it down (core_power.h) — kept separately so the
+// clamp never rewrites the person's own setting.
+uint8_t appliedBrightness = DEFAULT_BRIGHTNESS;
 bool brightnessAdjusting = false;
 uint32_t brightnessIdleAtMs = 0;
 bool brightnessDirty = false;
@@ -133,6 +140,9 @@ void setup() {
   prefs.begin("patternflow", false);
   currentBrightness = prefs.getUChar("brightness", DEFAULT_BRIGHTNESS);
   dma_display->setBrightness8(currentBrightness);
+  // The clamp needs a frame's demand before it can say anything, so it starts
+  // out of the way and takes over from the first present().
+  PatternflowPower::load();
 
   // OSC + audio-react runtime flags, restored from NVS so the device boots
   // into whatever the K2 info screen was last set to.
@@ -321,6 +331,25 @@ void drawBrightnessNotice() {
   dma_display->drawFastHLine(x, by, w, pfDimC());
   int fw = ((int)w * pct) / 100;
   if (fw > 0) dma_display->drawFastHLine(x, by, fw, pfLedC());
+
+  // While the power clamp is holding brightness down, turning the knob up
+  // moves this bar and changes nothing on the panel. Say so, or it reads as
+  // a broken control: the dim segment is the part the clamp is withholding.
+  if (PatternflowPower::limiting) {
+    int allowedPct = (int)((PatternflowPower::allowedBrightness * 100 + 127) / 255);
+    int aw = ((int)w * allowedPct) / 100;
+    if (aw < fw) dma_display->drawFastHLine(x + aw, by, fw - aw, pfDimC());
+    char lim[20];
+    snprintf(lim, sizeof(lim), "PWR %umA", (unsigned)PatternflowPower::estimateMa);
+    uint16_t lw, lh;
+    dma_display->getTextBounds(lim, 0, 0, &x1, &y1, &lw, &lh);
+    int lx = (dma_display->width() - (int)lw) / 2;
+    int ly = y - (int)lh - 3;
+    dma_display->fillRect(lx - 2, ly - 2, lw + 4, lh + 4, 0);
+    dma_display->setTextColor(pfLedC());
+    dma_display->setCursor(lx, ly);
+    dma_display->print(lim);
+  }
 }
 
 // NETWORK info + toggle screen (K2 longpress). Shows Wi-Fi / OSC / audio
@@ -1156,5 +1185,19 @@ void loop() {
     dma_display->flipDMABuffer();
     uint32_t frameUs = micros() - frameStartedUs;
     renderFrameUs = renderFrameUs ? (renderFrameUs * 7 + frameUs) / 8 : frameUs;
+
+    // Total power clamp. The frame that just went out is the one whose demand
+    // was measured, so the answer lands on the next one — invisible at this
+    // frame rate, and it costs no second pass over the pixels.
+    //
+    // currentBrightness stays exactly what the person chose: only the value
+    // handed to the panel is capped, so turning the clamp off (or pointing a
+    // pattern at something darker) restores their setting with no further
+    // input from them.
+    uint8_t allowed = PatternflowPower::allow(currentBrightness);
+    if (allowed != appliedBrightness) {
+      appliedBrightness = allowed;
+      dma_display->setBrightness8(allowed);
+    }
   }
 }

--- a/firmware/patternflow/src/core_display_http.h
+++ b/firmware/patternflow/src/core_display_http.h
@@ -38,6 +38,7 @@
 
 #if PF_STATUS_HTTP_ENABLED && PF_DISPLAY_HTTP_ENABLED
 #include "core_canvas.h"
+#include "core_power.h"             // total power clamp: budget + telemetry
 #include "core_status_http.h"       // shared WebServer
 #include "../presets/preset_calib.h"  // absolute screen/level control
 #endif
@@ -96,18 +97,34 @@ inline void handleDisplay() {
     CalibPattern::requestedLevel = (int)server().arg("level").toInt();
   }
 
+  // Power clamp: budget is settable here, the rest is read-only telemetry.
+  if (server().hasArg("power_budget")) {
+    PatternflowPower::setBudgetMa((int)server().arg("power_budget").toInt());
+  }
+  if (server().hasArg("power_limit")) {
+    PatternflowPower::setEnabled(server().arg("power_limit") != "0");
+  }
+
   // snprintf, not String: this endpoint is hit continuously while somebody
   // drags a slider, and the shared heap is the scarcest thing on the board.
-  char json[256];
+  char json[384];
   snprintf(json, sizeof(json),
            "{\"wb_r\":%.3f,\"wb_g\":%.3f,\"wb_b\":%.3f,"
            "\"gamma_r\":%.3f,\"gamma_g\":%.3f,\"gamma_b\":%.3f,"
-           "\"sat\":%.3f,\"brightness\":%u,\"calib\":%d,\"screen\":%d,\"level\":%d}",
+           "\"sat\":%.3f,\"brightness\":%u,\"calib\":%d,\"screen\":%d,\"level\":%d,"
+           "\"power_limit\":%d,\"power_budget\":%u,\"power_ma\":%u,"
+           "\"power_demand\":%u,\"power_limiting\":%d,\"power_applied\":%u}",
            PFCanvas::wbR, PFCanvas::wbG, PFCanvas::wbB,
            PFCanvas::gammaR, PFCanvas::gammaG, PFCanvas::gammaB,
            PFCanvas::satBoost, (unsigned)currentBrightness,
            CalibPattern::overrideOn ? 1 : 0,
-           CalibPattern::screen, CalibPattern::whiteLevel);
+           CalibPattern::screen, CalibPattern::whiteLevel,
+           PatternflowPower::enabled ? 1 : 0,
+           (unsigned)PatternflowPower::budgetMa,
+           (unsigned)PatternflowPower::estimateMa,
+           (unsigned)PatternflowPower::demandPercent(),
+           PatternflowPower::limiting ? 1 : 0,
+           (unsigned)PatternflowPower::allowedBrightness);
 
   server().sendHeader("Cache-Control", "no-store");
   server().sendHeader("Access-Control-Allow-Origin", "*");

--- a/firmware/patternflow/src/core_pack_select.h
+++ b/firmware/patternflow/src/core_pack_select.h
@@ -9,6 +9,7 @@
 
 #include <Arduino.h>
 #include "../pattern_registry.h"
+#include "core_mem.h"
 
 namespace PatternflowPackSelect {
 
@@ -16,7 +17,11 @@ constexpr uint8_t MAX = 64;
 
 inline uint32_t rev = 0;
 inline uint8_t count = 0;
-inline char slugs[MAX][MODULE_NAME_BYTES] = {};
+// 2.5 KB, used only while a Director session is marking modules — PSRAM on
+// first use, never internal DRAM. As a static array this was a measurable
+// slice of the ~15 KB the console runs on (nm showed it as the largest
+// non-canvas symbol our code adds), for a feature most boots never touch.
+inline char (*slugs)[MODULE_NAME_BYTES] = nullptr;
 
 inline void bump() {
   rev++;
@@ -29,7 +34,7 @@ inline void clear() {
 }
 
 inline bool has(const char* slug) {
-  if (!slug || !slug[0]) return false;
+  if (!slugs || !slug || !slug[0]) return false;
   for (uint8_t i = 0; i < count; i++) {
     if (strcasecmp(slugs[i], slug) == 0) return true;
   }
@@ -39,6 +44,11 @@ inline bool has(const char* slug) {
 // True if the slug is now in the list (already present or newly added).
 inline bool add(const char* slug) {
   if (!slug || !slug[0]) return false;
+  if (!slugs) {
+    slugs = (char(*)[MODULE_NAME_BYTES])PFMem::alloc(
+        (size_t)MAX * MODULE_NAME_BYTES);
+    if (!slugs) return false;
+  }
   if (has(slug)) return true;
   if (count >= MAX) return false;
   snprintf(slugs[count], MODULE_NAME_BYTES, "%s", slug);

--- a/firmware/patternflow/src/core_power.h
+++ b/firmware/patternflow/src/core_power.h
@@ -1,0 +1,153 @@
+// ═══════════════════════════════════════════════════════════
+// PatternFlow - total power clamp
+//
+// A near-white frame at full brightness draws about 4.8 A at 5 V on this
+// panel. That is above what a USB-A port is rated for, it warms the
+// connector, and on a bank that cannot deliver it the device browns out —
+// so the pattern that asks for it gets dimmed instead of being allowed to.
+//
+// ── How the estimate works ──────────────────────────────────────────────
+// The blit already sums every pixel's post-CIE value (see
+// blitRGB888/lastFrameOnTime), which is the LED on-time the frame asks for.
+// Divided by an all-white frame's total, that is the fraction of full-white
+// current the frame wants:
+//
+//     amps ≈ IDLE + FULL_WHITE_SPAN × demand × (brightness / 255)
+//
+// Brightness scales it because it is applied afterwards as OE duty; the
+// driver ICs' own draw does not, which is why IDLE sits outside the product.
+//
+// ── Where the numbers come from ─────────────────────────────────────────
+// Measured on a 40,000 mAh bank (README "Power & runtime"):
+//   full white, max brightness   26.6 W  →  4.8 A   (9% in 30 min)
+//   bright generative pattern    ~9.6 W  →  ~1.9 A  (13% in 2 h, ~15 h total)
+// The white figure anchors the top of the curve, which is the only end that
+// matters for a clamp. IDLE is not measured — 0.55 A is a deliberate
+// over-estimate of the panel drivers plus the ESP32 with Wi-Fi up, so the
+// model errs toward clamping early rather than late.
+//
+// ── The budget ──────────────────────────────────────────────────────────
+// 2.4 A by default: the high-power USB-A rating, and comfortably above the
+// ~1.9 A a normal bright pattern actually draws, so ordinary use never
+// notices this file exists. A white-out frame lands at roughly half
+// brightness instead of pulling 4.8 A.
+//
+// License: MIT
+// ═══════════════════════════════════════════════════════════
+#pragma once
+
+#include <Arduino.h>
+#include <Preferences.h>
+
+#include "core_display.h"
+
+namespace PatternflowPower {
+
+// Milliamps drawn with every LED off but the panel and board awake.
+constexpr uint32_t IDLE_MA = 550;
+// Additional milliamps at full white, full brightness (4800 measured − idle).
+constexpr uint32_t FULL_WHITE_SPAN_MA = 4250;
+
+constexpr uint16_t BUDGET_DEFAULT_MA = 2400;
+// Below the idle draw a budget cannot be met at any brightness, and above
+// the panel's own maximum the clamp would never do anything — outside this
+// range the setting is not a setting.
+constexpr uint16_t BUDGET_MIN_MA = 800;
+constexpr uint16_t BUDGET_MAX_MA = 5000;
+
+inline uint16_t budgetMa = BUDGET_DEFAULT_MA;
+inline bool enabled = true;
+
+// Last frame's demand as a Q16 fraction of an all-white frame, and what the
+// clamp did about it.
+inline uint32_t demandQ16 = 0;
+inline uint16_t estimateMa = 0;
+inline uint8_t allowedBrightness = 255;
+inline bool limiting = false;
+
+inline void load() {
+  Preferences prefs;
+  if (!prefs.begin("patternflow", true)) return;
+  budgetMa = prefs.getUShort("pwr_budget", BUDGET_DEFAULT_MA);
+  enabled = prefs.getBool("pwr_on", true);
+  prefs.end();
+  if (budgetMa < BUDGET_MIN_MA) budgetMa = BUDGET_MIN_MA;
+  if (budgetMa > BUDGET_MAX_MA) budgetMa = BUDGET_MAX_MA;
+}
+
+inline void save() {
+  Preferences prefs;
+  if (!prefs.begin("patternflow", false)) return;
+  prefs.putUShort("pwr_budget", budgetMa);
+  prefs.putBool("pwr_on", enabled);
+  prefs.end();
+}
+
+inline bool setBudgetMa(int ma) {
+  if (ma < BUDGET_MIN_MA || ma > BUDGET_MAX_MA) return false;
+  budgetMa = (uint16_t)ma;
+  save();
+  return true;
+}
+
+inline void setEnabled(bool on) {
+  enabled = on;
+  if (!on) {
+    limiting = false;
+    allowedBrightness = 255;
+  }
+  save();
+}
+
+/** Estimated draw at a given brightness, for the frame just blitted. */
+inline uint16_t estimateAtMa(uint8_t brightness) {
+  uint64_t span = (uint64_t)FULL_WHITE_SPAN_MA * demandQ16 >> 16;
+  span = span * brightness / 255;
+  uint32_t total = IDLE_MA + (uint32_t)span;
+  return total > 65535 ? 65535 : (uint16_t)total;
+}
+
+/**
+ * Read the frame the panel just drew and return the brightness it may keep.
+ *
+ * Call once per frame, after present(). The answer applies to the NEXT frame
+ * — measuring frame N and acting on N+1 — which is invisible at 40-plus fps
+ * and avoids a second pass over the pixels.
+ *
+ * `requested` is whatever the user set; the return is never above it, so the
+ * clamp can only ever take brightness away, and the brightness control keeps
+ * working normally whenever there is headroom.
+ */
+inline uint8_t allow(uint8_t requested) {
+  if (!dma_display) return requested;
+
+  const uint64_t maxOnTime = dma_display->maxFrameOnTime();
+  if (maxOnTime == 0) return requested;
+  demandQ16 = (uint32_t)((dma_display->lastFrameOnTime() << 16) / maxOnTime);
+
+  estimateMa = estimateAtMa(requested);
+  if (!enabled || estimateMa <= budgetMa) {
+    limiting = false;
+    allowedBrightness = requested;
+    return requested;
+  }
+
+  // Solve the model for the brightness that lands on the budget. A frame
+  // whose idle draw alone exceeds the budget cannot be helped by dimming —
+  // floor it rather than divide toward zero, since a dark panel is not what
+  // the person asked for and the LEDs are not what is drawing the current.
+  const uint32_t headroom = budgetMa > IDLE_MA ? budgetMa - IDLE_MA : 0;
+  const uint64_t span = (uint64_t)FULL_WHITE_SPAN_MA * demandQ16 >> 16;
+  uint32_t scaled = span ? (uint32_t)((uint64_t)headroom * 255 / span) : 255;
+  if (scaled > requested) scaled = requested;
+  if (scaled < 5) scaled = 5;
+
+  limiting = true;
+  allowedBrightness = (uint8_t)scaled;
+  estimateMa = estimateAtMa(allowedBrightness);
+  return allowedBrightness;
+}
+
+inline uint16_t demandPercent() { return (uint16_t)((demandQ16 * 100) >> 16); }
+
+}  // namespace PatternflowPower

--- a/firmware/patternflow/src/hub75/ESP32-HUB75-MatrixPanel-I2S-DMA.cpp
+++ b/firmware/patternflow/src/hub75/ESP32-HUB75-MatrixPanel-I2S-DMA.cpp
@@ -430,6 +430,12 @@ void MatrixPanel_I2S_DMA::blitRGB888(const uint8_t *rgb,
   const uint8_t depth = m_cfg.getPixelColorDepthBits();
   const uint8_t rows = ROWS_PER_FRAME;
 
+  // Total LED on-time this frame asks for, summed as we go. The per-pixel
+  // linear values are computed below anyway and live in registers when we add
+  // them, so this rides along for six adds per pixel pair — nothing next to
+  // the bitplane writes underneath it. See lastFrameOnTime().
+  uint64_t onTime = 0;
+
   // A two-scan panel lights row `r` and row `r + ROWS_PER_FRAME` together, and
   // both live in the same uint16_t. Walk the pairs, not the rows.
   for (uint8_t row = 0; row < rows; row++)
@@ -463,6 +469,11 @@ void MatrixPanel_I2S_DMA::blitRGB888(const uint8_t *rgb,
       const uint16_t r1 = lumConvTab[t[0]], g1 = lumConvTab[t[1]], b1 = lumConvTab[t[2]];
       const uint16_t r2 = lumConvTab[m[0]], g2 = lumConvTab[m[1]], b2 = lumConvTab[m[2]];
 #endif
+
+      // Post-CIE, so this is the duty each channel will actually be driven at
+      // — the thing current is proportional to, rather than the raw byte the
+      // pattern wrote.
+      onTime += (uint32_t)r1 + g1 + b1 + (uint32_t)r2 + g2 + b2;
 
       uint8_t d = depth;
       do
@@ -498,6 +509,12 @@ void MatrixPanel_I2S_DMA::blitRGB888(const uint8_t *rgb,
       } while (d);
     }
   }
+
+  _lastFrameOnTime = onTime;
+  // What an all-white frame would have summed to: every pixel, every channel,
+  // at the top of the CIE table. Recomputed rather than cached because panel
+  // geometry and colour depth are both configurable.
+  _maxFrameOnTime = (uint64_t)w * rows * 2ULL * 3ULL * lumConvTab[255];
 } // blitRGB888
 
 

--- a/firmware/patternflow/src/hub75/ESP32-HUB75-MatrixPanel-I2S-DMA.h
+++ b/firmware/patternflow/src/hub75/ESP32-HUB75-MatrixPanel-I2S-DMA.h
@@ -629,6 +629,23 @@ public:
                   const uint8_t *lutR, const uint8_t *lutG, const uint8_t *lutB,
                   int satBoostQ8);
 
+  /**
+   * Total LED on-time the last blit asked for, and the largest value that
+   * total could have been (an all-white frame).
+   *
+   * Summed from the post-CIE linear values — the numbers that actually become
+   * PWM duty — so the ratio between them is the fraction of full-white current
+   * the frame draws. Accumulated inside the blit's existing pixel loop from
+   * values already in registers, which is why it costs nothing worth
+   * measuring; see core_power.h for what reads it.
+   *
+   * Brightness is applied later, in OE timing, so this is deliberately
+   * independent of it: the limiter measures demand and sets brightness, and
+   * cannot end up chasing its own tail.
+   */
+  uint64_t lastFrameOnTime() const { return _lastFrameOnTime; }
+  uint64_t maxFrameOnTime() const { return _maxFrameOnTime; }
+
 #ifdef USE_GFX_LITE
   // 24bpp FASTLED CRGB colour struct support
   void fillScreen(CRGB color);
@@ -928,6 +945,10 @@ private:
   // Other private variables
   bool initialized = false;
   bool config_set = false;
+
+  // Power demand of the last blitted frame — see lastFrameOnTime().
+  uint64_t _lastFrameOnTime = 0;
+  uint64_t _maxFrameOnTime = 0;
 
 }; // end Class header
 


### PR DESCRIPTION
The two firmware commits left on `dev` after the rest landed.

## A white-out frame gets dimmed instead of pulling 4.8 A

The README's power section documents the hazard — a near-white pattern at max
brightness draws 26.6 W, above USB-A ratings and enough to warm the connector —
and promises a clamp. This is it.

The measurement rides the blit: `blitRGB888` already walks every pixel with the
post-CIE values in registers, which are exactly what current is proportional to,
so summing them costs six adds per pixel pair and no second pass. The estimate
is anchored to the README's own measurements (idle 550 mA + a 4,250 mA
full-white span reproduces 4,800 mA for white and 1,910 mA for the measured
typical pattern), and brightness is solved against a 2,400 mA budget — the
high-power USB-A rating.

The person's own brightness setting is never rewritten; only what the panel is
driven at is capped, and it is restored the moment there is headroom. Brightness
is OE duty applied after the blit, so the estimate cannot depend on it and the
loop cannot oscillate. `/api/display` exposes budget, estimate, demand and
state, and `?power_budget=` / `?power_limit=0` tune or disable it.

Measured on the panel: Origin 15% demand, the white calibration card 92%; at a
forced 800 mA budget the clamp lands on 796 mA and releases when the budget
rises; 92 fps throughout. At the default budget a normal pattern is untouched.

## Pack-select back to PSRAM — and the real cause of the console lag

Reverting the show player took the PSRAM move for `PatternflowPackSelect` with
it, so its 2.5 KB slug list was back in `.bss`. Re-applied (static DRAM
90,680 → 88,128; idle internal heap 9.9 → 13.8 KB, within ~1.8 KB of stock).

That was **not** what made the console lag, though — I had that wrong. It was
Director mode, left enabled in NVS and pointing at a PC that no longer runs a
broker: its reconnect blocks the single render-and-serve loop and console
requests queue behind it at 8+ seconds each. With MQTT off, every page renders
in 50–100 ms in a real browser with a module resident. Worth knowing before
anyone enables Director mode and forgets.
