### PR TITLE
Pattern Lab: editor tab follow + capture stage & controls cleanup

### DIFF
--- a/web/scripts/lab-capture-smoke.ts
+++ b/web/scripts/lab-capture-smoke.ts
@@ -41,9 +41,8 @@ const matrix = { width: 128, height: 64 };
   const huge = resolveGeometry({ ...DEFAULT_CAPTURE_SETTINGS, style: "native", width: 99999, height: 1 }, matrix);
   assert(huge.output.width === 4096 && huge.output.height === 16, "native sides clamp");
 
-  const normalized = normalizeCaptureSettings({ style: "bogus", width: "x", rotation: 45, previewMode: 3, video: { fps: 17, seconds: 900 } });
+  const normalized = normalizeCaptureSettings({ style: "bogus", width: "x", rotation: 45, video: { fps: 17, seconds: 900 } });
   assert(normalized.style === "auto" && normalized.rotation === 0 && normalized.video.fps === 30 && normalized.video.seconds === 60, "settings normalize");
-  assert(normalized.previewMode === "auto", "previewMode normalize");
 
   // Turns: the size is the finished picture; the pattern runs in the frame that turns into it.
   const portrait = resolveGeometry({ ...DEFAULT_CAPTURE_SETTINGS, style: "native", width: 1080, height: 1920, rotation: 90 }, matrix);

--- a/web/scripts/lab-capture-smoke.ts
+++ b/web/scripts/lab-capture-smoke.ts
@@ -41,8 +41,9 @@ const matrix = { width: 128, height: 64 };
   const huge = resolveGeometry({ ...DEFAULT_CAPTURE_SETTINGS, style: "native", width: 99999, height: 1 }, matrix);
   assert(huge.output.width === 4096 && huge.output.height === 16, "native sides clamp");
 
-  const normalized = normalizeCaptureSettings({ style: "bogus", width: "x", rotation: 45, video: { fps: 17, seconds: 900 } });
+  const normalized = normalizeCaptureSettings({ style: "bogus", width: "x", rotation: 45, upscale: "blurry", previewMode: 3, video: { fps: 17, seconds: 900 } });
   assert(normalized.style === "auto" && normalized.rotation === 0 && normalized.video.fps === 30 && normalized.video.seconds === 60, "settings normalize");
+  assert(normalized.upscale === "crisp" && normalized.previewMode === "auto", "upscale/previewMode normalize");
 
   // Turns: the size is the finished picture; the pattern runs in the frame that turns into it.
   const portrait = resolveGeometry({ ...DEFAULT_CAPTURE_SETTINGS, style: "native", width: 1080, height: 1920, rotation: 90 }, matrix);

--- a/web/scripts/lab-capture-smoke.ts
+++ b/web/scripts/lab-capture-smoke.ts
@@ -41,9 +41,9 @@ const matrix = { width: 128, height: 64 };
   const huge = resolveGeometry({ ...DEFAULT_CAPTURE_SETTINGS, style: "native", width: 99999, height: 1 }, matrix);
   assert(huge.output.width === 4096 && huge.output.height === 16, "native sides clamp");
 
-  const normalized = normalizeCaptureSettings({ style: "bogus", width: "x", rotation: 45, upscale: "blurry", previewMode: 3, video: { fps: 17, seconds: 900 } });
+  const normalized = normalizeCaptureSettings({ style: "bogus", width: "x", rotation: 45, previewMode: 3, video: { fps: 17, seconds: 900 } });
   assert(normalized.style === "auto" && normalized.rotation === 0 && normalized.video.fps === 30 && normalized.video.seconds === 60, "settings normalize");
-  assert(normalized.upscale === "crisp" && normalized.previewMode === "auto", "upscale/previewMode normalize");
+  assert(normalized.previewMode === "auto", "previewMode normalize");
 
   // Turns: the size is the finished picture; the pattern runs in the frame that turns into it.
   const portrait = resolveGeometry({ ...DEFAULT_CAPTURE_SETTINGS, style: "native", width: 1080, height: 1920, rotation: 90 }, matrix);

--- a/web/scripts/lab-capture-smoke.ts
+++ b/web/scripts/lab-capture-smoke.ts
@@ -50,14 +50,17 @@ const matrix = { width: 128, height: 64 };
   const turnedPixel = resolveGeometry({ ...DEFAULT_CAPTURE_SETTINGS, style: "pixel", scale: 8, rotation: 270 }, matrix);
   assert(turnedPixel.render.width === 128 && turnedPixel.box.width === 1024 && turnedPixel.output.width === 512 && turnedPixel.output.height === 1024, "270° pixel output is the turned box");
 
-  // Smooth / auto fallback: cover fit, centred, cropping the overflow.
-  const smooth = resolveGeometry({ ...DEFAULT_CAPTURE_SETTINGS, style: "smooth", width: 1050, height: 600 }, matrix);
-  assert(smooth.look === "smooth" && smooth.render.width === 128 && Math.abs(smooth.scale - 9.375) < 1e-9, `cover scale: ${smooth.scale}`);
-  assert(Math.abs(smooth.offsetX + 75) < 1e-9 && smooth.offsetY === 0, `cover offsets: ${smooth.offsetX}, ${smooth.offsetY}`);
+  // Auto fallback: cover fit, centred, cropping the overflow.
   const autoNative = resolveGeometry({ ...DEFAULT_CAPTURE_SETTINGS, style: "auto", width: 1050, height: 600 }, matrix, "native");
   const autoPixel = resolveGeometry({ ...DEFAULT_CAPTURE_SETTINGS, style: "auto", width: 1050, height: 600 }, matrix, "pixel");
   assert(autoNative.look === "native" && autoNative.render.width === 1050, "auto → native re-renders at the output size");
   assert(autoPixel.look === "pixel" && autoPixel.render.width === 128 && autoPixel.output.width === 1050, "auto → pixel keeps the output size, renders the matrix");
+  assert(Math.abs(autoPixel.scale - 9.375) < 1e-9, `cover scale: ${autoPixel.scale}`);
+  assert(Math.abs(autoPixel.offsetX + 75) < 1e-9 && autoPixel.offsetY === 0, `cover offsets: ${autoPixel.offsetX}, ${autoPixel.offsetY}`);
+
+  // "smooth" was a look until 2026-08 — stored settings carrying it open as auto.
+  const legacy = normalizeCaptureSettings({ ...DEFAULT_CAPTURE_SETTINGS, style: "smooth" });
+  assert(legacy.style === "auto", "legacy smooth style falls back to auto");
 }
 
 // ── scaling probe ──

--- a/web/src/app/pattern-lab/PatternLabClient.tsx
+++ b/web/src/app/pattern-lab/PatternLabClient.tsx
@@ -31,6 +31,7 @@ import { clearLabHandoff, readLabHandoff } from "@/lib/community/handoff";
 import PublishModal from "@/components/community/PublishModal";
 import { CODE_MAX } from "@/lib/community/validate";
 import { withKnobsAnnotation } from "@/lib/lab/annotations";
+import { onEditorReveal } from "@/lib/lab/editorReveal";
 import { flattenLayers, needsFlatten } from "@/lib/lab/flatten";
 import { LAYOUT_STORAGE, layoutViewCount } from "@/lib/lab/serialize";
 import { listSessions, type SessionMeta } from "@/lib/lab/sessions";
@@ -297,6 +298,30 @@ export default function PatternLabClient() {
   const syncOpenPanels = useCallback((api: DockviewApi) => {
     setOpenPanels(new Set(api.panels.map((panel) => panel.id)));
   }, []);
+
+  // Layer gestures front the matching editor: clicking a pixel layer brings
+  // the Pixel tab forward instead of leaving Code on top with a "use the
+  // Pixel panel" hint. Creating a layer may also reopen a closed editor
+  // panel; plain selection only fronts what is already open, so a
+  // deliberately closed panel stays closed while you dup/delete/retitle.
+  useEffect(
+    () =>
+      onEditorReveal(({ kind, open }) => {
+        const api = apiRef.current;
+        if (!api) return;
+        const existing = api.getPanel(kind);
+        if (existing) {
+          existing.api.setActive();
+          return;
+        }
+        if (!open) return;
+        const def = PANEL_DEFS.find((entry) => entry.id === kind);
+        if (!def) return;
+        api.addPanel({ id: def.id, component: def.id, title: def.title });
+        syncOpenPanels(api);
+      }),
+    [syncOpenPanels],
+  );
 
   const onReady = useCallback(
     (event: DockviewReadyEvent) => {

--- a/web/src/app/pattern-lab/panels/CapturePanel.tsx
+++ b/web/src/app/pattern-lab/panels/CapturePanel.tsx
@@ -57,6 +57,8 @@ type Hud = {
   height: number;
   errors: LayerError[];
   auto: AutoVerdict | null;
+  /** Linear scale of the live stage vs the export size; null = exact. */
+  preview: number | null;
 };
 
 function nameErrors(errors: Record<string, string>): LayerError[] {
@@ -105,6 +107,7 @@ export default function CapturePanel(props: IDockviewPanelProps) {
     height: 0,
     errors: [],
     auto: null,
+    preview: null,
   });
   const [exporting, setExporting] = useState<ExportState | null>(null);
   const [message, setMessage] = useState<{ text: string; error: boolean } | null>(null);
@@ -172,6 +175,7 @@ export default function CapturePanel(props: IDockviewPanelProps) {
           height: frame.height,
           errors: nameErrors(frame.errors),
           auto: frame.auto,
+          preview: frame.preview,
         });
       }
     };
@@ -387,6 +391,18 @@ export default function CapturePanel(props: IDockviewPanelProps) {
           <span>{hud.renderMs.toFixed(1)} ms</span>
           <span className={styles.dotSep}>·</span>
           <span>{hud.playing ? `${hud.fps.toFixed(0)} fps` : "paused"}</span>
+          {hud.preview !== null && (
+            <>
+              <span className={styles.dotSep}>·</span>
+              <span
+                title={`The live stage is rendering at ${Math.round(
+                  hud.preview * 100,
+                )}% of the output size to stay fluid. PNG and video exports always render at the full size.`}
+              >
+                preview {Math.round(hud.preview * 100)}%
+              </span>
+            </>
+          )}
         </span>
       </div>
 

--- a/web/src/app/pattern-lab/panels/CapturePanel.tsx
+++ b/web/src/app/pattern-lab/panels/CapturePanel.tsx
@@ -31,10 +31,8 @@ import {
   CAPTURE_SECONDS_MAX,
   CAPTURE_SIDE_MAX,
   CAPTURE_SIDE_MIN,
-  CAPTURE_SPEEDS,
   SIZED_STYLES,
   type AutoVerdict,
-  type CaptureLook,
   type CaptureSettings,
   type FrameMessage,
 } from "@/lib/lab/capture/types";
@@ -58,8 +56,6 @@ type Hud = {
   auto: AutoVerdict | null;
   /** Linear scale of the live stage vs the export size; null = exact. */
   preview: number | null;
-  /** The look the last frame actually painted (auto resolved). */
-  look: CaptureLook | null;
 };
 
 function nameErrors(errors: Record<string, string>): LayerError[] {
@@ -109,7 +105,6 @@ export default function CapturePanel(props: IDockviewPanelProps) {
     errors: [],
     auto: null,
     preview: null,
-    look: null,
   });
   const [exporting, setExporting] = useState<ExportState | null>(null);
   const [message, setMessage] = useState<{ text: string; error: boolean } | null>(null);
@@ -177,7 +172,6 @@ export default function CapturePanel(props: IDockviewPanelProps) {
           errors: nameErrors(frame.errors),
           auto: frame.auto,
           preview: frame.preview,
-          look: frame.geometry.look,
         });
       }
     };
@@ -372,20 +366,6 @@ export default function CapturePanel(props: IDockviewPanelProps) {
             ▶
           </button>
         </span>
-        <label>
-          speed
-          <select
-            value={settings.speed}
-            aria-label="Stage speed"
-            onChange={(event) => update({ speed: Number(event.target.value) })}
-          >
-            {CAPTURE_SPEEDS.map((speed) => (
-              <option key={speed} value={speed}>
-                {speed}×
-              </option>
-            ))}
-          </select>
-        </label>
         <span style={{ flex: 1 }} />
         <span className={styles.stats}>
           <span className={local.readoutStrong}>t {hud.time.toFixed(2)} s</span>
@@ -394,25 +374,14 @@ export default function CapturePanel(props: IDockviewPanelProps) {
           <span className={styles.dotSep}>·</span>
           <span>{hud.playing ? `${hud.fps.toFixed(0)} fps` : "paused"}</span>
           <span className={styles.dotSep}>·</span>
-          {hud.look === "native" ? (
-            <span title="Native re-runs the pattern's code at the exact output grid, and its picture can depend on that grid — so the stage always renders every pixel and what you see IS the export. Expect a low frame rate at big sizes.">
-              exact 100%
+          {hud.preview !== null ? (
+            <span title="The stage shows this look at reduced size to stay fluid — it only blows the panel frame up, so the picture is identical, just fewer pixels. Exports always render the full size.">
+              preview {Math.round(hud.preview * 100)}%
             </span>
           ) : (
-            <button
-              type="button"
-              data-active={settings.previewMode === "fast" ? "true" : undefined}
-              title={
-                settings.previewMode === "fast"
-                  ? "Fast preview: the same picture at far fewer pixels (this look renders the pattern at the panel frame and only blows it up). Exports always render full size. Click to go back to normal preview quality."
-                  : "Big outputs show at reduced size to stay fluid — the same picture, smaller, since this look only blows up the panel frame. Exports always render full size. Click for an even faster draft preview."
-              }
-              onClick={() =>
-                update({ previewMode: settings.previewMode === "fast" ? "auto" : "fast" })
-              }
-            >
-              preview {hud.preview !== null ? Math.round(hud.preview * 100) : 100}%
-            </button>
+            <span title="Every output pixel — what you see is exactly the export. Native re-runs the pattern's code on the real grid, so big sizes trade frame rate for truth.">
+              exact 100%
+            </span>
           )}
         </span>
       </div>

--- a/web/src/app/pattern-lab/panels/CapturePanel.tsx
+++ b/web/src/app/pattern-lab/panels/CapturePanel.tsx
@@ -34,6 +34,7 @@ import {
   CAPTURE_SPEEDS,
   SIZED_STYLES,
   type AutoVerdict,
+  type CaptureLook,
   type CaptureSettings,
   type FrameMessage,
 } from "@/lib/lab/capture/types";
@@ -57,6 +58,8 @@ type Hud = {
   auto: AutoVerdict | null;
   /** Linear scale of the live stage vs the export size; null = exact. */
   preview: number | null;
+  /** The look the last frame actually painted (auto resolved). */
+  look: CaptureLook | null;
 };
 
 function nameErrors(errors: Record<string, string>): LayerError[] {
@@ -106,6 +109,7 @@ export default function CapturePanel(props: IDockviewPanelProps) {
     errors: [],
     auto: null,
     preview: null,
+    look: null,
   });
   const [exporting, setExporting] = useState<ExportState | null>(null);
   const [message, setMessage] = useState<{ text: string; error: boolean } | null>(null);
@@ -173,6 +177,7 @@ export default function CapturePanel(props: IDockviewPanelProps) {
           errors: nameErrors(frame.errors),
           auto: frame.auto,
           preview: frame.preview,
+          look: frame.geometry.look,
         });
       }
     };
@@ -389,20 +394,26 @@ export default function CapturePanel(props: IDockviewPanelProps) {
           <span className={styles.dotSep}>·</span>
           <span>{hud.playing ? `${hud.fps.toFixed(0)} fps` : "paused"}</span>
           <span className={styles.dotSep}>·</span>
-          <button
-            type="button"
-            data-active={settings.previewMode === "fast" ? "true" : undefined}
-            title={
-              settings.previewMode === "fast"
-                ? "Fast preview: the stage renders far fewer pixels for instant feedback — the composition is identical, and PNG/video exports still render the full size. Click to go back to normal preview quality."
-                : "The live stage renders big outputs at reduced size to stay fluid; the number is the current scale. Click for an even faster, lower-resolution preview — same composition, exports stay full size."
-            }
-            onClick={() =>
-              update({ previewMode: settings.previewMode === "fast" ? "auto" : "fast" })
-            }
-          >
-            preview {hud.preview !== null ? Math.round(hud.preview * 100) : 100}%
-          </button>
+          {hud.look === "native" ? (
+            <span title="Native re-runs the pattern's code at the exact output grid, and its picture can depend on that grid — so the stage always renders every pixel and what you see IS the export. Expect a low frame rate at big sizes.">
+              exact 100%
+            </span>
+          ) : (
+            <button
+              type="button"
+              data-active={settings.previewMode === "fast" ? "true" : undefined}
+              title={
+                settings.previewMode === "fast"
+                  ? "Fast preview: the same picture at far fewer pixels (this look renders the pattern at the panel frame and only blows it up). Exports always render full size. Click to go back to normal preview quality."
+                  : "Big outputs show at reduced size to stay fluid — the same picture, smaller, since this look only blows up the panel frame. Exports always render full size. Click for an even faster draft preview."
+              }
+              onClick={() =>
+                update({ previewMode: settings.previewMode === "fast" ? "auto" : "fast" })
+              }
+            >
+              preview {hud.preview !== null ? Math.round(hud.preview * 100) : 100}%
+            </button>
+          )}
         </span>
       </div>
 

--- a/web/src/app/pattern-lab/panels/CapturePanel.tsx
+++ b/web/src/app/pattern-lab/panels/CapturePanel.tsx
@@ -2,9 +2,9 @@
 
 // Capture — the lab's output stage. A second, independent render of the
 // layer stack for pictures and clips rather than for the LED panel: pick a
-// print/screen size, a look (auto, re-rendered, smooth, pixel blocks, or
-// LED dots), a turn, pause on the moment you want, and save a PNG or record
-// an MP4/WebM.
+// print/screen size, a look (auto, re-rendered, pixel blocks, or LED dots),
+// a turn, pause on the moment you want, and save a PNG or record an
+// MP4/WebM.
 //
 // Everything runs in lib/lab/capture (a worker with its own engine). This
 // component only holds the controls and shows the bitmaps the worker sends;
@@ -28,7 +28,6 @@ import {
 import {
   CAPTURE_FPS,
   CAPTURE_HEAVY_PIXELS,
-  CAPTURE_ROTATIONS,
   CAPTURE_SCALES,
   CAPTURE_SECONDS_MAX,
   CAPTURE_SIDE_MAX,
@@ -413,12 +412,11 @@ export default function CapturePanel(props: IDockviewPanelProps) {
           <select
             value={settings.style}
             aria-label="Output look"
-            title="Auto re-runs the pattern at the output size when a test render shows its code scales, and upscales the panel frame otherwise. Native always re-runs it. Smooth and Pixel scale the panel frame up (soft / crisp blocks). LED draws each pixel as a round light."
+            title="Auto re-runs the pattern at the output size when a test render shows its code scales, and upscales the panel frame otherwise. Native always re-runs it. Pixel scales the panel frame up as crisp blocks. LED draws each pixel as a round light."
             onChange={(event) => update({ style: event.target.value as CaptureSettings["style"] })}
           >
             <option value="auto">Auto</option>
             <option value="native">Native (re-rendered)</option>
-            <option value="smooth">Smooth upscale</option>
             <option value="pixel">Pixel blocks</option>
             <option value="led">LED dots</option>
           </select>
@@ -497,23 +495,35 @@ export default function CapturePanel(props: IDockviewPanelProps) {
           </label>
         )}
 
-        <label>
-          turn
-          <select
-            value={settings.rotation}
-            aria-label="Turn"
-            title="Turn the finished picture clockwise, like mounting the panel on its side — the pattern itself keeps its own orientation."
-            onChange={(event) =>
-              update({ rotation: Number(event.target.value) as CaptureSettings["rotation"] })
+        <span
+          className={local.group}
+          role="group"
+          aria-label="Turn"
+          title="Turn the finished picture, like mounting the panel on its side — the pattern itself keeps its own orientation."
+        >
+          <span className={local.readout}>turn</span>
+          <button
+            type="button"
+            aria-label="Turn 90° counter-clockwise"
+            title="Turn the picture 90° counter-clockwise"
+            onClick={() =>
+              update({ rotation: ((settings.rotation + 270) % 360) as CaptureSettings["rotation"] })
             }
           >
-            {CAPTURE_ROTATIONS.map((rotation) => (
-              <option key={rotation} value={rotation}>
-                {rotation}°
-              </option>
-            ))}
-          </select>
-        </label>
+            ⟲
+          </button>
+          <span className={local.readout}>{settings.rotation}°</span>
+          <button
+            type="button"
+            aria-label="Turn 90° clockwise"
+            title="Turn the picture 90° clockwise"
+            onClick={() =>
+              update({ rotation: ((settings.rotation + 90) % 360) as CaptureSettings["rotation"] })
+            }
+          >
+            ⟳
+          </button>
+        </span>
 
         <label>
           backdrop

--- a/web/src/app/pattern-lab/panels/CapturePanel.tsx
+++ b/web/src/app/pattern-lab/panels/CapturePanel.tsx
@@ -496,23 +496,6 @@ export default function CapturePanel(props: IDockviewPanelProps) {
           </label>
         )}
 
-        {(settings.style === "auto" || settings.style === "pixel") && (
-          <label>
-            upscale
-            <select
-              value={settings.upscale}
-              aria-label="Upscale finish"
-              title="How the frame is blown up when it is not re-rendered — crisp keeps hard pixel edges, soft interpolates between them. Applies to the Pixel look and Auto's upscale fallback."
-              onChange={(event) =>
-                update({ upscale: event.target.value as CaptureSettings["upscale"] })
-              }
-            >
-              <option value="crisp">Crisp blocks</option>
-              <option value="soft">Soft (interpolated)</option>
-            </select>
-          </label>
-        )}
-
         <span
           className={local.group}
           role="group"

--- a/web/src/app/pattern-lab/panels/CapturePanel.tsx
+++ b/web/src/app/pattern-lab/panels/CapturePanel.tsx
@@ -27,7 +27,6 @@ import {
 } from "@/lib/lab/capture/settings";
 import {
   CAPTURE_FPS,
-  CAPTURE_HEAVY_PIXELS,
   CAPTURE_SCALES,
   CAPTURE_SECONDS_MAX,
   CAPTURE_SIDE_MAX,
@@ -121,7 +120,6 @@ export default function CapturePanel(props: IDockviewPanelProps) {
   const exportingRef = useRef(false);
 
   const geometry = resolveGeometry(settings, matrix);
-  const heavy = geometry.output.width * geometry.output.height > CAPTURE_HEAVY_PIXELS;
 
   const update = useCallback((patch: Partial<CaptureSettings>) => {
     setSettings((current) => normalizeCaptureSettings({ ...current, ...patch }));
@@ -390,18 +388,21 @@ export default function CapturePanel(props: IDockviewPanelProps) {
           <span>{hud.renderMs.toFixed(1)} ms</span>
           <span className={styles.dotSep}>·</span>
           <span>{hud.playing ? `${hud.fps.toFixed(0)} fps` : "paused"}</span>
-          {hud.preview !== null && (
-            <>
-              <span className={styles.dotSep}>·</span>
-              <span
-                title={`The live stage is rendering at ${Math.round(
-                  hud.preview * 100,
-                )}% of the output size to stay fluid. PNG and video exports always render at the full size.`}
-              >
-                preview {Math.round(hud.preview * 100)}%
-              </span>
-            </>
-          )}
+          <span className={styles.dotSep}>·</span>
+          <button
+            type="button"
+            data-active={settings.previewMode === "fast" ? "true" : undefined}
+            title={
+              settings.previewMode === "fast"
+                ? "Fast preview: the stage renders far fewer pixels for instant feedback — the composition is identical, and PNG/video exports still render the full size. Click to go back to normal preview quality."
+                : "The live stage renders big outputs at reduced size to stay fluid; the number is the current scale. Click for an even faster, lower-resolution preview — same composition, exports stay full size."
+            }
+            onClick={() =>
+              update({ previewMode: settings.previewMode === "fast" ? "auto" : "fast" })
+            }
+          >
+            preview {hud.preview !== null ? Math.round(hud.preview * 100) : 100}%
+          </button>
         </span>
       </div>
 
@@ -495,6 +496,23 @@ export default function CapturePanel(props: IDockviewPanelProps) {
           </label>
         )}
 
+        {(settings.style === "auto" || settings.style === "pixel") && (
+          <label>
+            upscale
+            <select
+              value={settings.upscale}
+              aria-label="Upscale finish"
+              title="How the frame is blown up when it is not re-rendered — crisp keeps hard pixel edges, soft interpolates between them. Applies to the Pixel look and Auto's upscale fallback."
+              onChange={(event) =>
+                update({ upscale: event.target.value as CaptureSettings["upscale"] })
+              }
+            >
+              <option value="crisp">Crisp blocks</option>
+              <option value="soft">Soft (interpolated)</option>
+            </select>
+          </label>
+        )}
+
         <span
           className={local.group}
           role="group"
@@ -512,7 +530,6 @@ export default function CapturePanel(props: IDockviewPanelProps) {
           >
             ⟲
           </button>
-          <span className={local.readout}>{settings.rotation}°</span>
           <button
             type="button"
             aria-label="Turn 90° clockwise"
@@ -523,6 +540,7 @@ export default function CapturePanel(props: IDockviewPanelProps) {
           >
             ⟳
           </button>
+          <span className={local.readout}>{settings.rotation}°</span>
         </span>
 
         <label>
@@ -601,14 +619,6 @@ export default function CapturePanel(props: IDockviewPanelProps) {
           </>
         )}
 
-        {heavy && (
-          <span
-            className={styles.frameWarning}
-            title="Every frame runs the pattern over this many pixels. The stage stays responsive (it renders off the main thread) but expect a low frame rate and slower exports."
-          >
-            heavy
-          </span>
-        )}
         {settings.style === "auto" && hud.auto && (
           <span className={local.verdict} data-verdict={hud.auto.verdict} title={hud.auto.detail}>
             auto → {hud.auto.description}

--- a/web/src/app/pattern-lab/panels/LayersPanel.tsx
+++ b/web/src/app/pattern-lab/panels/LayersPanel.tsx
@@ -6,6 +6,7 @@
 
 import { useState } from "react";
 import { BLEND_MODES } from "@/lib/lab/types";
+import { revealEditor } from "@/lib/lab/editorReveal";
 import { useLabStore } from "@/lib/lab/store";
 import dock from "../LabPanels.module.css";
 
@@ -41,16 +42,34 @@ export default function LayersPanel() {
   return (
     <div className={dock.panel}>
       <div className={dock.panelBar}>
-        <button type="button" onClick={addCodeLayer} title="Add a code pattern layer">
+        <button
+          type="button"
+          onClick={() => {
+            addCodeLayer();
+            revealEditor("code", { open: true });
+          }}
+          title="Add a code pattern layer"
+        >
           + Code
         </button>
-        <button type="button" onClick={addPixelLayer} title="Add a pixel art layer">
+        <button
+          type="button"
+          onClick={() => {
+            addPixelLayer();
+            revealEditor("pixel", { open: true });
+          }}
+          title="Add a pixel art layer"
+        >
           + Pixel
         </button>
         <span style={{ flex: 1 }} />
         <button
           type="button"
-          onClick={() => active && duplicateLayer(active.id)}
+          onClick={() => {
+            if (!active) return;
+            duplicateLayer(active.id);
+            revealEditor(active.type, { open: true });
+          }}
           disabled={!active}
           title="Duplicate the selected layer"
         >
@@ -99,7 +118,12 @@ export default function LayersPanel() {
                     setDragIndex(null);
                     setDragOverIndex(null);
                   }}
-                  onClick={() => selectLayer(layer.id)}
+                  onClick={() => {
+                    selectLayer(layer.id);
+                    // Fronts the matching editor tab even when this layer is
+                    // already active — clicking a layer means "let me edit it".
+                    revealEditor(layer.type);
+                  }}
                   onDoubleClick={() => {
                     setRenamingId(layer.id);
                     setRenameValue(layer.name);

--- a/web/src/lib/lab/capture/capture.worker.ts
+++ b/web/src/lib/lab/capture/capture.worker.ts
@@ -12,12 +12,13 @@
 // encodes it; a clip steps the clock at a fixed 1/fps from the current
 // moment, so what the stage shows when you press Record is the first frame.
 
-import { CaptureCore, mergeWireProject, type CaptureFrame } from "./core";
+import { CaptureCore, clampScale, mergeWireProject, resolveGeometry, type CaptureFrame } from "./core";
 import { StagePainter } from "./paint";
 import { describeProbe, probeKey, probeScaling, type ProbeResult } from "./probe";
 import {
   DEFAULT_CAPTURE_SETTINGS,
   type AutoVerdict,
+  type CaptureGeometry,
   type CaptureProject,
   type CaptureSettings,
   type FromWorker,
@@ -33,6 +34,11 @@ const scope = self as unknown as WorkerScope;
 
 const MAX_DT = 0.05;
 const EXPORT_PREVIEW_INTERVAL_MS = 120;
+// The live stage renders at most this many output pixels. A native 4K frame
+// is hundreds of milliseconds of pattern JS; capped near 720p-class the stage
+// stays fluid while you compose, and only the exports — which are exact by
+// contract — pay the full price.
+const PREVIEW_PIXEL_BUDGET = 1_200_000;
 
 const core = new CaptureCore(DEFAULT_CAPTURE_SETTINGS);
 const painter = new StagePainter((width, height) => new OffscreenCanvas(width, height));
@@ -97,7 +103,11 @@ function autoVerdict(): AutoVerdict | null {
   };
 }
 
-function frameMessage(frame: CaptureFrame, bitmap: ImageBitmap): FromWorker {
+function frameMessage(
+  frame: CaptureFrame,
+  bitmap: ImageBitmap,
+  preview: number | null = null,
+): FromWorker {
   return {
     type: "frame",
     bitmap,
@@ -109,16 +119,48 @@ function frameMessage(frame: CaptureFrame, bitmap: ImageBitmap): FromWorker {
     errors: frame.errors,
     geometry: frame.geometry,
     auto: autoVerdict(),
+    preview,
   };
 }
 
+/**
+ * The geometry the live stage should render at: the full one while it fits
+ * the budget, otherwise the same settings shrunk linearly — sized looks by
+ * their output edges, cell looks by their blow-up factor — and re-resolved,
+ * so cover fits, offsets and rotation stay exactly the export's, smaller.
+ */
+function previewFor(full: CaptureGeometry): { geometry: CaptureGeometry; factor: number } | null {
+  if (!project) return null;
+  const pixels = full.output.width * full.output.height;
+  if (pixels <= PREVIEW_PIXEL_BUDGET) return null;
+  const k = Math.sqrt(PREVIEW_PIXEL_BUDGET / pixels);
+  const settings = core.settings;
+  let scaled: CaptureSettings;
+  if (settings.style === "pixel" || settings.style === "led") {
+    const scale = Math.max(1, Math.floor(clampScale(settings.scale, project.matrix) * k));
+    if (scale >= full.scale) return null;
+    scaled = { ...settings, scale };
+  } else {
+    scaled = {
+      ...settings,
+      width: Math.max(1, Math.round(full.output.width * k)),
+      height: Math.max(1, Math.round(full.output.height * k)),
+    };
+  }
+  const geometry = resolveGeometry(scaled, project.matrix, core.autoLook);
+  return { geometry, factor: geometry.output.width / full.output.width };
+}
+
 function renderAndPost(dt: number) {
-  const frame = core.step(dt);
+  const full = core.geometry();
+  if (!full) return;
+  const preview = previewFor(full);
+  const frame = core.step(dt, preview?.geometry);
   if (!frame) return;
   painter.paint(stage, frame, core.settings);
   const bitmap = stage.transferToImageBitmap();
   awaitingAck = true;
-  post(frameMessage(frame, bitmap), [bitmap]);
+  post(frameMessage(frame, bitmap, preview?.factor ?? null), [bitmap]);
 }
 
 function requestTick() {

--- a/web/src/lib/lab/capture/capture.worker.ts
+++ b/web/src/lib/lab/capture/capture.worker.ts
@@ -34,11 +34,10 @@ const scope = self as unknown as WorkerScope;
 
 const MAX_DT = 0.05;
 const EXPORT_PREVIEW_INTERVAL_MS = 120;
-// The live stage renders at most this many output pixels. A native 4K frame
-// is hundreds of milliseconds of pattern JS; capped near 720p-class the stage
-// stays fluid while you compose, and only the exports — which are exact by
-// contract — pay the full price. "Fast" is the HUD button's draft mode:
-// same composition, far fewer pixels, for instant feedback on heavy code.
+// Stage pixel caps for the matrix-rendered looks (pixel/led/auto fallback),
+// where fewer output pixels are the same picture, smaller — the LED look's
+// full-size blur was the main lag. "Fast" is the HUD button's draft mode.
+// The Native look is exempt (see previewFor) and exports never reduce.
 const PREVIEW_PIXEL_BUDGET = 1_200_000;
 const FAST_PIXEL_BUDGET = 300_000;
 
@@ -133,6 +132,12 @@ function frameMessage(
  */
 function previewFor(full: CaptureGeometry): { geometry: CaptureGeometry; factor: number } | null {
   if (!project) return null;
+  // Native re-runs the pattern code on the stage grid: shrink that grid and
+  // pixel-unit math draws a different picture, not a smaller one. Never
+  // reduce it — a slow exact stage is a preview, a fast different one isn't.
+  // Matrix-rendered looks (pixel/led/auto's fallback) only shrink the
+  // blow-up, so their reduced frame is the same picture at fewer pixels.
+  if (full.look === "native") return null;
   const budget = core.settings.previewMode === "fast" ? FAST_PIXEL_BUDGET : PREVIEW_PIXEL_BUDGET;
   const pixels = full.output.width * full.output.height;
   if (pixels <= budget) return null;

--- a/web/src/lib/lab/capture/capture.worker.ts
+++ b/web/src/lib/lab/capture/capture.worker.ts
@@ -37,8 +37,10 @@ const EXPORT_PREVIEW_INTERVAL_MS = 120;
 // The live stage renders at most this many output pixels. A native 4K frame
 // is hundreds of milliseconds of pattern JS; capped near 720p-class the stage
 // stays fluid while you compose, and only the exports — which are exact by
-// contract — pay the full price.
+// contract — pay the full price. "Fast" is the HUD button's draft mode:
+// same composition, far fewer pixels, for instant feedback on heavy code.
 const PREVIEW_PIXEL_BUDGET = 1_200_000;
+const FAST_PIXEL_BUDGET = 300_000;
 
 const core = new CaptureCore(DEFAULT_CAPTURE_SETTINGS);
 const painter = new StagePainter((width, height) => new OffscreenCanvas(width, height));
@@ -131,9 +133,10 @@ function frameMessage(
  */
 function previewFor(full: CaptureGeometry): { geometry: CaptureGeometry; factor: number } | null {
   if (!project) return null;
+  const budget = core.settings.previewMode === "fast" ? FAST_PIXEL_BUDGET : PREVIEW_PIXEL_BUDGET;
   const pixels = full.output.width * full.output.height;
-  if (pixels <= PREVIEW_PIXEL_BUDGET) return null;
-  const k = Math.sqrt(PREVIEW_PIXEL_BUDGET / pixels);
+  if (pixels <= budget) return null;
+  const k = Math.sqrt(budget / pixels);
   const settings = core.settings;
   let scaled: CaptureSettings;
   if (settings.style === "pixel" || settings.style === "led") {

--- a/web/src/lib/lab/capture/capture.worker.ts
+++ b/web/src/lib/lab/capture/capture.worker.ts
@@ -34,12 +34,11 @@ const scope = self as unknown as WorkerScope;
 
 const MAX_DT = 0.05;
 const EXPORT_PREVIEW_INTERVAL_MS = 120;
-// Stage pixel caps for the matrix-rendered looks (pixel/led/auto fallback),
+// Stage pixel cap for the matrix-rendered looks (pixel/led/auto fallback),
 // where fewer output pixels are the same picture, smaller — the LED look's
-// full-size blur was the main lag. "Fast" is the HUD button's draft mode.
-// The Native look is exempt (see previewFor) and exports never reduce.
+// full-size blur was the main lag. The Native look is exempt (see
+// previewFor) and exports never reduce.
 const PREVIEW_PIXEL_BUDGET = 1_200_000;
-const FAST_PIXEL_BUDGET = 300_000;
 
 const core = new CaptureCore(DEFAULT_CAPTURE_SETTINGS);
 const painter = new StagePainter((width, height) => new OffscreenCanvas(width, height));
@@ -138,10 +137,9 @@ function previewFor(full: CaptureGeometry): { geometry: CaptureGeometry; factor:
   // Matrix-rendered looks (pixel/led/auto's fallback) only shrink the
   // blow-up, so their reduced frame is the same picture at fewer pixels.
   if (full.look === "native") return null;
-  const budget = core.settings.previewMode === "fast" ? FAST_PIXEL_BUDGET : PREVIEW_PIXEL_BUDGET;
   const pixels = full.output.width * full.output.height;
-  if (pixels <= budget) return null;
-  const k = Math.sqrt(budget / pixels);
+  if (pixels <= PREVIEW_PIXEL_BUDGET) return null;
+  const k = Math.sqrt(PREVIEW_PIXEL_BUDGET / pixels);
   const settings = core.settings;
   let scaled: CaptureSettings;
   if (settings.style === "pixel" || settings.style === "led") {
@@ -182,7 +180,7 @@ function tick() {
   if (exporting || awaitingAck || !visible || !core.ready) return;
   const now = performance.now();
   if (playing) {
-    const dt = Math.min(MAX_DT, Math.max(0, (now - lastTick) / 1000)) * core.settings.speed;
+    const dt = Math.min(MAX_DT, Math.max(0, (now - lastTick) / 1000));
     lastTick = now;
     dirty = false;
     renderAndPost(dt);

--- a/web/src/lib/lab/capture/core.ts
+++ b/web/src/lib/lab/capture/core.ts
@@ -268,12 +268,15 @@ export class CaptureCore {
 
   /**
    * Advance the stage clock by `dt` seconds of pattern time (0 re-renders
-   * the current moment) and produce the output picture.
+   * the current moment) and produce the output picture. `geometryOverride`
+   * lets the caller render the same moment at a different size — the live
+   * stage passes a budget-capped geometry, exports pass nothing.
    */
-  step(dt: number): CaptureFrame | null {
+  step(dt: number, geometryOverride?: CaptureGeometry): CaptureFrame | null {
     const project = this.project;
     if (!project) return null;
-    const geometry = resolveGeometry(this.settings, project.matrix, this.autoLook);
+    const geometry =
+      geometryOverride ?? resolveGeometry(this.settings, project.matrix, this.autoLook);
     const layers = this.layersFor(geometry.render);
     this.time += dt;
 

--- a/web/src/lib/lab/capture/paint.ts
+++ b/web/src/lib/lab/capture/paint.ts
@@ -86,8 +86,7 @@ export class StagePainter {
     }
 
     if (look === "pixel") {
-      context.imageSmoothingEnabled = settings.upscale === "soft";
-      if ("imageSmoothingQuality" in context) context.imageSmoothingQuality = "high";
+      context.imageSmoothingEnabled = false;
       context.drawImage(
         staging,
         0,

--- a/web/src/lib/lab/capture/paint.ts
+++ b/web/src/lib/lab/capture/paint.ts
@@ -85,9 +85,8 @@ export class StagePainter {
       return;
     }
 
-    if (look === "pixel" || look === "smooth") {
-      context.imageSmoothingEnabled = look === "smooth";
-      context.imageSmoothingQuality = "high";
+    if (look === "pixel") {
+      context.imageSmoothingEnabled = false;
       context.drawImage(
         staging,
         0,

--- a/web/src/lib/lab/capture/paint.ts
+++ b/web/src/lib/lab/capture/paint.ts
@@ -86,7 +86,8 @@ export class StagePainter {
     }
 
     if (look === "pixel") {
-      context.imageSmoothingEnabled = false;
+      context.imageSmoothingEnabled = settings.upscale === "soft";
+      if ("imageSmoothingQuality" in context) context.imageSmoothingQuality = "high";
       context.drawImage(
         staging,
         0,

--- a/web/src/lib/lab/capture/settings.ts
+++ b/web/src/lib/lab/capture/settings.ts
@@ -72,7 +72,9 @@ export function normalizeCaptureSettings(input: unknown): CaptureSettings {
       ? Math.max(1, Math.min(CAPTURE_SECONDS_MAX, Math.round(video.seconds * 10) / 10))
       : base.video.seconds;
   return {
-    style: pick(raw.style, ["auto", "native", "smooth", "pixel", "led"] as const, base.style),
+    // "smooth" was a look until 2026-08; stored settings carrying it fall
+    // back to auto here.
+    style: pick(raw.style, ["auto", "native", "pixel", "led"] as const, base.style),
     width: clampSide(typeof raw.width === "number" ? raw.width : base.width),
     height: clampSide(typeof raw.height === "number" ? raw.height : base.height),
     scale: pick(raw.scale, CAPTURE_SCALES, base.scale),

--- a/web/src/lib/lab/capture/settings.ts
+++ b/web/src/lib/lab/capture/settings.ts
@@ -78,7 +78,6 @@ export function normalizeCaptureSettings(input: unknown): CaptureSettings {
     width: clampSide(typeof raw.width === "number" ? raw.width : base.width),
     height: clampSide(typeof raw.height === "number" ? raw.height : base.height),
     scale: pick(raw.scale, CAPTURE_SCALES, base.scale),
-    upscale: pick(raw.upscale, ["crisp", "soft"] as const, base.upscale),
     previewMode: pick(raw.previewMode, ["auto", "fast"] as const, base.previewMode),
     rotation: pick(raw.rotation, CAPTURE_ROTATIONS, base.rotation),
     backdrop: pick(raw.backdrop, ["black", "transparent", "color"] as const, base.backdrop),

--- a/web/src/lib/lab/capture/settings.ts
+++ b/web/src/lib/lab/capture/settings.ts
@@ -9,7 +9,6 @@ import {
   CAPTURE_ROTATIONS,
   CAPTURE_SCALES,
   CAPTURE_SECONDS_MAX,
-  CAPTURE_SPEEDS,
   DEFAULT_CAPTURE_SETTINGS,
   type CaptureSettings,
 } from "./types";
@@ -78,14 +77,12 @@ export function normalizeCaptureSettings(input: unknown): CaptureSettings {
     width: clampSide(typeof raw.width === "number" ? raw.width : base.width),
     height: clampSide(typeof raw.height === "number" ? raw.height : base.height),
     scale: pick(raw.scale, CAPTURE_SCALES, base.scale),
-    previewMode: pick(raw.previewMode, ["auto", "fast"] as const, base.previewMode),
     rotation: pick(raw.rotation, CAPTURE_ROTATIONS, base.rotation),
     backdrop: pick(raw.backdrop, ["black", "transparent", "color"] as const, base.backdrop),
     cutout: pick(raw.cutout, ["unpainted", "dark"] as const, base.cutout),
     backdropColor: hexColor(raw.backdropColor, base.backdropColor),
     ledDot: unit(raw.ledDot, base.ledDot),
     ledGlow: unit(raw.ledGlow, base.ledGlow),
-    speed: pick(raw.speed, CAPTURE_SPEEDS, base.speed),
     video: {
       fps: pick(video.fps, CAPTURE_FPS, base.video.fps),
       seconds,

--- a/web/src/lib/lab/capture/settings.ts
+++ b/web/src/lib/lab/capture/settings.ts
@@ -78,6 +78,8 @@ export function normalizeCaptureSettings(input: unknown): CaptureSettings {
     width: clampSide(typeof raw.width === "number" ? raw.width : base.width),
     height: clampSide(typeof raw.height === "number" ? raw.height : base.height),
     scale: pick(raw.scale, CAPTURE_SCALES, base.scale),
+    upscale: pick(raw.upscale, ["crisp", "soft"] as const, base.upscale),
+    previewMode: pick(raw.previewMode, ["auto", "fast"] as const, base.previewMode),
     rotation: pick(raw.rotation, CAPTURE_ROTATIONS, base.rotation),
     backdrop: pick(raw.backdrop, ["black", "transparent", "color"] as const, base.backdrop),
     cutout: pick(raw.cutout, ["unpainted", "dark"] as const, base.cutout),

--- a/web/src/lib/lab/capture/types.ts
+++ b/web/src/lib/lab/capture/types.ts
@@ -1,10 +1,11 @@
 // ── Pattern Lab capture module ───────────────────────────────────────────────
 // Renders the lab's layer stack for OUTPUT rather than for the LED panel:
 // stills (PNG) and clips (MP4/WebM) at print/screen resolutions, with the
-// pattern either re-run at the output size ("native"), scaled up smoothly
-// ("smooth"), blown up as crisp blocks ("pixel"), drawn as round LEDs
-// ("led"), or — the default — re-run only when a probe shows the code
-// scales, upscaled otherwise ("auto", see probe.ts).
+// pattern either re-run at the output size ("native"), blown up as crisp
+// blocks ("pixel"), drawn as round LEDs ("led"), or — the default — re-run
+// only when a probe shows the code scales, upscaled otherwise ("auto", see
+// probe.ts). Upscales are nearest-only for now; smoothing/interpolation is
+// planned to return as a separate option layered on top, not as a look.
 //
 // This whole directory is an add-on. It owns its own LabEngine instance and
 // runs it in a Web Worker, so nothing here touches the live preview, the
@@ -16,11 +17,11 @@ import type { MatrixSize } from "@/lib/patternMatrix";
 import type { Layer, PixelLayer } from "../types";
 
 /** What the user picks. */
-export type CaptureStyle = "auto" | "native" | "smooth" | "pixel" | "led";
+export type CaptureStyle = "auto" | "native" | "pixel" | "led";
 /** What actually gets painted once `auto` has been resolved. */
-export type CaptureLook = "native" | "smooth" | "pixel" | "led";
+export type CaptureLook = "native" | "pixel" | "led";
 /** Looks that take a W×H output size; the others take a blow-up factor. */
-export const SIZED_STYLES: CaptureStyle[] = ["auto", "native", "smooth"];
+export const SIZED_STYLES: CaptureStyle[] = ["auto", "native"];
 
 /**
  * What sits behind the picture.
@@ -54,9 +55,9 @@ export const CAPTURE_ROTATIONS: CaptureRotation[] = [0, 90, 180, 270];
 export type CaptureSettings = {
   style: CaptureStyle;
   /**
-   * Output size for `auto` / `native` / `smooth`. Native runs the pattern
-   * code at exactly this grid; smooth (and an auto fallback) cover it with
-   * the matrix render, cropping the overflow.
+   * Output size for `auto` / `native`. Native runs the pattern code at
+   * exactly this grid; the auto fallback covers it with the matrix render,
+   * cropping the overflow.
    */
   width: number;
   height: number;

--- a/web/src/lib/lab/capture/types.ts
+++ b/web/src/lib/lab/capture/types.ts
@@ -4,8 +4,9 @@
 // pattern either re-run at the output size ("native"), blown up as crisp
 // blocks ("pixel"), drawn as round LEDs ("led"), or — the default — re-run
 // only when a probe shows the code scales, upscaled otherwise ("auto", see
-// probe.ts). Upscales are nearest-only for now; smoothing/interpolation is
-// planned to return as a separate option layered on top, not as a look.
+// probe.ts). Upscales are nearest-only ON PURPOSE: both a Smooth look and a
+// crisp/soft finish option existed briefly in 2026-08 and were rejected —
+// the interpolated blow-up just reads as a broken render at these sizes.
 //
 // This whole directory is an add-on. It owns its own LabEngine instance and
 // runs it in a Web Worker, so nothing here touches the live preview, the
@@ -64,11 +65,6 @@ export type CaptureSettings = {
   /** Integer blow-up of the project matrix for `pixel` / `led`. */
   scale: number;
   /**
-   * How blocky upscales are drawn — the Pixel look and Auto's fallback.
-   * "crisp" keeps hard cell edges, "soft" interpolates between them.
-   */
-  upscale: "crisp" | "soft";
-  /**
    * Live-stage quality only, never the exports: "auto" caps the stage near
    * 720p-class, "fast" much lower for instant feedback on heavy patterns.
    * The picture keeps the exact composition either way, just fewer pixels.
@@ -103,7 +99,6 @@ export const DEFAULT_CAPTURE_SETTINGS: CaptureSettings = {
   width: 1024,
   height: 512,
   scale: 8,
-  upscale: "crisp",
   previewMode: "auto",
   rotation: 0,
   backdrop: "black",

--- a/web/src/lib/lab/capture/types.ts
+++ b/web/src/lib/lab/capture/types.ts
@@ -184,6 +184,12 @@ export type FrameMessage = {
   geometry: CaptureGeometry;
   /** Present while the style is `auto`. */
   auto: AutoVerdict | null;
+  /**
+   * Set when the live stage rendered below the requested size to stay fluid:
+   * the linear factor applied (0.5 = half width). Exports are never scaled,
+   * so export previews and small outputs carry null.
+   */
+  preview: number | null;
 };
 
 export type FromWorker =

--- a/web/src/lib/lab/capture/types.ts
+++ b/web/src/lib/lab/capture/types.ts
@@ -64,16 +64,6 @@ export type CaptureSettings = {
   height: number;
   /** Integer blow-up of the project matrix for `pixel` / `led`. */
   scale: number;
-  /**
-   * Live-stage quality only, never the exports: "auto" caps the stage near
-   * 720p-class, "fast" much lower for instant feedback. Applies ONLY to
-   * looks that render the pattern at the matrix and blow it up (pixel, led,
-   * auto's fallback) — there fewer pixels are the same picture, smaller. The
-   * Native look is never reduced: its code re-runs on the stage grid, and
-   * pixel-unit math draws a DIFFERENT picture on a different grid — a
-   * reduced native stage would preview a pattern that doesn't exist.
-   */
-  previewMode: "auto" | "fast";
   rotation: CaptureRotation;
   backdrop: CaptureBackdrop;
   cutout: CaptureCutout;
@@ -82,8 +72,6 @@ export type CaptureSettings = {
   /** LED look: dot diameter as a fraction of the cell, and glow strength. */
   ledDot: number;
   ledGlow: number;
-  /** Stage playback speed multiplier. */
-  speed: number;
   video: {
     fps: number;
     seconds: number;
@@ -94,7 +82,6 @@ export type CaptureSettings = {
 export const CAPTURE_SIDE_MAX = 4096;
 export const CAPTURE_SIDE_MIN = 16;
 export const CAPTURE_SCALES = [2, 3, 4, 6, 8, 10, 12, 16, 20, 24, 32] as const;
-export const CAPTURE_SPEEDS = [0.25, 0.5, 1, 2, 4] as const;
 export const CAPTURE_FPS = [24, 30, 60] as const;
 export const CAPTURE_SECONDS_MAX = 60;
 
@@ -103,14 +90,12 @@ export const DEFAULT_CAPTURE_SETTINGS: CaptureSettings = {
   width: 1024,
   height: 512,
   scale: 8,
-  previewMode: "auto",
   rotation: 0,
   backdrop: "black",
   cutout: "unpainted",
   backdropColor: "#ffffff",
   ledDot: 0.72,
   ledGlow: 0.35,
-  speed: 1,
   video: { fps: 30, seconds: 6, format: "mp4" },
 };
 

--- a/web/src/lib/lab/capture/types.ts
+++ b/web/src/lib/lab/capture/types.ts
@@ -66,8 +66,12 @@ export type CaptureSettings = {
   scale: number;
   /**
    * Live-stage quality only, never the exports: "auto" caps the stage near
-   * 720p-class, "fast" much lower for instant feedback on heavy patterns.
-   * The picture keeps the exact composition either way, just fewer pixels.
+   * 720p-class, "fast" much lower for instant feedback. Applies ONLY to
+   * looks that render the pattern at the matrix and blow it up (pixel, led,
+   * auto's fallback) — there fewer pixels are the same picture, smaller. The
+   * Native look is never reduced: its code re-runs on the stage grid, and
+   * pixel-unit math draws a DIFFERENT picture on a different grid — a
+   * reduced native stage would preview a pattern that doesn't exist.
    */
   previewMode: "auto" | "fast";
   rotation: CaptureRotation;

--- a/web/src/lib/lab/capture/types.ts
+++ b/web/src/lib/lab/capture/types.ts
@@ -63,6 +63,17 @@ export type CaptureSettings = {
   height: number;
   /** Integer blow-up of the project matrix for `pixel` / `led`. */
   scale: number;
+  /**
+   * How blocky upscales are drawn — the Pixel look and Auto's fallback.
+   * "crisp" keeps hard cell edges, "soft" interpolates between them.
+   */
+  upscale: "crisp" | "soft";
+  /**
+   * Live-stage quality only, never the exports: "auto" caps the stage near
+   * 720p-class, "fast" much lower for instant feedback on heavy patterns.
+   * The picture keeps the exact composition either way, just fewer pixels.
+   */
+  previewMode: "auto" | "fast";
   rotation: CaptureRotation;
   backdrop: CaptureBackdrop;
   cutout: CaptureCutout;
@@ -82,8 +93,6 @@ export type CaptureSettings = {
 
 export const CAPTURE_SIDE_MAX = 4096;
 export const CAPTURE_SIDE_MIN = 16;
-/** Above this the stage stays usable but the fps counter tells the story. */
-export const CAPTURE_HEAVY_PIXELS = 2_000_000;
 export const CAPTURE_SCALES = [2, 3, 4, 6, 8, 10, 12, 16, 20, 24, 32] as const;
 export const CAPTURE_SPEEDS = [0.25, 0.5, 1, 2, 4] as const;
 export const CAPTURE_FPS = [24, 30, 60] as const;
@@ -94,6 +103,8 @@ export const DEFAULT_CAPTURE_SETTINGS: CaptureSettings = {
   width: 1024,
   height: 512,
   scale: 8,
+  upscale: "crisp",
+  previewMode: "auto",
   rotation: 0,
   backdrop: "black",
   cutout: "unpainted",

--- a/web/src/lib/lab/editorReveal.ts
+++ b/web/src/lib/lab/editorReveal.ts
@@ -1,0 +1,35 @@
+// ── Editor reveal bus ────────────────────────────────────────────────────────
+// Selecting a pixel layer while the Code tab is fronted used to leave you
+// staring at "use the Pixel panel" — the layer click changed the store, but
+// nothing touched the dock. This tiny bus carries that one gesture: panels
+// announce "the user wants to edit a <kind> layer now", and the dock shell
+// (which owns the dockview api) fronts the matching editor tab.
+//
+// Deliberately NOT store state: deriving it from activeLayerId would front
+// tabs on every programmatic selection (gallery loads, imports, deletes), and
+// re-clicking the already-active layer — the exact "let me in" gesture — would
+// change nothing and emit nothing.
+
+export type EditorKind = "code" | "pixel";
+
+export type EditorRevealRequest = {
+  kind: EditorKind;
+  /** Creating a layer may reopen a closed editor panel; selecting never does. */
+  open: boolean;
+};
+
+type Listener = (request: EditorRevealRequest) => void;
+
+const listeners = new Set<Listener>();
+
+export function onEditorReveal(listener: Listener): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+export function revealEditor(kind: EditorKind, options?: { open?: boolean }): void {
+  const request: EditorRevealRequest = { kind, open: options?.open ?? false };
+  for (const listener of listeners) listener(request);
+}


### PR DESCRIPTION
Pattern Lab work batched on dev.

**Layers → editor**
- Clicking a layer fronts its editor tab (Code / Pixel); creating or duplicating one also reopens a closed editor panel, while plain selection never resurrects a deliberately closed one. Carried by a small reveal bus (`lib/lab/editorReveal.ts`) rather than state derived from `activeLayerId`, so gallery loads and imports don't yank tabs and re-clicking the active layer still reveals.

**Capture stage**
- Big outputs render the live stage under a pixel cap so it stays fluid — but **only for the looks where that is honest**. The Native look re-runs pattern code on the stage grid, and pixel-unit math draws a *different* picture on a smaller grid, so Native is never reduced: it renders every pixel and the HUD says `exact 100%`. Matrix-rendered looks (Pixel, LED, Auto's fallback) only shrink the blow-up, so their reduced frame is the same picture at fewer pixels (`preview N%`).
- PNG and video exports always render the exact requested size — verified 3840×2160 and 4096×2048 PNGs saved while the stage was capped.

**Capture controls**
- Removed: the Smooth upscale look, the crisp/soft upscale finish (tried, rejected — upscales are nearest-only on purpose now), the `heavy` badge, the fast-preview toggle, and the stage speed select.
- Turn is now ⟲/⟳ buttons with the angle after them, so stepping the angle never shifts the button you're about to click.

Local `npm run build`, `npm run check:capture`, `tsc --noEmit` and eslint all pass; behaviour verified in a browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)