### PR TITLE
build(firmware): a PlatformIO path on core 2.x buys the heap back

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,3 +100,8 @@ firmware/patternflow/data/patterns/
 
 # Python bytecode from the firmware toolchain scripts
 __pycache__/
+
+# PlatformIO (firmware/patternflow) — generated/cloned, never committed
+.pio/
+firmware/patternflow/pio_src/
+firmware/patternflow/lib/

--- a/firmware/patternflow/partitions/app3M_fat9M_16MB.csv
+++ b/firmware/patternflow/partitions/app3M_fat9M_16MB.csv
@@ -1,0 +1,8 @@
+# Name,   Type, SubType, Offset,  Size, Flags
+# Keep IDENTICAL to Arduino package / website app3M_fat9M_16MB.
+nvs,      data, nvs,     0x9000,  0x5000,
+otadata,  data, ota,     0xe000,  0x2000,
+app0,     app,  ota_0,   0x10000, 0x300000,
+app1,     app,  ota_1,   0x310000,0x300000,
+ffat,     data, fat,     0x610000,0x9E0000,
+coredump, data, coredump,0xFF0000,0x10000,

--- a/firmware/patternflow/platformio.ini
+++ b/firmware/patternflow/platformio.ini
@@ -1,0 +1,94 @@
+; Patternflow - PlatformIO build (Arduino core 2.x / IDF 4.4)
+;
+; WHY THIS EXISTS: the Arduino-IDE build on core 3.x (IDF 5.5) leaves ~15 KB of
+; internal heap after services; the same source built here leaves ~98 KB. That
+; generation occupies ~71 KB more internal RAM before the sketch even starts -
+; the gap is already there at the first heap reading in setup(), before Wi-Fi is
+; up, so it is not a network-buffer setting. Only ~15 KB of it is static (11 KB
+; more code in IRAM, which shares physical SRAM with DRAM on the S3, plus ~3.5 KB
+; of .data/.bss); the rest is heap taken during IDF startup.
+;
+; The headroom is what lets big .pfm modules load - a module's .text needs one
+; contiguous internal executable block - and keeps the console alive with a heavy
+; module resident. Measured 2026-08-18, same board: core3 15,320/7,668 vs core2
+; 98,708/90,100 (free/largest after services), muybridge_35mm refused vs 48.5 fps.
+;
+; The build tool is incidental: PlatformIO's classic espressif32 platform pins
+; core 2.0.17; the Arduino IDE here has 3.3.8. pioarduino would give core 3 under
+; PlatformIO, and Boards Manager can install core 2 in the IDE. The variable is
+; the core/IDF generation.
+;
+; WINDOWS + NON-ASCII REPO PATH: xtensa ld cannot open outputs under the Korean
+; repo path. Build with the project copied to an ASCII path, or set
+;   PLATFORMIO_BUILD_DIR=C:/Users/<you>/pf-pio-build
+; before `pio run`.
+;
+; ARDUINO_USB_CDC_ON_BOOT must stay 1: Improv-Serial (the browser flasher's
+; Wi-Fi setup) listens on the native USB port via Serial. Setting it to 0 moves
+; Serial to UART0 and silently breaks provisioning.
+[platformio]
+default_envs = firmware
+src_dir = pio_src
+include_dir = .
+data_dir = data
+
+[env:firmware]
+platform = espressif32
+board = esp32-s3-devkitc-1
+framework = arduino
+monitor_speed = 115200
+
+board_build.mcu = esp32s3
+board_build.f_cpu = 240000000L
+board_build.f_flash = 80000000L
+board_build.flash_mode = qio
+board_build.arduino.memory_type = qio_opi
+board_build.psram_type = opi
+board_upload.flash_size = 16MB
+board_upload.maximum_size = 16777216
+board_build.partitions = partitions/app3M_fat9M_16MB.csv
+board_build.filesystem = fatfs
+
+extra_scripts =
+  pre:toolchain/sync_ino_to_src.py
+  post:toolchain/copy_named_bin.py
+
+build_unflags =
+  -std=gnu++11
+  -std=c++11
+
+build_flags =
+  -std=gnu++17
+  -DBOARD_HAS_PSRAM
+  -DARDUINO_USB_MODE=1
+  -DARDUINO_USB_CDC_ON_BOOT=1
+  -I$PROJECT_DIR
+  -I$PROJECT_DIR/src
+  -I$PROJECT_DIR/abi
+
+; Vendored HUB75 (src/hub75) has blitRGB888; ignore the Library Manager clone.
+lib_ignore = HUB75
+lib_ldf_mode = deep+
+
+build_src_filter =
+  +<*>
+  +<../src/hub75/*.cpp>
+  +<../src/hub75/platforms/esp32/*.cpp>
+  +<../src/hub75/platforms/esp32s3/*.cpp>
+  +<../src/pubsubclient/*.cpp>
+
+; Optional:
+; upload_port = COM5
+; monitor_port = COM5
+
+; Two 64×64 HUB75 modules daisy-chained (ESP → panel A IN, A OUT → panel B IN).
+; Same source as `firmware`; logical canvas stays 128×64 so the 128×64
+; pattern pack and Director/Sequences behaviour match. Output:
+;   .pio/build/firmware64x2/firmware64x2.bin
+[env:firmware64x2]
+extends = env:firmware
+build_flags =
+  ${env:firmware.build_flags}
+  -DPANEL_GEOMETRY=PANEL_GEOM_64x64_CHAIN2
+  -DPF_IMPROV_FW_SUFFIX=\"-64x2\"
+

--- a/firmware/patternflow/toolchain/copy_named_bin.py
+++ b/firmware/patternflow/toolchain/copy_named_bin.py
@@ -1,0 +1,17 @@
+# After a successful link, copy firmware.bin to <PIOENV>.bin so the
+# cascade build is distinguishable on disk (firmware64x2.bin).
+Import("env")
+from pathlib import Path
+import shutil
+
+
+def copy_named(source, target, env):
+    built = Path(str(target[0]))
+    dest = built.with_name(f"{env['PIOENV']}.bin")
+    if dest.resolve() == built.resolve():
+        return
+    shutil.copy2(built, dest)
+    print(f"[patternflow] {built.name} -> {dest.name}")
+
+
+env.AddPostAction("$BUILD_DIR/${PROGNAME}.bin", copy_named)

--- a/firmware/patternflow/toolchain/sync_ino_to_src.py
+++ b/firmware/patternflow/toolchain/sync_ino_to_src.py
@@ -1,0 +1,73 @@
+# Pre-build: sync Arduino sketch into PlatformIO src_dir; vendor libs under
+# short paths (Windows breaks on "Adafruit GFX Library" style folder names).
+Import("env")
+import subprocess
+from pathlib import Path
+
+root = Path(env["PROJECT_DIR"])
+lib = root / "lib"
+lib.mkdir(exist_ok=True)
+
+pio_src = root / "pio_src"
+pio_src.mkdir(exist_ok=True)
+ino = root / "patternflow.ino"
+main_cpp = pio_src / "main.cpp"
+if not ino.is_file():
+    raise SystemExit(f"Missing sketch: {ino}")
+main_cpp.write_text(ino.read_text(encoding="utf-8"), encoding="utf-8")
+print(f"[patternflow] synced {ino.name} -> pio_src/main.cpp")
+
+
+def ensure_git(dest: Path, url: str) -> None:
+    marker = dest / ".git"
+    if dest.is_dir() and (marker.is_dir() or (dest / "src").is_dir() or (dest / "library.properties").is_file()):
+        return
+    if dest.exists():
+        raise SystemExit(f"[patternflow] {dest} exists but looks incomplete; remove it and rebuild")
+    print(f"[patternflow] cloning {url} -> {dest}")
+    subprocess.check_call(["git", "clone", "--depth", "1", url, str(dest)])
+
+
+ensure_git(lib / "HUB75", "https://github.com/mrfaptastic/ESP32-HUB75-MatrixPanel-DMA.git")
+ensure_git(lib / "Adafruit_GFX", "https://github.com/adafruit/Adafruit-GFX-Library.git")
+ensure_git(lib / "Adafruit_BusIO", "https://github.com/adafruit/Adafruit_BusIO.git")
+ensure_git(lib / "WebSockets", "https://github.com/Links2004/arduinoWebSockets.git")
+
+# PlatformIO does not always inject WiFi include paths into this lib's compile
+# units; declare the deps and skip Socket.IO client (unused by Patternflow).
+# PlatformIO: compile only the WebSockets pieces Patternflow uses, and avoid
+# UTF-8 BOM (Windows PowerShell Set-Content) which breaks library.json parsing.
+ws_json = lib / "WebSockets" / "library.json"
+ws_json.write_text(
+    '{\n'
+    '  "name": "WebSockets",\n'
+    '  "version": "2.7.3",\n'
+    '  "frameworks": "arduino",\n'
+    '  "platforms": ["espressif32", "espressif8266"],\n'
+    '  "build": {\n'
+    '    "srcFilter": [\n'
+    '      "+<WebSockets.cpp>",\n'
+    '      "+<WebSocketsServer.cpp>",\n'
+    '      "+<WebSocketsClient.cpp>",\n'
+    '      "+<libsha1/libsha1.c>"\n'
+    '    ]\n'
+    '  }\n'
+    '}\n',
+    encoding="utf-8",
+    newline="\n",
+)
+props = lib / "WebSockets" / "library.properties"
+if props.is_file():
+    text = props.read_text(encoding="utf-8")
+    lines = [ln for ln in text.splitlines() if not ln.startswith("depends=")]
+    props.write_text("\n".join(lines).rstrip() + "\n", encoding="utf-8", newline="\n")
+
+# Inject WiFi include paths for WebSockets compile units (PlatformIO LDF gap).
+from pathlib import Path as _P
+import os as _os
+pio_home = _P(_os.environ.get("PLATFORMIO_CORE_DIR", _P.home() / ".platformio"))
+wifi_inc = pio_home / "packages" / "framework-arduinoespressif32" / "libraries" / "WiFi" / "src"
+wifics_inc = pio_home / "packages" / "framework-arduinoespressif32" / "libraries" / "WiFiClientSecure" / "src"
+for inc in (wifi_inc, wifics_inc):
+    if inc.is_dir():
+        env.Append(CPPPATH=[str(inc)])


### PR DESCRIPTION
## The finding

Heavy patterns stopped working — muybridge_35mm refused to load, strawberry_rush took the console down. The cause turned out to be the **build, not the code**: the Arduino-IDE build rides core 3.3.8 / IDF 5.5, and that generation occupies **~71 KB more internal RAM before the sketch even starts**.

The gap is already there at the first heap reading in `setup()`, long before Wi-Fi comes up — so it is not a network-buffer setting (the sdkconfig Wi-Fi flags are in fact identical between the two prebuilts). Only ~15 KB of it is static:

```
                core3 (IDF 5.5)   core2 (IDF 4.4)   delta
.iram0.text          79,827            68,559      +11,268   (IRAM shares physical SRAM with DRAM on S3)
.dram0.data          23,272            22,692         +580
.dram0.bss           64,896            61,968       +2,928
```

The remaining ~56 KB is heap taken during IDF startup. Display and network init widen the gap to ~83 KB.

On this hardware that number decides everything a module can do: a `.pfm`'s `.text` must land in **one contiguous internal executable block** (PSRAM cannot execute loaded code), so the largest free block after services is the hard cap on module size.

## Measured — same board, same source, same patterns

| | core3 (Arduino IDE) | **core2 (this PR)** |
| :--- | :--- | :--- |
| free at boot (entering setup) | 224,428 | **295,612** |
| free / largest after services | 15,320 / 7,668 | **98,708 / 90,100** |
| muybridge_35mm (.text 12,470) | load refused | **loads, 48.5 fps** |
| strawberry_rush | console unreachable | **18.9 fps, 79 KB still free** |
| remembered module → reboot | zombie at 1.1 KB | **81 KB free, network alive** |
| Origin idle | 63.8 fps | 61.4 fps (−2.4, the one regression) |

Reference point: Simone's PIO-built fork measured 72,320 / 61,428 on the same board — that is where the trail came from. Ours lands higher because the fork carries extra features.

## The build tool is incidental

PlatformIO's classic `espressif32` platform pins core 2.0.17; the Arduino IDE here has 3.3.8. `pioarduino` would give core 3 under PlatformIO, and Boards Manager can install core 2 in the IDE. **The variable is the core/IDF generation, not IDE vs PlatformIO.**

## Verified on hardware, all features

- Improv-Serial answers over native USB CDC (`ARDUINO_USB_CDC_ON_BOOT=1` — the fork's `=0` would silently break the browser flasher)
- 13 dBm radio readback · power budget 2400 enabled · Origin the only preset
- Sleep round trip (#314) · boot latch (#316) · pattern remembered across reboot
- `/update` page · FATFS patterns intact · MQTT API up
- Secrets scan clean (placeholders present, no real credentials)

## What this PR is and is not

It **adds** `firmware/patternflow/platformio.ini` + two helper scripts + the partition CSV (from Simone Majocchi's performance-director fork, trimmed to stock). Generated dirs (`pio_src/`, `lib/`, `.pio/`) are gitignored. The vendored `src/hub75` — with the power-clamp hooks and `resumeDMAoutput` — is what compiles; the cloned HUB75 only satisfies headers.

It does **not** change any firmware source, and it does not decide which path cuts releases. Trade-offs are recorded in the ini header: IDF 4.4 is an older generation (security patch tail), and Windows non-ASCII repo paths need `PLATFORMIO_BUILD_DIR` redirected (xtensa ld chokes on the Korean path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)