### PR TITLE
fix(lab): opening someone else's show no longer deletes its pattern switches

### DIFF
--- a/web/scripts/lab-director-smoke.ts
+++ b/web/scripts/lab-director-smoke.ts
@@ -318,4 +318,28 @@ function key(t: number, v: number, mode: "hold" | "curve" = "hold"): DirectorKey
     fail("opening pattern must ride the existing t=0 cue");
   }
   console.log("director smoke OK", { part: "opening-pattern" });
+
+  // -- pattern cues the lab does not author must survive a round trip --
+  // A show from another editor can walk a palette of patterns. The lab has
+  // no UI for that, but opening such a show here and exporting it again
+  // used to delete every switch silently.
+  const palette = emptyShow();
+  palette.length = 30;
+  palette.lanes[0] = [key(0, 200), key(1, 900)];
+  const carried = bakeShowV2(palette, { openingPattern: "Lab Piece" });
+  carried.perf.timeline.push({ t: 1, pattern: "Second" });
+  carried.perf.timeline.push({ t: 2, pattern: "Third" });
+  carried.perf.timeline.sort((a, b) => a.t - b.t);
+  const reopened = showFromPerformance(decodePfst(encodePfst(carried.perf)));
+  const out = bakeShowV2(reopened, { openingPattern: "Lab Piece" });
+  const names = out.perf.timeline.filter((c) => c.pattern).map((c) => c.pattern);
+  if (!names.includes("Second") || !names.includes("Third")) {
+    fail(`pattern switches lost on a lab round trip: ${JSON.stringify(names)}`);
+  }
+  // The lab's own name must not overwrite an imported show's opener.
+  const opener = out.perf.timeline.find((c) => c.t === 0 && c.pattern);
+  if (opener?.pattern !== "Lab Piece") {
+    fail(`imported opener wrong: ${JSON.stringify(opener)}`);
+  }
+  console.log("director smoke OK", { part: "pattern-cue-passthrough", names });
 }

--- a/web/src/lib/lab/director/bake.ts
+++ b/web/src/lib/lab/director/bake.ts
@@ -210,6 +210,9 @@ export function bakeShow(show: DirectorShow): BakedShow {
 export function showFromPerformance(perf: Performance): DirectorShow {
   const lanes: DirectorShow["lanes"] = [[], [], [], []];
   const messages: DirectorShow["messages"] = [];
+  // Pattern switches are not something the lab authors, but they are
+  // something a .pfs can carry. Read them so an export puts them back.
+  const patternCues: NonNullable<DirectorShow["patternCues"]> = [];
   for (const cue of perf.timeline) {
     if (cue.param) {
       for (let i = 0; i < 4; i++) {
@@ -226,6 +229,8 @@ export function showFromPerformance(perf: Performance): DirectorShow {
     }
     if (cue.message)
       messages.push({ id: directorId(), t: snapWireTime(cue.t), text: cue.message });
+    if (cue.pattern)
+      patternCues.push({ id: directorId(), t: snapWireTime(cue.t), name: cue.pattern });
   }
   let lastCue = 0;
   for (const cue of perf.timeline) if (cue.t > lastCue) lastCue = cue.t;
@@ -235,6 +240,7 @@ export function showFromPerformance(perf: Performance): DirectorShow {
     loop: perf.loop,
     lanes,
     messages,
+    patternCues,
   };
 }
 
@@ -398,8 +404,24 @@ export function bakeShowV2(
   }
   timeline.sort((a, b) => a.t - b.t);
 
+  // Pattern switches carried in from another editor go back out unchanged.
+  // The lab cannot author these, but a show that walks a palette must survive
+  // being opened here — dropping them silently deleted somebody's work.
+  for (const carried of show.patternCues ?? []) {
+    const name = carried.name.trim();
+    if (!name) continue;
+    const t = snapV2(Math.max(0, carried.t));
+    const host = timeline.find((cue) => cue.t === t && !cue.ease && !cue.pattern);
+    if (host) host.pattern = name;
+    else timeline.push({ t, pattern: name });
+  }
+  timeline.sort((a, b) => a.t - b.t);
+
   const openingPattern = opts?.openingPattern?.trim();
-  if (openingPattern) {
+  // An imported show already says which pattern it opens with; the lab's own
+  // name must not overwrite somebody else's choice.
+  const hasOwnOpener = timeline.some((cue) => cue.t === 0 && cue.pattern);
+  if (openingPattern && !hasOwnOpener) {
     // Ride the opening cue when one exists (a plain t=0 cue the player fires
     // first); otherwise open with a dedicated pattern-only cue.
     const opener = timeline.find((cue) => cue.t === 0 && !cue.ease);

--- a/web/src/lib/lab/director/types.ts
+++ b/web/src/lib/lab/director/types.ts
@@ -28,6 +28,22 @@ export type DirectorKeyframe = {
   cp: [number, number, number, number];
 };
 
+/**
+ * A pattern switch at a point in time — "at t, show this pattern".
+ *
+ * The lab does not author these: its Director builds a show for the one
+ * pattern on the canvas, and the piece's name goes on the opening cue.
+ * Other editors do author them — a show can walk a whole palette — and the
+ * format has carried them since v1. They are kept here so that opening
+ * such a show in the lab and exporting it again returns the pattern
+ * switches untouched, instead of silently deleting somebody's palette.
+ */
+export type DirectorPatternCue = {
+  id: string;
+  t: number;
+  name: string;
+};
+
 export type DirectorMessage = {
   id: string;
   t: number;
@@ -43,6 +59,12 @@ export type DirectorShow = {
   /** One lane per physical knob, keyframes kept sorted by t. */
   lanes: [DirectorKeyframe[], DirectorKeyframe[], DirectorKeyframe[], DirectorKeyframe[]];
   messages: DirectorMessage[];
+  /**
+   * Pattern switches this show carried in from elsewhere. Never written by
+   * the lab's own editing; passed through on import/export so a
+   * multi-pattern show survives a round trip (see DirectorPatternCue).
+   */
+  patternCues?: DirectorPatternCue[];
 };
 
 /** Gentle ease-in-out — the default shape when a segment turns into a curve. */
@@ -92,5 +114,6 @@ export function cloneShow(show: DirectorShow): DirectorShow {
     loop: show.loop,
     lanes: show.lanes.map((lane) => lane.map((k) => ({ ...k, cp: [...k.cp] }))) as DirectorShow["lanes"],
     messages: show.messages.map((m) => ({ ...m })),
+    patternCues: show.patternCues?.map((c) => ({ ...c })),
   };
 }


### PR DESCRIPTION
A `.pfs` can switch patterns as it plays — a show can walk a whole palette, and the format has carried that since v1. The lab's Director doesn't author them (it builds a show for the one pattern on the canvas, which is a deliberate scope choice), but it was also *deleting* them: `showFromPerformance` ignored `cue.pattern`, so importing a multi-pattern show and exporting it again returned a show with every switch gone, silently.

Pattern cues now ride through untouched. An imported show also keeps its own opening pattern instead of having the lab's piece name stamped over it. `check:director` covers it.

Came out of @SimonePDA's feedback on the lab Director — the format was never the limitation he ran into, but this bug would have destroyed his palette the first time he opened a show here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)