### PR TITLE
fix(ci): type the pfst vector smoke

### DIFF
--- a/web/scripts/pfst-v2-vectors-smoke.ts
+++ b/web/scripts/pfst-v2-vectors-smoke.ts
@@ -6,64 +6,115 @@
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { decodePfst } from "../src/lib/community/performance";
+import { decodePfst, type PerformanceCue } from "../src/lib/community/performance";
 
 // Resolve vectors from THIS file, not the cwd the runner happened to use.
-const VECTORS = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../docs/pfst-v2-vectors");
+const VECTORS = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../../docs/pfst-v2-vectors",
+);
 
-// Executable model of the spec's player rule (docs/pfst-v2-spec.md §3-4).
-function player(timeline: any[], version: number) {
-  const tick = version === 2 ? 0.1 : 1;
-  return (ch: number, now: number) => {
-    let prev: any = null, prevIdx = -1;
-    timeline.forEach((c, i) => { if (c.param?.[ch] != null && c.t <= now) { prev = c; prevIdx = i; } });
-    if (!prev) return null;
-    if (!prev.ease) return prev.param[ch];
-    let next: any = null;
-    for (let j = prevIdx + 1; j < timeline.length; j++) {
-      const c = timeline[j];
-      if (c.param?.[ch] == null) continue;
-      if (c.t > prev.t) next = c;
-      break;                       // first cue touching the channel decides
+/**
+ * Executable model of the spec's player rule (docs/pfst-v2-spec.md §3–4).
+ * Returns the channel's value at a wall-clock time in seconds, or null before
+ * the channel's first cue.
+ */
+function player(timeline: PerformanceCue[]) {
+  return (ch: number, now: number): number | null => {
+    // Last cue at or before `now` that sets this channel. A plain loop, not
+    // forEach: an assignment inside a callback is invisible to TypeScript's
+    // narrowing, which then reads the result as `never`.
+    let from: PerformanceCue | null = null;
+    let prevIdx = -1;
+    for (let i = 0; i < timeline.length; i++) {
+      const cue = timeline[i];
+      if (cue.param?.[ch] != null && cue.t <= now) {
+        from = cue;
+        prevIdx = i;
+      }
     }
-    if (!next) return prev.param[ch];
-    if (now >= next.t) return next.param[ch];
-    const u = (now - prev.t) / (next.t - prev.t);
-    return Math.round(prev.param[ch] + (next.param[ch] - prev.param[ch]) * u);
+    if (!from) return null;
+    const fromValue = from.param![ch]!;
+    if (!from.ease) return fromValue;
+
+    let next: PerformanceCue | null = null;
+    for (let j = prevIdx + 1; j < timeline.length; j++) {
+      const cue = timeline[j];
+      if (cue.param?.[ch] == null) continue;
+      if (cue.t > from.t) next = cue; // a same-t next cue is no segment
+      break; // the first cue that touches the channel decides
+    }
+    if (!next) return fromValue; // no later cue → hold
+    const toValue = next.param![ch]!;
+    if (now >= next.t) return toValue;
+    const u = (now - from.t) / (next.t - from.t);
+    return Math.round(fromValue + (toValue - fromValue) * u);
   };
 }
-let fail = 0;
-const eq = (label: string, got: any, want: any) => {
-  const ok = Math.abs((got ?? -1) - want) <= 1;
-  if (!ok) { console.error(`FAIL ${label}: got ${got}, want ${want}`); fail++; }
-};
 
-const A = decodePfst(new Uint8Array(fs.readFileSync(path.join(VECTORS, "a-ease-ramp.pfs"))));
-const pa = player(A.timeline, A.version);
-console.log("A version", A.version, "length", A.length, "cues", A.timeline.length);
-[[0,0],[0.5,167],[1,333],[1.5,500],[2,667],[2.9,967],[3,1000],[4,1000]].forEach(([t,v]) => eq(`A t=${t}`, pa(0,t as number), v as number));
+let failures = 0;
+function eq(label: string, got: number | null, want: number): void {
+  if (got == null || Math.abs(got - want) > 1) {
+    console.error(`FAIL ${label}: got ${got}, want ${want}`);
+    failures++;
+  }
+}
 
-const B = decodePfst(new Uint8Array(fs.readFileSync(path.join(VECTORS, "b-mixed-moment.pfs"))));
-const pb = player(B.timeline, B.version);
-eq("B ch1 t=1.75 (midpoint)", pb(0,1.75), 500);
-eq("B ch2 t=1.0", pb(1,1.0), 250);
-eq("B ch2 t=2.0 (never interpolates)", pb(1,2.0), 250);
-if (pb(1,0.5) !== null) { console.error("FAIL B ch2 before its first cue should be null"); fail++; }
+function load(file: string) {
+  return decodePfst(new Uint8Array(fs.readFileSync(path.join(VECTORS, file))));
+}
 
-const C = decodePfst(new Uint8Array(fs.readFileSync(path.join(VECTORS, "c-chained.pfs"))));
-const pc = player(C.timeline, C.version);
-eq("C t=1.0 (up leg mid)", pc(0,1.0), 400);
-eq("C t=2.0 (junction exact)", pc(0,2.0), 800);
-eq("C t=3.0 (down leg mid)", pc(0,3.0), 500);
-eq("C t=4.0 (end)", pc(0,4.0), 200);
-eq("C t=5.0 (holds past end)", pc(0,5.0), 200);
+// ── A: one eased ramp, ch1 0 → 1000 over 0.0–3.0 s ──
+const a = load("a-ease-ramp.pfs");
+const pa = player(a.timeline);
+if (a.version !== 2) {
+  console.error(`FAIL vector A should be version 2, got ${a.version}`);
+  failures++;
+}
+const rampTable: [number, number][] = [
+  [0, 0],
+  [0.5, 167],
+  [1, 333],
+  [1.5, 500],
+  [2, 667],
+  [2.9, 967],
+  [3, 1000],
+  [4, 1000],
+];
+for (const [t, want] of rampTable) eq(`A t=${t}`, pa(0, t), want);
 
-// Edge: EASE with no later cue on that channel must hold.
-const hold = player([{t:0,param:[300,null,null,null],ease:true}], 2);
-eq("no-next holds", hold(0, 9), 300);
-// Edge: next cue at the SAME t must not interpolate.
-const samet = player([{t:1,param:[0,null,null,null],ease:true},{t:1,param:[900,null,null,null]}], 2);
-eq("same-t no segment", samet(0, 1), 900);
+// ── B: eased ch1 alongside a hard-cutting ch2 at the same tick ──
+const b = load("b-mixed-moment.pfs");
+const pb = player(b.timeline);
+eq("B ch1 t=1.75 (midpoint)", pb(0, 1.75), 500);
+eq("B ch2 t=1.0", pb(1, 1.0), 250);
+eq("B ch2 t=2.0 (never interpolates)", pb(1, 2.0), 250);
+if (pb(1, 0.5) !== null) {
+  console.error("FAIL B ch2 before its first cue should be null");
+  failures++;
+}
 
-console.log(fail === 0 ? "\nspec vectors OK — all cases match the documented rule" : `\n${fail} MISMATCHES`);
-process.exit(fail ? 1 : 0);
+// ── C: chained eases — a segment's end arms the next ──
+const c = load("c-chained.pfs");
+const pc = player(c.timeline);
+eq("C t=1.0 (up leg mid)", pc(0, 1.0), 400);
+eq("C t=2.0 (junction exact)", pc(0, 2.0), 800);
+eq("C t=3.0 (down leg mid)", pc(0, 3.0), 500);
+eq("C t=4.0 (end)", pc(0, 4.0), 200);
+eq("C t=5.0 (holds past the end)", pc(0, 5.0), 200);
+
+// ── The two edge cases the spec decides in prose ──
+const noNext = player([{ t: 0, param: [300, null, null, null], ease: true }]);
+eq("EASE with no later cue holds", noNext(0, 9), 300);
+
+const sameTick = player([
+  { t: 1, param: [0, null, null, null], ease: true },
+  { t: 1, param: [900, null, null, null] },
+]);
+eq("same-t next cue is no segment", sameTick(0, 1), 900);
+
+if (failures > 0) {
+  console.error(`\n${failures} mismatch(es) — the spec and the vectors disagree`);
+  process.exit(1);
+}
+console.log("pfst v2 vectors OK — every case matches the documented rule");


### PR DESCRIPTION
Lint is the hard CI gate and my new script went in with five `any`s and an unused variable — main went red on #345's merge. Typed against `PerformanceCue`, lookup rewritten as a plain loop (an assignment inside a `forEach` callback is invisible to TS narrowing, which then reads the result as `never`).

Same assertions, same result. Verified locally with exactly what CI runs: `npm run lint` (0 errors), `npm run build`, plus `npm run check:pfstvectors`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)