### PR TITLE
fix(firmware): a remembered pattern gets one boot to prove itself

### DIFF
--- a/firmware/patternflow/patternflow.ino
+++ b/firmware/patternflow/patternflow.ino
@@ -100,6 +100,24 @@ bool patternDirty = false;
 uint32_t patternChangedAtMs = 0;
 const uint32_t PATTERN_SAVE_DELAY_MS = 3000;
 
+// Restoring a module at boot is not the same risk as picking one by hand.
+// Loading any .pfm drops internal heap from ~14 KB to ~5 KB (measured), which
+// is under what the console needs to send a page and low enough that a printf
+// can fail to allocate its lock and abort() — so a pattern that is merely
+// marginal can take the board down a few seconds after it starts. Picked by
+// hand that is a crash you reboot out of; remembered, the reboot restores the
+// same pattern and does it again, every 4 seconds, with the console alive too
+// briefly to fix anything. Only a full NVS erase gets out of that, which no
+// owner can do.
+//
+// So the restore arms a latch first and disarms it once the pattern has run
+// long enough to be trusted. A boot that finds the latch still armed knows the
+// previous boot did not survive its own remembered pattern, and forgets it.
+// Origin is compiled in and cannot fail this way, so remembering it costs no
+// NVS traffic at all.
+bool patternLatchArmed = false;
+const uint32_t PATTERN_LATCH_CLEAR_MS = 15000;
+
 // Shown whenever no pattern is resident: the web console paused it, or a module
 // refused to load. Before this the render loop simply drew nothing and flipped
 // the buffer anyway, so the panel showed a torn, flickering leftover frame —
@@ -187,8 +205,38 @@ int restoreSavedPatternIdx() {
                   slug, patterns[0].name);
     return 0;
   }
+
+  // Presets cannot exhaust the heap the way a module can, so pattern 0 skips
+  // the latch entirely and a default board never writes NVS on boot.
+  if (idx != 0) {
+    if (prefs.getBool("pat_trying", false)) {
+      // Armed from the previous boot and never disarmed: that boot died with
+      // this pattern resident. Forget it rather than repeat the crash — the
+      // owner can pick it again, and if it was a one-off nothing is lost but
+      // the memory of it.
+      prefs.remove("pattern");
+      prefs.putBool("pat_trying", false);
+      Serial.printf("[NVS] \"%s\" did not survive the last boot - forgetting it, "
+                    "starting at %s\n",
+                    slug, patterns[0].name);
+      return 0;
+    }
+    prefs.putBool("pat_trying", true);
+    patternLatchArmed = true;
+  }
+
   Serial.printf("[NVS] restoring pattern: %s\n", patterns[idx].name);
   return idx;
+}
+
+// Disarm once the restored pattern has run long enough that the crash this
+// guards against would already have happened. Runs from loop(); costs one NVS
+// write per boot, and only on a board that remembers a module.
+void clearPatternLatchIfStable() {
+  if (!patternLatchArmed) return;
+  if (millis() < PATTERN_LATCH_CLEAR_MS) return;
+  patternLatchArmed = false;
+  prefs.putBool("pat_trying", false);
 }
 
 void setup() {
@@ -857,6 +905,11 @@ void applyAudioVirtualKnobs(InputFrame& input, bool enabled) {
 }
 
 void loop() {
+  // Above the sleep block on purpose: a board that is asleep still has to be
+  // able to disarm the latch, or a device told to sleep within the first few
+  // seconds of boot would forget a pattern that never misbehaved.
+  clearPatternLatchIfStable();
+
   // Maintain Wi-Fi (non-blocking): retries while down, and on each fresh
   // (re)connection starts the network services. begin() is idempotent.
   PatternflowWifi::tick();


### PR DESCRIPTION
Follow-up to #314. The sleep half tested clean on hardware; this fixes the pattern-persistence half.

## The problem

Loading any `.pfm` drops internal heap from ~14 KB to ~5 KB. Measured on a 128x64 board:

| resident pattern | internal heap |
| :--- | ---: |
| Origin (preset) | 14,144 |
| Cyber City | 5,804 |
| Fractal Holes | 6,952 |
| Layer Stack | 5,332 |

That is under the ~10 KB the console needs to send a page, and low enough that a `printf` can fail to allocate its lock and `abort()`. The observed crash:

```
rst:0xc (RTC_SW_CPU_RST)
abort() was called at PC 0x4037b423
  lock_init_generic  <- uart_write <- esp_vfs_write <- console_write <- vprintf
```

Picked by hand that is a crash you reboot out of, because the reboot lands on Origin. **Remembered, the reboot restores the same pattern and does it again** — a 3.9 s boot loop, observed for five consecutive cycles:

```
=== Patternflow OS Booting... ===
[NVS] restoring pattern: Layer Stack
[MODULE] loaded Layer Stack
Current Pattern: Layer Stack
   ... ~3.7 s later, abort, repeat
```

The console is alive too briefly to fix anything, so the only way out was `esptool erase-region 0x9000 0x5000` over USB — which no owner can do.

#314's existing guard does not catch this. It falls back to Origin when a remembered pattern *is gone or fails to load*; this one **loads fine** and dies seconds later.

## The fix

The restore arms a latch in NVS (`pat_trying`) and disarms it once the pattern has run 15 s. A boot that finds the latch still armed knows the previous boot did not survive its own remembered pattern, forgets it, and comes up on Origin.

- **Pattern 0 skips the latch entirely**, so a board that remembers Origin — every factory-fresh one — writes no NVS on boot at all. The cost is two NVS writes per boot only on a board that remembers a module.
- **Disarming runs above the sleep block.** A device told to sleep in its first few seconds still has to be able to disarm, or it would forget a pattern that never misbehaved.
- The feature is untouched on the happy path: a pattern that runs is still remembered across power-off.

## Verified on hardware

Against the real crash, not a simulated one:

```
Booting -> [NVS] restoring pattern: Layer Stack -> Current Pattern: Layer Stack
   (aborts, reboots)
Booting -> [NVS] "layer_stack" did not survive the last boot - forgetting it, starting at Origin
        -> Current Pattern: Origin
```

A module that runs stably (Fractal Holes) is still restored across repeated reboots, and the board stays up — 12 s observed with zero reboots.

## Not fixed here

`savePatternIfSettled()` logs `[NVS] pattern saved` without checking the `putString()` return, so a failing write reports success. That cost me a while chasing a phantom during this investigation. Left alone to keep this diff to the boot loop.

The underlying heap pressure is the real root cause and is unchanged — this only stops a marginal pattern from being unrecoverable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)