### PR TITLE
fix(firmware): coshf was missing, so the whole soliton genre looked impossible

### DIFF
--- a/firmware/patternflow/src/core_module_loader.h
+++ b/firmware/patternflow/src/core_module_loader.h
@@ -247,11 +247,28 @@ inline uintptr_t resolveHostSymbol(const char* symbol) {
   PF_HOST_SYMBOL(asinf);
   PF_HOST_SYMBOL(acosf);
   PF_HOST_SYMBOL(atanf);
-  PF_HOST_SYMBOL(tanhf);
   PF_HOST_SYMBOL(hypotf);
   PF_HOST_SYMBOL(copysignf);
   PF_HOST_SYMBOL(truncf);
   PF_HOST_SYMBOL(fabsf);
+  PF_HOST_SYMBOL(cbrtf);
+  PF_HOST_SYMBOL(expm1f);
+  PF_HOST_SYMBOL(log1pf);
+  PF_HOST_SYMBOL(ldexpf);
+  PF_HOST_SYMBOL(frexpf);
+  PF_HOST_SYMBOL(modff);
+
+  // Hyperbolics. tanhf was here alone, which turns out to be the worst
+  // possible subset: sech(x) = 1/cosh(x) is the closed form of a soliton, so
+  // every wave/soliton/lattice pattern reaches for coshf and hit a hard load
+  // failure ("unresolved symbol: coshf") that reads as the pattern being too
+  // heavy for the board. It was never too heavy — it never ran.
+  PF_HOST_SYMBOL(sinhf);
+  PF_HOST_SYMBOL(coshf);
+  PF_HOST_SYMBOL(tanhf);
+  PF_HOST_SYMBOL(asinhf);
+  PF_HOST_SYMBOL(acoshf);
+  PF_HOST_SYMBOL(atanhf);
 
   // Double soft-float + libm, so a pattern written with bare sin()/pow()
   // loads instead of failing on an unresolved symbol.
@@ -290,6 +307,16 @@ inline uintptr_t resolveHostSymbol(const char* symbol) {
   PF_HOST_FN(round, double (*)(double));
   PF_HOST_FN(fmod, double (*)(double, double));
   PF_HOST_FN(fabs, double (*)(double));
+  PF_HOST_FN(sinh, double (*)(double));
+  PF_HOST_FN(cosh, double (*)(double));
+  PF_HOST_FN(tanh, double (*)(double));
+  PF_HOST_FN(asinh, double (*)(double));
+  PF_HOST_FN(acosh, double (*)(double));
+  PF_HOST_FN(atanh, double (*)(double));
+  PF_HOST_FN(hypot, double (*)(double, double));
+  PF_HOST_FN(cbrt, double (*)(double));
+  PF_HOST_FN(expm1, double (*)(double));
+  PF_HOST_FN(log1p, double (*)(double));
 
   // String/memory helpers a pattern can pull in without meaning to.
   PF_HOST_SYMBOL(memmove);

--- a/firmware/patternflow/src/core_module_loader.h
+++ b/firmware/patternflow/src/core_module_loader.h
@@ -3,7 +3,9 @@
 #include <Arduino.h>
 #include <FS.h>
 #include <esp_heap_caps.h>
+#include <ctype.h>
 #include <math.h>
+#include <stdlib.h>
 #include <string.h>
 
 #if defined(CONFIG_IDF_TARGET_ESP32S3)
@@ -46,6 +48,21 @@ int __ledf2(double, double);
 int __gtdf2(double, double);
 int __gedf2(double, double);
 int __unorddf2(double, double);
+// 64-bit integer helpers. A pattern doing arithmetic on long long — a
+// microsecond timestamp, a large LCG state — emits these, and the S3 has no
+// 64-bit divide either.
+long long __divdi3(long long, long long);
+long long __moddi3(long long, long long);
+unsigned long long __udivdi3(unsigned long long, unsigned long long);
+unsigned long long __umoddi3(unsigned long long, unsigned long long);
+long long __fixsfdi(float);
+long long __fixdfdi(double);
+unsigned long long __fixunssfdi(float);
+unsigned long long __fixunsdfdi(double);
+float __floatdisf(long long);
+double __floatdidf(long long);
+float __floatundisf(unsigned long long);
+double __floatundidf(unsigned long long);
 }
 
 namespace PFModuleLoader {
@@ -210,6 +227,8 @@ inline void* moduleAlloc(size_t bytes);  // defined below
 inline void* pfModuleMalloc(size_t bytes) { return moduleAlloc(bytes); }
 inline void* pfModuleCalloc(size_t count, size_t size) { return moduleAlloc(count * size); }
 inline void pfModuleFree(void*) {}
+// Report success, register nothing — see the atexit note in resolveSymbol().
+inline int pfModuleAtexit(void (*)(void)) { return 0; }
 
 #define PF_HOST_SYMBOL(name) \
   if (strcmp(symbol, #name) == 0) return (uintptr_t)(void*)(&name)
@@ -269,6 +288,14 @@ inline uintptr_t resolveHostSymbol(const char* symbol) {
   PF_HOST_SYMBOL(asinhf);
   PF_HOST_SYMBOL(acoshf);
   PF_HOST_SYMBOL(atanhf);
+  PF_HOST_SYMBOL(rintf);
+  PF_HOST_SYMBOL(nearbyintf);
+  PF_HOST_SYMBOL(lrintf);
+  PF_HOST_SYMBOL(remainderf);
+  PF_HOST_SYMBOL(fdimf);
+  PF_HOST_SYMBOL(scalbnf);
+  PF_HOST_SYMBOL(erff);
+  PF_HOST_SYMBOL(erfcf);
 
   // Double soft-float + libm, so a pattern written with bare sin()/pow()
   // loads instead of failing on an unresolved symbol.
@@ -289,6 +316,18 @@ inline uintptr_t resolveHostSymbol(const char* symbol) {
   PF_HOST_SYMBOL(__gtdf2);
   PF_HOST_SYMBOL(__gedf2);
   PF_HOST_SYMBOL(__unorddf2);
+  PF_HOST_SYMBOL(__divdi3);
+  PF_HOST_SYMBOL(__moddi3);
+  PF_HOST_SYMBOL(__udivdi3);
+  PF_HOST_SYMBOL(__umoddi3);
+  PF_HOST_SYMBOL(__fixsfdi);
+  PF_HOST_SYMBOL(__fixdfdi);
+  PF_HOST_SYMBOL(__fixunssfdi);
+  PF_HOST_SYMBOL(__fixunsdfdi);
+  PF_HOST_SYMBOL(__floatdisf);
+  PF_HOST_SYMBOL(__floatdidf);
+  PF_HOST_SYMBOL(__floatundisf);
+  PF_HOST_SYMBOL(__floatundidf);
   PF_HOST_FN(sin, double (*)(double));
   PF_HOST_FN(cos, double (*)(double));
   PF_HOST_FN(tan, double (*)(double));
@@ -333,6 +372,44 @@ inline uintptr_t resolveHostSymbol(const char* symbol) {
   PF_HOST_SYMBOL(srand);
   PF_HOST_FN(abs, int (*)(int));
   PF_HOST_FN(labs, long (*)(long));
+  PF_HOST_SYMBOL(qsort);
+  PF_HOST_SYMBOL(bsearch);
+  PF_HOST_SYMBOL(strtof);
+  PF_HOST_SYMBOL(strtod);
+  PF_HOST_SYMBOL(strtol);
+  PF_HOST_SYMBOL(strtoul);
+  PF_HOST_SYMBOL(atoi);
+  PF_HOST_SYMBOL(atol);
+  PF_HOST_SYMBOL(atof);
+
+  // More string/ctype. Same bulk-removal rationale: a pattern parsing its own
+  // little config string, or classifying characters for a text effect, should
+  // not die on the device for a name this ordinary.
+  PF_HOST_SYMBOL(strcpy);
+  PF_HOST_SYMBOL(strncpy);
+  PF_HOST_SYMBOL(strcat);
+  PF_HOST_SYMBOL(strncat);
+  PF_HOST_SYMBOL(strchr);
+  PF_HOST_SYMBOL(strrchr);
+  PF_HOST_SYMBOL(strstr);
+  PF_HOST_SYMBOL(memchr);
+  PF_HOST_SYMBOL(strcasecmp);
+  PF_HOST_SYMBOL(strncasecmp);
+  PF_HOST_SYMBOL(toupper);
+  PF_HOST_SYMBOL(tolower);
+  PF_HOST_SYMBOL(isalpha);
+  PF_HOST_SYMBOL(isdigit);
+  PF_HOST_SYMBOL(isalnum);
+  PF_HOST_SYMBOL(isspace);
+  PF_HOST_SYMBOL(isupper);
+  PF_HOST_SYMBOL(islower);
+
+  // atexit: -fno-use-cxa-atexit turns a local static's destructor
+  // registration into a plain atexit() call. Nothing on this board ever
+  // exits, and a module is dropped wholesale rather than destructed (see the
+  // /DISCARD/ note in module.ld), so registering the pointer would only store
+  // a reference into memory that may later be reused. Accept and forget.
+  if (strcmp(symbol, "atexit") == 0) return (uintptr_t)(void*)(&pfModuleAtexit);
 
   // Allocators, routed through the module's tracked heap (see the shims above).
   if (strcmp(symbol, "malloc") == 0) return (uintptr_t)(void*)(&pfModuleMalloc);

--- a/firmware/toolchain/build_module.py
+++ b/firmware/toolchain/build_module.py
@@ -150,6 +150,40 @@ def resolve_source(argument: Path) -> Path:
     raise SystemExit(f"No pattern.cpp under {argument}")
 
 
+_HOST_SYMBOLS: set[str] | None = None
+
+
+def host_symbol_table() -> set[str]:
+    """Names the on-device loader can resolve, parsed from its source.
+
+    core_module_loader.h is the single source of truth: PF_HOST_SYMBOL /
+    PF_HOST_FN entries plus the hand-routed special cases (allocators, atexit).
+    Parsing the header keeps this checker honest — adding a symbol to the
+    firmware automatically teaches the build about it.
+    """
+    global _HOST_SYMBOLS
+    if _HOST_SYMBOLS is None:
+        header = (ROOT / "patternflow" / "src" / "core_module_loader.h").read_text(
+            encoding="utf-8"
+        )
+        names = set(re.findall(r"PF_HOST_(?:SYMBOL|FN)\((\w+)", header))
+        names |= set(re.findall(r'strcmp\(symbol,\s*"(\w+)"\)\s*==\s*0', header))
+        _HOST_SYMBOLS = names
+    return _HOST_SYMBOLS
+
+
+def check_host_symbols(pfm: Path, gxx: Path) -> set[str]:
+    """Undefined symbols in the .pfm that the device loader will NOT resolve."""
+    nm = gxx.parent / gxx.name.replace("g++", "nm")
+    proc = subprocess.run([str(nm), "-u", str(pfm)], capture_output=True, text=True)
+    if proc.returncode != 0:
+        return set()  # nm unavailable: don't block the build on the checker
+    undefined = {
+        line.split()[-1] for line in proc.stdout.splitlines() if line.strip()
+    }
+    return undefined - host_symbol_table()
+
+
 def build_one(src_dir: Path, gxx: Path, compile_only: bool, abi: Path,
               build_dir: Path, out_dir: Path, opt: str = DEFAULT_OPT) -> tuple[str, bool, str]:
     slug = src_dir.name
@@ -220,6 +254,22 @@ def build_one(src_dir: Path, gxx: Path, compile_only: bool, abi: Path,
     proc = subprocess.run(link_cmd, capture_output=True, text=True)
     if proc.returncode != 0:
         return slug, False, proc.stdout + proc.stderr
+
+    # Every undefined symbol left in the .pfm must be one the on-device loader
+    # can resolve, or the pattern builds fine here and dies on the device with
+    # "unresolved symbol: X" — which reads as the pattern being too heavy, not
+    # as a missing name. That exact misread wrote off a whole genre once
+    # (soliton patterns need coshf; the table had only tanhf). Check at build
+    # time, against the loader source itself so there is one list to maintain.
+    unresolved = check_host_symbols(pfm, gxx)
+    if unresolved:
+        return slug, False, (
+            "device loader cannot resolve: " + ", ".join(sorted(unresolved)) + "\n"
+            "  These names are not in the firmware's host symbol table\n"
+            "  (firmware/patternflow/src/core_module_loader.h, resolveSymbol).\n"
+            "  Either avoid them, or add them to the table and ship a firmware\n"
+            "  release first — a module using them needs that firmware anyway."
+        )
 
     meta_src = src_dir / "module.json"
     meta = json.loads(meta_src.read_text(encoding="utf-8")) if meta_src.is_file() else {}


### PR DESCRIPTION
Two commits: the one-symbol fix that solved a mystery, and the systematic sweep so it is the last mystery of its kind.

## The mystery

A community pattern (Hyperbolic Soliton Lattice Echo) would not install, and read as too heavy for the board — it got written off as an ESP32 limit. It never ran:

```
loadError = [unresolved symbol: coshf]
```

The loader resolves modules against a fixed host-symbol table. `tanhf` was in it; `sinhf` and `coshf` were not — the worst possible subset, because **sech(x) = 1/cosh(x) is the closed form of a soliton**. The entire wave/soliton genre hit a hard load failure that looked exactly like "not enough RAM".

## The sweep (second commit)

- **Real corpus**: nm -u over all 33 Basics-pack modules + the community modules on the bench board → 0 missing after coshf. The shipped library is fully served.
- **Forward surface**: a synthetic torture module referencing every libc/libm name a future pattern could plausibly emit (volatile-seeded — constant folding hid seven names on the first pass) → **34 missing, all added**: int64 helpers (`__divdi3` family + 64-bit int↔float conversions), `rintf`/`remainderf`/`erff` families, `qsort`/`bsearch`/`strto*`/`ato*`, string/ctype, and an `atexit` shim (reports success, registers nothing — nothing here ever exits, and modules are dropped wholesale).
- **Deliberately absent**: `sincosf` (never emitted without `-ffast-math`), `__cxa_guard_*` (`-fno-threadsafe-statics`), `operator new` (inline in `pf_module.h`).

## The enforcement

`build_module.py` now runs `nm -u` on every `.pfm` it links and **fails the build with the missing names spelled out** if the loader cannot resolve them — parsing `core_module_loader.h` itself, so there is exactly one list to maintain. A pattern that would die on the device now dies on the build machine instead. Negative-tested with `lgammaf`.

## Verified on hardware

- Torture module loads clean and **runs at 83 fps** with qsort, strtof, 64-bit division, ctype and the atexit shim actually executed.
- The user's original Soliton Lattice upload — untouched bytes, uploaded before any of this — **loads and runs at 17.9 fps**.
- Perf side-finding for the record: the transcendental was the whole bill (a 4 KB sech² LUT takes the same pattern to 33 fps); its 64 KB of PSRAM state was noise (18.2 vs 18.5 fps forced internal).

Companion to #324, which teaches the Pattern Lab prompt about all of this. Needs a firmware release (v3.5.2) to reach devices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)