### PR TITLE
Put the firmware on the releases

### DIFF
--- a/.github/scripts/flashing-md.sh
+++ b/.github/scripts/flashing-md.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+#
+# Write the FLASHING.md that ships beside a release's firmware images.
+#
+#   .github/scripts/flashing-md.sh <image-dir> <tag> [date] > FLASHING.md
+#
+# A file rather than a heredoc inside the workflow, for one reason: this can
+# be run locally against a real image directory and read before it is ever
+# published. Shell embedded in YAML cannot.
+set -euo pipefail
+
+DIR="${1:?usage: flashing-md.sh <image-dir> <tag> [date]}"
+TAG="${2:?usage: flashing-md.sh <image-dir> <tag> [date]}"
+DATE="${3:-}"
+
+[ -d "$DIR" ] || { echo "no such directory: $DIR" >&2; exit 1; }
+[ -f "$DIR/patternflow.ino.bin" ] || {
+  echo "no patternflow.ino.bin in $DIR" >&2; exit 1
+}
+
+have() { [ -f "$DIR/$1" ]; }
+
+echo "# Patternflow $TAG"
+echo
+if [ -n "$DATE" ]; then
+  echo "Published $DATE. These are the exact images the browser flasher serves"
+else
+  echo "These are the exact images the browser flasher serves"
+fi
+echo "for this version — the same bytes, not a rebuild."
+echo
+echo "## Over Wi-Fi, if the panel already runs Patternflow"
+echo
+echo 'Open `http://patternflow.local/update` and drop `patternflow.ino.bin` on'
+echo 'it. That is the app image only; the others do not change between releases'
+echo "and are not rewritten."
+echo
+echo "## Over USB"
+echo
+echo '```'
+echo 'esptool.py --chip esp32s3 --baud 921600 write_flash \'
+# Only the parts that exist, and the last one never gets a trailing backslash
+# — a continuation with nothing after it makes the shell swallow whatever the
+# reader types next, and this block exists to be pasted.
+LINES=""
+for pair in "0x0     patternflow.ino.bootloader.bin" \
+            "0x8000  patternflow.ino.partitions.bin" \
+            "0xe000  boot_app0.bin" \
+            "0x10000 patternflow.ino.bin"; do
+  file="${pair##* }"
+  have "$file" && LINES="${LINES}  ${pair}"$'\n'
+done
+printf '%s' "$LINES" | sed '$ !s/$/ \\/'
+echo '```'
+echo
+echo 'Or use the browser flasher at <https://patternflow.work/flash>, which'
+echo "does the same thing with no toolchain."
+echo
+if have boot_app0.bin; then
+  echo '**`boot_app0.bin` at 0xe000 matters more than it looks.** A wireless'
+  echo "update writes the *passive* app slot and flips otadata to it, so a"
+  echo "later USB write to 0x10000 lands in the slot the board is no longer"
+  echo "booting from and appears to do nothing. Writing boot_app0 resets that."
+else
+  echo '**This release predates `boot_app0.bin`.** If the board has ever taken'
+  echo "a wireless update, a USB write to 0x10000 may land in the slot it is no"
+  echo "longer booting from and appear to do nothing. Take boot_app0.bin from a"
+  echo "later release and write it at 0xe000 to reset that."
+fi
+echo
+echo "## What these are"
+echo
+echo "| file | offset | |"
+echo "|---|---|---|"
+have patternflow.ino.bootloader.bin &&
+  echo '| `patternflow.ino.bootloader.bin` | 0x0 | second-stage bootloader |'
+have patternflow.ino.partitions.bin &&
+  echo '| `patternflow.ino.partitions.bin` | 0x8000 | partition table — **never changes between releases**, and a firmware that changes it strands every pattern already on the board |'
+have boot_app0.bin &&
+  echo '| `boot_app0.bin` | 0xe000 | which app slot to boot; comes from the ESP32 core, not a build output |'
+echo '| `patternflow.ino.bin` | 0x10000 | the firmware itself |'
+echo
+echo "## Checksums"
+echo
+echo "If this version is ever re-cut, these are what say so."
+echo
+echo '```'
+( cd "$DIR" && sha256sum ./*.bin | sed 's|\./||' )
+echo '```'

--- a/.github/workflows/firmware-release.yml
+++ b/.github/workflows/firmware-release.yml
@@ -1,0 +1,140 @@
+name: Firmware Release
+
+# Attach the firmware images to a published release.
+#
+# Why this exists: for a long time it did not, and the images only ever lived
+# at patternflow.work/flash/bin/<version>/. From the repository there was no
+# way to get the firmware a given release *was* — you had to know to look at
+# the website. Worse, one version (v3.6.3) was re-cut and overwritten in place
+# when fixes folded in, so the same version name carried two different
+# binaries and nothing recorded which one you had.
+#
+# The images are not built here. Building the sketch needs the ESP32 toolchain
+# and takes minutes; the release process already produces the files and commits
+# them under web/public/flash/bin/<tag>/ for the browser flasher. This workflow
+# takes them from the tag and attaches them, so the release and the website
+# cannot drift apart — they are literally the same bytes.
+#
+# FLASHING.md carries a sha256 for each one. That is the part that makes a
+# version name mean something: if an image is ever re-cut, the hash says so.
+
+on:
+  release:
+    types: [published]
+  # For releases published before this workflow existed, and for a run that
+  # failed.
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to attach images for (e.g. v3.6.3)"
+        required: true
+      # v3.6.3 was built with patternflow_secrets.h present and carries the
+      # maintainer's Wi-Fi credentials. The risk was assessed and accepted — it
+      # needs RF proximity — but the guard below still refuses it, and it
+      # should: an accepted risk is not the same as an invisible one. Ticking
+      # this is how you say "I know about this image", once, per run. It is not
+      # available on the automatic path at all.
+      known_secrets:
+        description: "This image is known to contain build-time credentials — attach it anyway"
+        type: boolean
+        default: false
+
+concurrency:
+  group: firmware-release-${{ github.event.release.tag_name || inputs.tag }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  attach:
+    runs-on: ubuntu-latest
+    env:
+      TAG: ${{ github.event.release.tag_name || inputs.tag }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name || inputs.tag }}
+
+      - name: Check the tag looks like a release
+        run: |
+          [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]] || {
+            echo "::error::'$TAG' is not a vX.Y.Z release tag"
+            exit 1
+          }
+
+      # A release with no images under its own version is not worth failing the
+      # run over — v1/v2-era tags predate this layout, and a prerelease may not
+      # have had a build cut. Say so and stop.
+      - name: Find the images
+        id: find
+        run: |
+          DIR="web/public/flash/bin/$TAG"
+          if [ ! -d "$DIR" ]; then
+            echo "::notice::no images committed at $DIR — nothing to attach"
+            echo "found=0" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "dir=$DIR" >> "$GITHUB_OUTPUT"
+          echo "found=1" >> "$GITHUB_OUTPUT"
+          ls -l "$DIR"
+
+      # The app image is the one part that must be there. The other three are
+      # expected but not universal: releases before v3.2.0 predate the four-part
+      # layout and carry no boot_app0.bin, which is not a build output at all —
+      # it comes from the ESP32 core. Attach what exists and let FLASHING.md
+      # describe exactly that, rather than failing on history.
+      - name: Work out which parts exist
+        if: steps.find.outputs.found == '1'
+        run: |
+          cd "${{ steps.find.outputs.dir }}"
+          [ -f patternflow.ino.bin ] || {
+            echo "::error::patternflow.ino.bin is missing — nothing to publish"
+            exit 1
+          }
+          for f in patternflow.ino.bootloader.bin patternflow.ino.partitions.bin boot_app0.bin; do
+            [ -f "$f" ] || echo "::warning::$f is not in this release"
+          done
+
+      # The one check that cannot be made after the fact. net_config.h bakes
+      # whatever patternflow_secrets.h defines straight into the image, and
+      # three published releases went out carrying the maintainer's home Wi-Fi
+      # credentials because of it. A clean image still has the placeholder in
+      # it; an image built with the secrets file does not.
+      - name: Refuse to publish an image built with secrets
+        if: steps.find.outputs.found == '1'
+        run: |
+          BIN="${{ steps.find.outputs.dir }}/patternflow.ino.bin"
+          if grep -qa YOUR_WIFI_SSID "$BIN"; then
+            echo "placeholder SSID present — built without patternflow_secrets.h"
+          elif [ "${{ inputs.known_secrets }}" = "true" ]; then
+            echo "::warning::$BIN has no placeholder SSID and is being attached"
+            echo "::warning::anyway, because this run said so. It carries whatever"
+            echo "::warning::patternflow_secrets.h defined when it was built."
+          else
+            echo "::error::$BIN has no placeholder SSID. Either it was built with"
+            echo "::error::patternflow_secrets.h present, or the placeholder changed."
+            echo "::error::Do not publish it until you know which."
+            echo "::error::To attach a known-leaky image deliberately, re-run this"
+            echo "::error::workflow by hand with 'This image is known to contain"
+            echo "::error::build-time credentials' ticked."
+            exit 1
+          fi
+
+      # The generator is a script rather than a heredoc so it can be run
+      # against a real image directory and read before anything is published:
+      #   .github/scripts/flashing-md.sh web/public/flash/bin/v3.7.0 v3.7.0
+      - name: Write FLASHING.md
+        if: steps.find.outputs.found == '1'
+        run: |
+          bash .github/scripts/flashing-md.sh             "${{ steps.find.outputs.dir }}" "$TAG" "$(git log -1 --format=%cs HEAD)"             > FLASHING.md
+          cat FLASHING.md
+
+      - name: Attach them to the release
+        if: steps.find.outputs.found == '1'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          DIR="${{ steps.find.outputs.dir }}"
+          gh release upload "$TAG" "$DIR"/*.bin FLASHING.md --clobber
+          echo "attached $(ls "$DIR"/*.bin | wc -l) images and FLASHING.md to $TAG"


### PR DESCRIPTION
Every release from v3.1.0 to v3.6.3 has firmware images committed under `web/public/flash/bin/<tag>/`, and **not one of them is attached to its release.** From this repository there has been no way to get the firmware a release actually *was* — you had to know to look at the website.

Simone raised this from the other end in #349, asking for builds that are dated, packaged and don't move. The packaging half was simply missing.

## What it does

Attaches the images already committed at the tag. It does not build them — the toolchain takes minutes, and the release process already commits exactly these files for the browser flasher, so the release and the website cannot drift apart: they are the same bytes.

`FLASHING.md` ships alongside with the offsets, one pasteable esptool line, the `boot_app0`-at-`0xe000` trap, and a **sha256 per file**. The hashes are the point — `v3.6.3` was re-cut and overwritten in place, so a version name on its own does not identify an image.

## Two things it handles

**Releases before v3.2.0 have no `boot_app0.bin`.** Those get a three-line esptool command with no trailing backslash on the last line, and a paragraph saying where to find the missing part. Verified locally against both layouts.

**The secrets guard.** `net_config.h` bakes whatever `patternflow_secrets.h` defines straight into the image; a clean build still contains the placeholder SSID and a contaminated one does not. Two releases have already gone out carrying the maintainer's home Wi-Fi credentials. **v3.6.3 makes three** — it is refused too, and attaching it needs a hand-run with an explicit "this image is known to contain build-time credentials" tick. The risk was assessed and accepted, but an accepted risk should still be a visible one.

## Testable before it publishes anything

The generator is a script rather than a heredoc inside YAML, so it can be run against a real directory and read:

```bash
.github/scripts/flashing-md.sh web/public/flash/bin/v3.7.0 v3.7.0
```