### PR TITLE
Take the variants shelf down

### DIFF
--- a/docs/rfc-core-and-variants.md
+++ b/docs/rfc-core-and-variants.md
@@ -99,7 +99,7 @@ The core is defined by what it **guarantees**, not by what it includes:
 | **Sleep** | Small, safety-adjacent (power/heat); the console needs it. |
 | **Minimal HTTP surface**: `/`, `/patterns`, `/status`, `/wifi`, `/update` + their `/api/*` | What the site, docs and the HA integration's read path assume exists everywhere. |
 | **`POST /api/params`** *(new)* | The capability MQTT was the only carrier of: write the four absolute channels over plain HTTP, one shot per request, same release-on-touch semantics as the bus. This is what lets MQTT leave without any capability leaving with it — HA's knob write moves to it. (The old `/api/knob` was removed as *unused*, not unsafe; the rule against polling this one-connection server stands.) |
-| **`/api/status` reports `variant` + `caps`** *(new)* | `variant`: one human-readable string (`"core"`, `"simone-pd"`, `"radio"`). `caps`: machine-probed feature list (`["shows","mqtt"]`) for the site/lab. Also how the update banner knows not to offer a core bin on top of a variant. |
+| **`/api/status` reports `variant` + `caps`** *(new)* | `variant`: one human-readable string (`"core"`, or whatever a variant calls itself). `caps`: machine-probed feature list (`["shows","mqtt"]`) for the site/lab. Also how the update banner knows not to offer a core bin on top of a variant. |
 
 This table is the whole of "maintaining the frame". It is small, changes
 slowly, and none of it is where creative disagreements live.
@@ -112,11 +112,11 @@ a listed variant, one file drop away.
 
 | leaves | natural home | notes |
 | --- | --- | --- |
-| **Show player** (`core_show*`, `core_show_schedule`, `/show`, night/wake) | Simone's variant | v3.6.3 integrated his stack whole and is the natural fork point — his variant starts *finished*. |
-| **MQTT** (all modes, `/mqtt`) | Simone's variant | Fails the infrastructure test (needs a broker); ~1,500 lines of state machine serving the minority who run one. **Corrected from an earlier draft**, which split this across two variants: FlowLocal is Simone's and the Director lives inside FlowLocal, so the MQTT code goes to him whole. That does not dissolve the IoT variant — bendobos's integration is its own body of work, and where the two meet is for them to agree. Every capability MQTT held stays reachable in core over HTTP, including the knob write via `/api/params`. |
-| **Weather** (`core_weather*`, `/weather`) | Simone's variant | |
+| **Show player** (`core_show*`, `core_show_schedule`, `/show`, night/wake) | a variant — unclaimed | v3.6.3 integrated this whole stack, so v3.6.3 is the natural fork point: a variant starting there starts *finished* rather than empty. Whose variant that is has not been settled, and this table is not the place to decide it. |
+| **MQTT** (all modes, `/mqtt`) | a variant — unclaimed | Fails the infrastructure test (needs a broker); ~1,500 lines of state machine serving the minority who run one. **Corrected from an earlier draft**, which split this across two variants. FlowLocal is Simone Majocchi's work and the Director lives inside FlowLocal, so the MQTT code travels as one piece rather than being parcelled out by mode. That is a fact about the code, not a decision about who maintains it. Every capability MQTT held stays reachable in core over HTTP, including the knob write via `/api/params`. |
+| **Weather** (`core_weather*`, `/weather`) | a variant — unclaimed | |
 | **Audio-react websocket** (`core_audio_ws`, `/audio`) | its own variant (or retired) | OSC stays core; this is only the browser-mic path. |
-| **Home Assistant / IoT** | an IoT variant + the existing HA repo | The integration's *read* path is plain core HTTP and works everywhere; its knob-*write* path moves from MQTT to `/api/params`, so **HA works fully against the bare core**. The MQTT half (publisher role, bridges) follows MQTT into the IoT variant. |
+| **Home Assistant / IoT** | the HA integration moves to its own repo (bendobos, agreed in the thread); the broker-side variant is unclaimed | The integration's *read* path is plain core HTTP and works everywhere; its knob-*write* path moves from MQTT to `/api/params`, so **HA works fully against the bare core**. The MQTT half (publisher role, bridges) follows MQTT into the IoT variant. |
 
 **PFST / `.pfs` splits down the middle, deliberately:** the *format* and
 its authoring stay with the project — [the spec](pfst-v2-spec.md), the
@@ -178,8 +178,8 @@ settings variant is then also an additions-only diff.
 
 **Proof of sufficiency is built into the migration:** the core's own show
 player becomes the first addon. If it ports onto the hooks cleanly, the
-seam is real — and the result doubles as the reference addon `simone-pd`
-starts from.
+seam is real — and the result doubles as the reference any variant
+can start from.
 
 **Deliberately out of reach in v1** (stated up front): the home page's
 PROGMEM cards; new screens in the device's physical UI (the K2 menu is
@@ -284,19 +284,28 @@ Staged, so nobody runs an empty forum:
 
 ## 2.9 The first shelf
 
-Three variants already visible — a good sign the shape is real:
+Empty, and it is worth saying why rather than quietly deleting the list
+that used to be here.
 
-1. **`simone-pd`** — shows, schedule, weather, MQTT (FlowLocal and the
-   Director inside it are his), his fonts.
-   Fork of v3.6.3; day-one finished.
-2. **`iot`** — bendobos's existing IoT integration as its own repo.
-   Not a gap to fill: it is built, and the split asks it to move out.
-   Where it ends and Simone's MQTT begins is for the two of them.
-   *(Owner to ask: @bendobos, who built the HA integration and sleep.)*
-3. **`radio`** — the cartoonmonkeystudio configuration: 8 MHz panel
-   clock, raised TX power, for hostile-Wi-Fi units. The patch the core
-   rightly declined becomes a firmware someone rightly ships. *(Owner to
-   ask: CE.)*
+This section named three variants and, with them, three people who had not
+been asked whether they wanted to maintain a firmware. It read as evidence
+that the shape was already working — "three variants already visible, a
+good sign the shape is real" — when what it actually listed was three
+guesses about how other people would like to spend their time.
+
+That is a bad way to treat a contributor and a worse way to argue for a
+proposal. Naming somebody as the future maintainer of a fork, in public,
+before asking them, makes the decision look already taken and leaves them
+to either accept it or object in front of an audience. The same list went
+up on the site's variants page for a few hours and has come down for the
+same reason.
+
+Anyone this concerns speaks for themselves, in their own words, wherever
+they choose to — not here and not through me.
+
+The seam is real and it is built. Who uses it is not for this document to
+predict.
+
 
 ## 2.10 Known tricky parts
 
@@ -343,16 +352,21 @@ refactors and additive endpoints that improve the tree either way. Steps
    first addon** — sufficiency proof and reference implementation.
 5. Delete the extracted features from core → **4.0.0**. Variants page +
    README table; lab upload buttons capability-probed.
-6. Simone forks v3.6.3 (or adopts the addon port) → `simone-pd`; ask CE
-   about `radio`, bendobos about `iot`.
+6. Somebody forks v3.6.3, or adopts the addon port, and publishes a
+   variant. **This step is the one that cannot be planned from here** —
+   it is other people's time, and step 5 does not happen without it.
+   Asking is the whole of the work; assuming an answer is what an
+   earlier draft of this document did wrong.
 
 ## 2.12 Open questions
 
-1. Simone — does the `simone-pd` shape match what you want to own?
-   Anything in §2.3 you'd rather see stay core?
-2. bendobos — the IoT integration as its own repo: does the `iot` split
-   in §2.3 match how you'd want to carry it? (The HA knob write moves to
-   core HTTP either way, so HA keeps working against a bare core.)
+1. *(asked)* Simone — the show/MQTT/weather stack is yours; is running
+   it as a separate firmware something you would want at all? Anything
+   in §2.3 you would rather see stay in core?
+2. *(answered — yes)* bendobos — the HA integration moves to his own
+   repo, and he reports nothing missing from the hook table for it. The
+   HA knob write is core HTTP either way, so HA works against a bare
+   core with no variant at all.
 3. Anything the hook table (§2.4) misses for what you'd want to build?
    It was derived from the features already integrated — but you know
    your own roadmaps, and hooks are easiest to add *before* they are a

--- a/firmware/patternflow/console/home.html
+++ b/firmware/patternflow/console/home.html
@@ -253,7 +253,7 @@ function sayVariant(s){
     v==='core'?'Patternflow core \u00b7 ':'Variant: '+v+' \u00b7 '));
   var a=document.createElement('a');
   a.href=href;a.target='_blank';a.rel='noopener';
-  a.textContent=v==='core'?'other firmwares':'about this firmware';
+  a.textContent=v==='core'?'variants':'about this firmware';
   el.appendChild(a);
 }
 document.addEventListener('pf-status',function(e){gate(e.detail);sayVariant(e.detail)});

--- a/firmware/patternflow/src/home_index.h
+++ b/firmware/patternflow/src/home_index.h
@@ -284,7 +284,7 @@ function sayVariant(s){
     v==='core'?'Patternflow core \u00b7 ':'Variant: '+v+' \u00b7 '));
   var a=document.createElement('a');
   a.href=href;a.target='_blank';a.rel='noopener';
-  a.textContent=v==='core'?'other firmwares':'about this firmware';
+  a.textContent=v==='core'?'variants':'about this firmware';
   el.appendChild(a);
 }
 document.addEventListener('pf-status',function(e){gate(e.detail);sayVariant(e.detail)});

--- a/web/src/app/variants/page.tsx
+++ b/web/src/app/variants/page.tsx
@@ -25,7 +25,7 @@ import {
 export const metadata: Metadata = {
   title: "Firmware variants / Patternflow",
   description:
-    "Patternflow core is the firmware that has to keep working. A variant adds what not everyone wants — show sequencing, MQTT, radio tuning — and you move between them over Wi-Fi without losing your patterns or settings. Three variants are proposed; none has a maintainer yet.",
+    "Patternflow core is the firmware that has to keep working. A variant adds what not everyone wants, and you move between firmwares over Wi-Fi without losing your patterns or settings. No variants exist yet — this is what one would be, and how to build one.",
   alternates: { canonical: "/variants" },
 };
 
@@ -61,14 +61,17 @@ export default function VariantsPage() {
         </section>
 
         <h2 className={styles.sectionHead}>The shelf</h2>
-        <p className={styles.shelfNote}>
-          <em>Nothing here is downloadable yet.</em> Some of this code exists
-          already and some of it does not; what none of it has is a person who
-          has said yes. Where a name appears below it is a suggestion made in
-          public &mdash; the people best placed to own each one &mdash; and
-          not a commitment any of them has made. If one of them is you, the
-          entry is yours to accept, correct or decline.
-        </p>
+        {VARIANTS.length === 0 ? (
+          <p className={styles.shelfNote}>
+            <em>There are no variants yet.</em> The seam they plug into is
+            built and in the firmware, but nobody has published one, and this
+            page is not going to list firmwares that do not exist or name
+            people who have not agreed to maintain them. When somebody does,
+            they go here. Until then the rest of this page is the useful part:
+            what a variant is, what it has to promise you, and how you would
+            move to one and back.
+          </p>
+        ) : null}
         <ul className={styles.list}>
           {VARIANTS.map((v) => (
             <li key={v.id} id={v.id} className={styles.item}>
@@ -194,9 +197,8 @@ export default function VariantsPage() {
             </a>
             , along with the seam a variant plugs into &mdash; a variant adds
             files, it does not edit core ones, which is what lets it take a
-            core update without a merge fight. To get on this shelf &mdash;
-            or to claim one of the openings above &mdash; open a pull request
-            adding your entry to{" "}
+            core update without a merge fight. To get on this shelf, open a
+            pull request adding your entry to{" "}
             <a
               href="https://github.com/engmung/Patternflow/blob/main/web/src/app/variants/variants-data.ts"
               target="_blank"

--- a/web/src/app/variants/variants-data.ts
+++ b/web/src/app/variants/variants-data.ts
@@ -67,72 +67,19 @@ export const CORE_ALSO =
   'and no variant in between. OSC is core too, for the same reason: it needs ' +
   'nothing but the network already in the room.';
 
-export const VARIANTS: Variant[] = [
-  {
-    id: 'simone-pd',
-    name: 'Performance Director',
-    maintainer: 'Simone Majocchi',
-    maintainerHref: 'https://github.com/SimonePDA',
-    status: 'proposed',
-    summary:
-      'For running a panel as part of a show — timed sequences, a schedule, ' +
-      'and a broker in the middle of several devices.',
-    adds: [
-      'show player (.pfs sequences, playlists)',
-      'night / wake schedule',
-      'MQTT',
-      'weather overlay',
-      'MatrixLight panel fonts',
-    ],
-    source: 'https://github.com/SimonePDA',
-    note:
-      'Nothing to download yet — this is an opening, not an announcement. ' +
-      'Firmware 3.6.3 integrated Simone\u2019s whole stack, which makes that ' +
-      'release the obvious fork point and him the obvious person to ask: a ' +
-      'variant starting from there starts finished rather than empty. He ' +
-      'has not agreed to anything. If it happens, choose it when you run ' +
-      'shows on a schedule or drive several panels from one place; if you ' +
-      'pick a pattern and leave it, core does that with more memory free.',
-  },
-  {
-    id: 'iot',
-    name: 'IoT',
-    status: 'proposed',
-    summary:
-      'For a panel driven over a broker rather than over HTTP \u2014 MQTT for ' +
-      'people who already run one.',
-    adds: [
-      'MQTT publisher and bridge roles, for setups that prefer a broker',
-    ],
-    note:
-      'Read the Home Assistant line above first, because it is probably why ' +
-      'you are here: that integration runs on plain core over HTTP, and ' +
-      'bendobos \u2014 who wrote it \u2014 is moving it into its own repository with ' +
-      'its own documentation. It is an integration, not a firmware, and it ' +
-      'needs no variant. What is left for this entry is narrower: a panel ' +
-      'that should speak MQTT to a broker somebody already runs, without ' +
-      'carrying Simone\u2019s FlowLocal and Director along with it. Nobody has ' +
-      'taken it on, and it may turn out nobody needs to.',
-  },
-  {
-    id: 'radio',
-    name: 'Radio',
-    status: 'proposed',
-    summary:
-      'For units in hostile radio conditions — a warehouse, a venue, a room ' +
-      'full of competing access points.',
-    adds: [
-      '8 MHz panel clock (down from the core default)',
-      'raised Wi-Fi transmit power',
-    ],
-    note:
-      'This adds no features. It re-tunes two numbers that core keeps ' +
-      'conservative on purpose, because the conservative values are the ones ' +
-      'that pass EMC and behave on every unit. Nobody is building it. It is ' +
-      'listed because the request came from a real person with a real room, ' +
-      'core was right to decline it, and that is exactly the disagreement ' +
-      'variants exist to hold — rather than a setting core has to defend to ' +
-      'everyone. Raising transmit power has regulatory consequences, so ' +
-      'whoever builds it owns those too.',
-  },
-];
+// Empty, and that is the honest state.
+//
+// Three entries stood here for a few hours, and every one of them named a
+// person — or left a slot open for one — who had never been asked whether
+// they wanted to maintain a firmware. A shelf of variants nobody had
+// committed to build made the split look further along than it was, and it
+// did that at the expense of people who had not agreed to be on it.
+//
+// Whatever any of them decides is theirs to say, in their own words, in
+// their own time. It does not get written down here first.
+//
+// So: no entries until somebody says yes. The rest of this page describes
+// what a variant IS and how you move between firmwares, which is true today
+// and useful to anyone thinking about building one. Adding a variant back is
+// one object in this array.
+export const VARIANTS: Variant[] = [];


### PR DESCRIPTION
The shelf listed three variants and, with them, three people who had never been asked whether they wanted to maintain a firmware. It went live this morning. It comes down.

Listing it that way made the split look further along than it was, at other people's expense. Naming somebody as the future maintainer of a fork, in public, before asking them, makes the decision look already taken and leaves them to either accept it or object in front of an audience.

**No entries until somebody says yes.**

The page keeps what was actually true: what core is, what a variant would have to promise you, what you keep when you switch, how to build one, and that Home Assistant needs no variant at all. Adding one back is one object in an array.

The RFC gets the same treatment beyond §2.9 — three rows of §2.3 pointed features at a named person's variant as though the destination were settled and now say "a variant — unclaimed"; §2.4, §2.11 step 6 and §2.2's example strings lose the name too. Step 6 now says the part that matters: it is other people's time, step 5 does not happen without it, and asking is the whole of the work.

**What stays.** Part 1 is the maintainer's own words, untouched. FlowLocal is credited to Simone Majocchi in §2.3 because that is a fact about who wrote the code, not a decision about who maintains it. The §2.12 questions stay, marked asked or answered.

Nobody's position is written down here. Whoever it concerns speaks for themselves.

Verified: firmware 1,410,277 B, 0 lint errors, console headers in sync, and no person's name renders on the built page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)