### PR TITLE
The compliance URL printed on the box now answers

### DIFF
--- a/web/src/app/compliance/Compliance.module.css
+++ b/web/src/app/compliance/Compliance.module.css
@@ -1,0 +1,298 @@
+/* Compliance — the regulatory document behind the URL printed in the box.
+   Set as plain prose in the project's own tokens, the same shape as /terms:
+   one column, real hierarchy, no decoration. The audience is a market
+   surveillance officer or a customs desk, and half of them will print it. */
+
+.page {
+  min-height: 100vh;
+  padding: 48px 24px 96px;
+  background: var(--pf-cream);
+  color: var(--pf-ink);
+  font-family: var(--pf-sans);
+}
+
+.doc {
+  max-width: 68ch;
+  margin: 0 auto;
+  /* Long identifiers — FCC IDs, module part numbers, the fccid.io URL — must
+     wrap rather than push the page sideways on a phone. */
+  overflow-wrap: break-word;
+}
+
+.head {
+  padding-bottom: 28px;
+  margin-bottom: 32px;
+  border-bottom: var(--pf-rule-w) solid var(--pf-rule);
+}
+
+.brand {
+  display: inline-block;
+  margin-bottom: 24px;
+  font-family: var(--pf-mono);
+  font-size: var(--pf-fs-mono);
+  letter-spacing: var(--pf-track-mono);
+  text-transform: uppercase;
+  color: var(--pf-ink-muted);
+  text-decoration: none;
+}
+
+.brand:hover {
+  color: var(--pf-led);
+}
+
+.head h1 {
+  margin: 0;
+  font-size: var(--pf-fs-h2);
+  letter-spacing: var(--pf-track-tight);
+  font-weight: 600;
+}
+
+.lede {
+  margin: 12px 0 0;
+  font-size: var(--pf-fs-sub);
+  line-height: 1.6;
+  color: var(--pf-ink-muted);
+}
+
+.doc section {
+  margin-bottom: 36px;
+}
+
+.doc h2 {
+  margin: 0 0 14px;
+  font-size: 19px;
+  font-weight: 600;
+  letter-spacing: var(--pf-track-tight);
+}
+
+.doc h3 {
+  margin: 24px 0 10px;
+  font-family: var(--pf-mono);
+  font-size: var(--pf-fs-mono);
+  letter-spacing: var(--pf-track-mono);
+  text-transform: uppercase;
+  font-weight: 500;
+  color: var(--pf-ink-muted);
+}
+
+.doc p,
+.doc li {
+  font-size: var(--pf-fs-body);
+  line-height: 1.7;
+  color: var(--pf-ink);
+}
+
+.doc p {
+  margin: 0 0 12px;
+}
+
+.doc ul {
+  margin: 0 0 12px;
+  padding-left: 20px;
+}
+
+.doc li {
+  margin-bottom: 7px;
+}
+
+.doc a {
+  color: var(--pf-led);
+  text-underline-offset: 2px;
+}
+
+/* ── Product specification ──
+   A definition list on a two-column grid, collapsing to stacked rows under
+   560px. Nothing here is wide enough to need horizontal scrolling. */
+.specs {
+  margin: 0;
+  border-top: var(--pf-rule-w) solid var(--pf-rule);
+}
+
+.specRow {
+  display: grid;
+  grid-template-columns: 15em minmax(0, 1fr);
+  border-bottom: var(--pf-rule-w) solid var(--pf-rule-soft);
+}
+
+.specRow dt {
+  padding: 11px 16px 11px 0;
+  font-family: var(--pf-mono);
+  font-size: var(--pf-fs-mono);
+  letter-spacing: var(--pf-track-mono);
+  text-transform: uppercase;
+  line-height: 1.6;
+  color: var(--pf-ink-muted);
+}
+
+.specRow dd {
+  margin: 0;
+  padding: 11px 0;
+  font-size: var(--pf-fs-body);
+  line-height: 1.6;
+  color: var(--pf-ink);
+}
+
+/* ── Document list ──
+   Sized to hold more rows than the one it currently has: as certifications
+   land, each becomes a name on the left and a link or a status on the right. */
+.docs {
+  margin: 0 0 12px;
+  padding-left: 0;
+  list-style: none;
+  border-top: var(--pf-rule-w) solid var(--pf-rule);
+}
+
+.docRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px 16px;
+  align-items: baseline;
+  justify-content: space-between;
+  margin: 0;
+  padding: 11px 0;
+  border-bottom: var(--pf-rule-w) solid var(--pf-rule-soft);
+}
+
+.docName {
+  color: var(--pf-ink);
+}
+
+.docStatus {
+  font-family: var(--pf-mono);
+  font-size: var(--pf-fs-mono);
+  letter-spacing: var(--pf-track-mono);
+  text-transform: uppercase;
+  color: var(--pf-ink-faint);
+  white-space: nowrap;
+}
+
+/* The FCC marking statement. It is a mandated wording that has to match the
+   label on the product, so it is framed rather than left to blend into prose. */
+.marking {
+  margin: 0 0 16px;
+  padding: 14px 18px;
+  border-left: 2px solid var(--pf-led);
+  background: var(--pf-cream-2);
+  font-family: var(--pf-mono);
+  font-size: var(--pf-fs-body);
+  letter-spacing: 0.02em;
+}
+
+.address {
+  font-style: normal;
+  font-size: var(--pf-fs-body);
+  line-height: 1.7;
+  color: var(--pf-ink);
+}
+
+.foot {
+  padding-top: 28px;
+  margin-top: 8px;
+  border-top: var(--pf-rule-w) solid var(--pf-rule);
+}
+
+.foot p {
+  margin: 0;
+  font-family: var(--pf-mono);
+  font-size: var(--pf-fs-mono);
+  letter-spacing: var(--pf-track-mono);
+  text-transform: uppercase;
+  color: var(--pf-ink-faint);
+}
+
+@media (max-width: 640px) {
+  .page {
+    padding: 32px 20px 72px;
+  }
+
+  .head h1 {
+    font-size: 26px;
+  }
+}
+
+@media (max-width: 560px) {
+  /* Stack the spec rows. The label keeps its own line above the value, which
+     is what keeps a 320px-wide screen free of sideways scroll. */
+  .specRow {
+    grid-template-columns: minmax(0, 1fr);
+    padding: 10px 0;
+  }
+
+  .specRow dt {
+    padding: 0 0 2px;
+  }
+
+  .specRow dd {
+    padding: 0;
+  }
+}
+
+/* ── Print ──
+   Authorities print this. Cream ground and orange links become ink and paper,
+   headings stay with the section they introduce, and no row splits across a
+   page break. The browser's own print footer carries the source URL. */
+@media print {
+  .page {
+    min-height: 0;
+    padding: 0;
+    background: #fff;
+    color: #000;
+  }
+
+  .doc {
+    max-width: none;
+  }
+
+  .doc a,
+  .brand,
+  .brand:hover,
+  .lede,
+  .specRow dt,
+  .specRow dd,
+  .docStatus,
+  .foot p {
+    color: #000;
+  }
+
+  .marking {
+    background: transparent;
+    border-left: 2px solid #000;
+  }
+
+  .head,
+  .foot,
+  .specs,
+  .docs,
+  .specRow,
+  .docRow {
+    border-color: #000;
+  }
+
+  .doc p,
+  .doc li,
+  .specRow dd,
+  .address {
+    font-size: 10.5pt;
+    line-height: 1.5;
+  }
+
+  .head h1 {
+    font-size: 20pt;
+  }
+
+  .doc h2 {
+    font-size: 12pt;
+  }
+
+  .doc h2,
+  .doc h3 {
+    break-after: avoid;
+  }
+
+  .doc section,
+  .specRow,
+  .docRow,
+  .address {
+    break-inside: avoid;
+  }
+}

--- a/web/src/app/compliance/page.tsx
+++ b/web/src/app/compliance/page.tsx
@@ -1,0 +1,175 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import styles from "./Compliance.module.css";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// REGULATORY DOCUMENT — NOT A MARKETING PAGE.
+//
+// The printed safety information in every retail box carries the line:
+//
+//   "The full text of the EU declaration of conformity is available at the
+//    following internet address: https://patternflow.work/compliance"
+//
+// That is the simplified EU declaration of conformity permitted by Article
+// 10(9) + Annex VII of the Radio Equipment Directive (2014/53/EU): the URL
+// stands in for the full text on paper, so the URL resolving is itself part
+// of the legal requirement.
+//
+// Consequences for anyone editing this file:
+//
+//   • The path is exactly /compliance. It is already printed on paper and
+//     cannot be changed. No /legal/compliance, no locale prefix, no redirect
+//     — this route must answer 200 directly.
+//   • English only. The readers are EU market surveillance authorities, the
+//     FCC, and customs.
+//   • The regulatory wording below is standard text. Fix typos; do not
+//     rewrite, paraphrase, or "improve" it.
+//   • It must render without JavaScript, so this stays a server component
+//     with no client boundary (see `dynamic` below).
+//   • Never add noindex, and never disallow it in robots. Public access is
+//     the entire point.
+//
+// Do NOT publish here, ever:
+//   • Espressif module test reports (R2111A1079-*) — under NDA. Supplying
+//     them to test labs and regulators is permitted; public posting is not.
+//   • Espressif module certificates — third-party documents that are not
+//     ours to redistribute. The US side is covered by the FCC public
+//     database link below.
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const metadata: Metadata = {
+  title: "Compliance / Patternflow",
+  description:
+    "Regulatory and compliance information for Patternflow products: EU declaration of conformity, FCC radio module certification, WEEE disposal, and manufacturer details.",
+  alternates: { canonical: "/compliance" },
+};
+
+// Explicit, not incidental. This page has to be readable with JS disabled and
+// has to survive a build even if the rest of the app goes dynamic around it.
+export const dynamic = "force-static";
+
+const UPDATED = "2026-08-17";
+const CONTACT = "contact@patternflow.work";
+
+// The signed declaration does not exist yet — testing is not finished. When it
+// is, drop the PDF in `web/public/compliance/` and put its path here; the row
+// in the Documents list turns into a link on its own.
+const EU_DOC_PDF: string | null = null;
+
+const SPECS: readonly (readonly [string, string])[] = [
+  ["Product name", "Patternflow"],
+  ["Model", "PATTERNFLOW-01, PATTERNFLOW-01-KIT"],
+  ["Hardware version", "v3.0.0"],
+  ["Radio module", "Espressif ESP32-S3-WROOM-1-N16R8"],
+  ["Frequency band", "2400 – 2483.5 MHz"],
+  ["Max RF power", "20 mW (13 dBm) EIRP"],
+  ["Power input", "5 V DC, max 2.4 A (12 W)"],
+];
+
+export default function CompliancePage() {
+  return (
+    <main className={styles.page}>
+      <article className={styles.doc}>
+        <header className={styles.head}>
+          <Link href="/" className={styles.brand}>
+            Patternflow
+          </Link>
+          <h1>Compliance</h1>
+          <p className={styles.lede}>
+            Regulatory and compliance information for Patternflow products.
+          </p>
+        </header>
+
+        <section>
+          <h2>Product</h2>
+          {/* Definition list rather than a table: it collapses to stacked rows
+              on a narrow screen, so nothing scrolls sideways on a phone. */}
+          <dl className={styles.specs}>
+            {SPECS.map(([label, value]) => (
+              <div key={label} className={styles.specRow}>
+                <dt>{label}</dt>
+                <dd>{value}</dd>
+              </div>
+            ))}
+          </dl>
+        </section>
+
+        <section>
+          <h2>European Union</h2>
+          {/* A statement of scope, NOT a claim of conformity. Nothing has been
+              declared until the testing is finished and the DoC is signed, and
+              claiming otherwise in front of a market surveillance authority is
+              an unsupported assertion. Once the declaration is signed, this
+              becomes "Patternflow is declared in conformity with:". */}
+          <p>The following EU legislation applies to Patternflow:</p>
+          <ul>
+            <li>Directive 2014/53/EU (Radio Equipment Directive)</li>
+            <li>Directive 2011/65/EU as amended by (EU) 2015/863 (RoHS)</li>
+          </ul>
+          <p>
+            <strong>EU Declaration of Conformity</strong> — publication pending completion of
+            testing. The signed declaration will be posted on this page. For a copy in the
+            meantime, contact <a href={`mailto:${CONTACT}`}>{CONTACT}</a>.
+          </p>
+
+          <h3>Documents</h3>
+          <ul className={styles.docs}>
+            <li className={styles.docRow}>
+              {EU_DOC_PDF ? (
+                <a href={EU_DOC_PDF}>EU Declaration of Conformity (PDF)</a>
+              ) : (
+                <>
+                  <span className={styles.docName}>EU Declaration of Conformity (PDF)</span>
+                  <span className={styles.docStatus}>Publication pending</span>
+                </>
+              )}
+            </li>
+          </ul>
+        </section>
+
+        <section>
+          <h2>United States</h2>
+          <p>This product contains an FCC-certified radio module.</p>
+          <p className={styles.marking}>
+            <strong>Contains FCC ID: 2AC7Z-ESPS3WROOM1</strong>
+          </p>
+          <p>
+            Grant details are available from the FCC public database:{" "}
+            <a href="https://fccid.io/2AC7Z-ESPS3WROOM1">https://fccid.io/2AC7Z-ESPS3WROOM1</a>
+          </p>
+          <p>
+            This equipment has been tested and found to comply with the limits for a Class B
+            digital device, pursuant to part 15 of the FCC Rules. The full notice is supplied with
+            the product.
+          </p>
+        </section>
+
+        <section>
+          <h2>Disposal (WEEE)</h2>
+          <p>
+            Do not dispose of this product with household waste. At the end of its life, take it to
+            a collection point for electrical and electronic equipment, in accordance with
+            Directive 2012/19/EU.
+          </p>
+        </section>
+
+        <section>
+          <h2>Manufacturer</h2>
+          <address className={styles.address}>
+            Patternflow (SeungHun Lee)
+            <br />
+            5F Room C, 19 Sinchon-ro 2-gil
+            <br />
+            Mapo-gu, Seoul 04051, Republic of Korea
+            <br />
+            <a href={`mailto:${CONTACT}`}>{CONTACT}</a>
+          </address>
+        </section>
+
+        <footer className={styles.foot}>
+          <p>Last updated: {UPDATED}</p>
+        </footer>
+      </article>
+    </main>
+  );
+}

--- a/web/src/app/sitemap.ts
+++ b/web/src/app/sitemap.ts
@@ -15,6 +15,9 @@ export default function sitemap(): MetadataRoute.Sitemap {
     { url: `${siteUrl}/roadmap`, lastModified: now, changeFrequency: "weekly", priority: 0.6 },
     { url: `${siteUrl}/contact`, lastModified: now, changeFrequency: "yearly", priority: 0.5 },
     { url: `${siteUrl}/terms`, lastModified: now, changeFrequency: "yearly", priority: 0.3 },
+    // Printed on the safety leaflet in every box as the address of the EU
+    // declaration of conformity — it has to stay reachable and indexable.
+    { url: `${siteUrl}/compliance`, lastModified: now, changeFrequency: "yearly", priority: 0.3 },
     { url: `${siteUrl}/journal`, lastModified: now, changeFrequency: "weekly", priority: 0.7 },
     { url: `${siteUrl}/journal/en`, lastModified: now, changeFrequency: "weekly", priority: 0.7 },
   ];


### PR DESCRIPTION
Every retail box carries a line of printed safety information:

> The full text of the EU declaration of conformity is available at the following internet address: https://patternflow.work/compliance

That is the simplified declaration permitted by **RED 2014/53/EU Article 10(9) + Annex VII** — a URL standing in for the full text on paper. The URL resolving is part of the legal requirement, and until now it 404'd.

## What landed

`/compliance` — a server-rendered document page in the site's existing style, the same shape as `/terms`. Product specification, the EU legislation that applies, the FCC module marking, WEEE disposal, and manufacturer details.

## Constraints baked in

Paper cannot be recalled, so these are frozen. The page file opens with a comment saying so, because from any *other* file they look like ordinary routing and SEO decisions:

- Path is exactly `/compliance` — no locale prefix, no `/legal/…`, **no redirect**, answers 200 directly. `src/proxy.ts` only matches `/journal/*`, which is why this works.
- English only. The readers are EU market surveillance authorities, the FCC, and customs.
- Renders without JavaScript — `dynamic = "force-static"`, no client boundary.
- No `noindex`, never disallowed in `robots.ts`. Public access is the point.

## Claims only what is signed

The EU section says *"The following EU legislation applies to Patternflow:"* rather than claiming conformity. Nothing is declared until testing finishes and the declaration is signed, and asserting otherwise one line above "publication pending completion of testing" is an unsupported claim. The wording changes when the signature exists.

The document list is already in place with the declaration listed as pending — dropping the signed PDF in `web/public/compliance/` and setting the `EU_DOC_PDF` constant turns the row into a link, no other edits.

## Deliberately absent

- **Espressif module test reports** (R2111A1079-*) — under NDA. Test labs and regulators only; public posting is outside the permitted scope.
- **Espressif module certificates** — third-party documents, not ours to redistribute. The US side is covered by a link to the FCC public database instead.

## Verification

- `curl -L` → `200`, `num_redirects=0`
- Build output lists `○ /compliance` (prerendered static); all mandated strings confirmed present in `.next/server/app/compliance.html`, i.e. what a JS-disabled reader gets
- No horizontal scroll at 375px **or** 320px — specs are a definition list that stacks, not a table that scrolls
- No `noindex`, `robots.txt` allows it, sitemap entry added, canonical correct
- `@media print` verified intact through the CSS pipeline: cream and orange become ink on paper, headings stay with their sections, no row splits across a page break
- `eslint` clean, `next build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
