### PR TITLE
Every addon's per-frame hook was dead

### DIFF
--- a/firmware/patternflow/addons/audio/addon_audio.h
+++ b/firmware/patternflow/addons/audio/addon_audio.h
@@ -54,6 +54,18 @@ inline void fillInput(InputFrame& input) {
 
 inline bool isRuntimeEnabled() { return PatternflowAudio::isRuntimeEnabled(); }
 
+// Whether audio is switched on, and whether anything is connected. Neither
+// was visible from outside the device: a browser could complete a websocket
+// handshake, send knob messages, and have every one of them silently dropped
+// because the AUD row on the NETWORK screen was off — with nothing anywhere
+// saying so. The page reported CONNECTED and the panel did not move.
+inline void appendStatus(String& json) {
+  json += ",\"audioRuntime\":";
+  json += PatternflowAudio::isRuntimeEnabled() ? "true" : "false";
+  json += ",\"audioClients\":";
+  json += PatternflowAudio::clientCount();
+}
+
 inline void setRuntimeEnabled(bool on) {
   PatternflowAudio::setRuntimeEnabled(on);
   Preferences prefs;
@@ -78,7 +90,7 @@ inline const PFAddon descriptor = {
     "AUD",         // shortName - the NETWORK screen row
     isRuntimeEnabled,
     setRuntimeEnabled,
-    nullptr,       // appendStatus
+    appendStatus,
     nullptr,       // drawOverlay
 };
 

--- a/firmware/patternflow/addons/audio/audio_index.h
+++ b/firmware/patternflow/addons/audio/audio_index.h
@@ -140,6 +140,12 @@ let audioCtx = null, analyser = null, sourceNode = null, freqBuf = null;
 let mediaElem = null, mediaStream = null;
 let currentSource = 'file';
 
+// createMediaElementSource() can be called ONCE per media element, ever. A
+// second call on the same <audio> throws InvalidStateError, which is why
+// loading a second file used to kill the page: the first track worked, every
+// one after it silently did nothing. Made once, kept, reconnected.
+let elemSource = null;
+
 function ensureAudio() {
   if (audioCtx) return;
   audioCtx = new (window.AudioContext || window.webkitAudioContext)();
@@ -150,10 +156,20 @@ function ensureAudio() {
 }
 
 function disconnectAll() {
+  // Disconnect, never discard: elemSource is not replaceable.
   try { if (sourceNode) sourceNode.disconnect(); } catch (e) {}
+  try { if (analyser) analyser.disconnect(); } catch (e) {}
   sourceNode = null;
-  if (mediaElem) { mediaElem.pause(); mediaElem.removeAttribute('src'); mediaElem.load(); mediaElem = null; }
+  if (mediaElem) {
+    mediaElem.pause();
+    if (mediaElem.src && mediaElem.src.startsWith('blob:')) URL.revokeObjectURL(mediaElem.src);
+    mediaElem.removeAttribute('src');
+    mediaElem.load();
+    mediaElem = null;
+  }
   if (mediaStream) { mediaStream.getTracks().forEach(t => t.stop()); mediaStream = null; }
+  // A dead source leaves the last levels frozen on screen and in the smoother.
+  smoothing.fill(0);
 }
 
 async function setSource(kind) {
@@ -171,12 +187,18 @@ async function loadFile(file) {
   ensureAudio();
   await audioCtx.resume();
   const audio = document.getElementById('audio-elem');
+  if (mediaElem && mediaElem.src && mediaElem.src.startsWith('blob:')) {
+    URL.revokeObjectURL(mediaElem.src);
+  }
   audio.src = URL.createObjectURL(file);
   audio.load();
   mediaElem = audio;
-  sourceNode = audioCtx.createMediaElementSource(audio);
+  if (!elemSource) elemSource = audioCtx.createMediaElementSource(audio);
+  sourceNode = elemSource;
   sourceNode.connect(analyser);
-  analyser.connect(audioCtx.destination); // file path: play to speakers too
+  // Routing the element through the graph takes it off the speakers, so the
+  // analyser has to hand it back.
+  analyser.connect(audioCtx.destination);
   audio.play().catch(() => {});
   document.getElementById('source-info').textContent = `Loaded: ${file.name}`;
 }
@@ -234,11 +256,20 @@ function bandEnergy(band) {
   const minBin = Math.max(0, hzToBin(band.hzMin));
   const maxBin = Math.min(freqBuf.length - 1, hzToBin(band.hzMax));
   if (maxBin < minBin) return 0;
-  let sum = 0;
-  for (let i = minBin; i <= maxBin; i++) sum += freqBuf[i];
-  const avgDb = sum / (maxBin - minBin + 1);
+  // getFloatFrequencyData returns -Infinity for an empty bin, and one of
+  // those makes the average -Infinity, then NaN once it meets the smoother —
+  // and `SMOOTH_ALPHA * raw + (1 - a) * NaN` is NaN for the rest of the
+  // session. The meters stick and nothing recovers until a reload. Skip them.
+  let sum = 0, n = 0;
+  for (let i = minBin; i <= maxBin; i++) {
+    const v = freqBuf[i];
+    if (Number.isFinite(v)) { sum += v; n++; }
+  }
+  if (!n) return 0;
+  const avgDb = sum / n;
   // Map -80..-10 dB → 0..1 (typical perceptual range)
-  return Math.max(0, Math.min(1, (avgDb + 80) / 70));
+  const x = (avgDb + 80) / 70;
+  return x < 0 ? 0 : x > 1 ? 1 : x;
 }
 
 // ═══ WebSocket ═══
@@ -365,6 +396,7 @@ function tick() {
   for (let i = 0; i < 4; i++) {
     const band = bands[i];
     const raw = bandEnergy(band);
+    if (!Number.isFinite(smoothing[i])) smoothing[i] = 0;
     smoothing[i] = SMOOTH_ALPHA * raw + (1 - SMOOTH_ALPHA) * smoothing[i];
     const mapped = Math.max(0, Math.min(1, band.base + smoothing[i] * band.range));
 

--- a/firmware/patternflow/addons/audio/core_audio_ws.h
+++ b/firmware/patternflow/addons/audio/core_audio_ws.h
@@ -67,7 +67,11 @@ inline float values[4] = { 0.0f, 0.0f, 0.0f, 0.0f };
 inline float pendingDeltas[4] = { 0.0f, 0.0f, 0.0f, 0.0f };
 inline float deltaResidual[4] = { 0.0f, 0.0f, 0.0f, 0.0f };
 inline uint32_t lastUpdateMs[4] = { 0, 0, 0, 0 };
-inline uint32_t connectedClients = 0;
+// Not a counter of our own. A hand-kept one drifts: a client whose TCP dies
+// without a close frame is reaped by the library without WStype_DISCONNECTED
+// ever reaching us, so the count only ever goes up. A panel sitting idle with
+// nothing attached was reporting one connected client. The library already
+// knows the truth - ask it.
 
 inline void setKnobValue(int idx, float value, uint32_t nowMs) {
   values[idx] = value;
@@ -129,17 +133,17 @@ inline void parseMessage(uint8_t* payload, size_t length) {
 inline void onEvent(uint8_t num, WStype_t type, uint8_t* payload, size_t length) {
   switch (type) {
     case WStype_CONNECTED: {
-      connectedClients++;
       IPAddress ip = wsServer.remoteIP(num);
-      Serial.printf("[AUDIO] client %u from %s (%u connected)\n",
-                    num, ip.toString().c_str(), connectedClients);
+      Serial.printf("[AUDIO] client %u from %s (%d connected)\n",
+                    num, ip.toString().c_str(), wsServer.connectedClients());
       break;
     }
     case WStype_DISCONNECTED: {
-      if (connectedClients > 0) connectedClients--;
-      if (connectedClients == 0) releaseAllKnobs();
-      Serial.printf("[AUDIO] client %u disconnected (%u connected)\n",
-                    num, connectedClients);
+      // connectedClients() still counts this one - the library frees the slot
+      // after the callback returns.
+      if (wsServer.connectedClients() <= 1) releaseAllKnobs();
+      Serial.printf("[AUDIO] client %u disconnected (%d connected)\n",
+                    num, wsServer.connectedClients() - 1);
       break;
     }
     case WStype_TEXT:
@@ -202,7 +206,9 @@ inline int consumeKnobDelta(int idx) {
 
 inline uint32_t clientCount() {
 #if PF_AUDIO_ENABLED
-  return connectedClients;
+  if (!initialized) return 0;
+  int n = wsServer.connectedClients();
+  return n > 0 ? (uint32_t)n : 0;
 #else
   return 0;
 #endif

--- a/firmware/patternflow/console/audio.html
+++ b/firmware/patternflow/console/audio.html
@@ -117,6 +117,12 @@ let audioCtx = null, analyser = null, sourceNode = null, freqBuf = null;
 let mediaElem = null, mediaStream = null;
 let currentSource = 'file';
 
+// createMediaElementSource() can be called ONCE per media element, ever. A
+// second call on the same <audio> throws InvalidStateError, which is why
+// loading a second file used to kill the page: the first track worked, every
+// one after it silently did nothing. Made once, kept, reconnected.
+let elemSource = null;
+
 function ensureAudio() {
   if (audioCtx) return;
   audioCtx = new (window.AudioContext || window.webkitAudioContext)();
@@ -127,10 +133,20 @@ function ensureAudio() {
 }
 
 function disconnectAll() {
+  // Disconnect, never discard: elemSource is not replaceable.
   try { if (sourceNode) sourceNode.disconnect(); } catch (e) {}
+  try { if (analyser) analyser.disconnect(); } catch (e) {}
   sourceNode = null;
-  if (mediaElem) { mediaElem.pause(); mediaElem.removeAttribute('src'); mediaElem.load(); mediaElem = null; }
+  if (mediaElem) {
+    mediaElem.pause();
+    if (mediaElem.src && mediaElem.src.startsWith('blob:')) URL.revokeObjectURL(mediaElem.src);
+    mediaElem.removeAttribute('src');
+    mediaElem.load();
+    mediaElem = null;
+  }
   if (mediaStream) { mediaStream.getTracks().forEach(t => t.stop()); mediaStream = null; }
+  // A dead source leaves the last levels frozen on screen and in the smoother.
+  smoothing.fill(0);
 }
 
 async function setSource(kind) {
@@ -148,12 +164,18 @@ async function loadFile(file) {
   ensureAudio();
   await audioCtx.resume();
   const audio = document.getElementById('audio-elem');
+  if (mediaElem && mediaElem.src && mediaElem.src.startsWith('blob:')) {
+    URL.revokeObjectURL(mediaElem.src);
+  }
   audio.src = URL.createObjectURL(file);
   audio.load();
   mediaElem = audio;
-  sourceNode = audioCtx.createMediaElementSource(audio);
+  if (!elemSource) elemSource = audioCtx.createMediaElementSource(audio);
+  sourceNode = elemSource;
   sourceNode.connect(analyser);
-  analyser.connect(audioCtx.destination); // file path: play to speakers too
+  // Routing the element through the graph takes it off the speakers, so the
+  // analyser has to hand it back.
+  analyser.connect(audioCtx.destination);
   audio.play().catch(() => {});
   document.getElementById('source-info').textContent = `Loaded: ${file.name}`;
 }
@@ -211,11 +233,20 @@ function bandEnergy(band) {
   const minBin = Math.max(0, hzToBin(band.hzMin));
   const maxBin = Math.min(freqBuf.length - 1, hzToBin(band.hzMax));
   if (maxBin < minBin) return 0;
-  let sum = 0;
-  for (let i = minBin; i <= maxBin; i++) sum += freqBuf[i];
-  const avgDb = sum / (maxBin - minBin + 1);
+  // getFloatFrequencyData returns -Infinity for an empty bin, and one of
+  // those makes the average -Infinity, then NaN once it meets the smoother —
+  // and `SMOOTH_ALPHA * raw + (1 - a) * NaN` is NaN for the rest of the
+  // session. The meters stick and nothing recovers until a reload. Skip them.
+  let sum = 0, n = 0;
+  for (let i = minBin; i <= maxBin; i++) {
+    const v = freqBuf[i];
+    if (Number.isFinite(v)) { sum += v; n++; }
+  }
+  if (!n) return 0;
+  const avgDb = sum / n;
   // Map -80..-10 dB → 0..1 (typical perceptual range)
-  return Math.max(0, Math.min(1, (avgDb + 80) / 70));
+  const x = (avgDb + 80) / 70;
+  return x < 0 ? 0 : x > 1 ? 1 : x;
 }
 
 // ═══ WebSocket ═══
@@ -342,6 +373,7 @@ function tick() {
   for (let i = 0; i < 4; i++) {
     const band = bands[i];
     const raw = bandEnergy(band);
+    if (!Number.isFinite(smoothing[i])) smoothing[i] = 0;
     smoothing[i] = SMOOTH_ALPHA * raw + (1 - SMOOTH_ALPHA) * smoothing[i];
     const mapped = Math.max(0, Math.min(1, band.base + smoothing[i] * band.range));
 

--- a/firmware/patternflow/patternflow.ino
+++ b/firmware/patternflow/patternflow.ino
@@ -962,16 +962,13 @@ void loop() {
   // starve the upload handler. Cheap when no upload is in flight.
   PatternflowOta::handle();
 
-  // Service the audio-react HTTP/WebSocket servers in the main loop
-  // (single-threaded — no separate core-0 task). Cheap when idle.
+  // The console's HTTP server. Addon-owned servers (the audio websocket on
+  // :81) are serviced by PFAddons::loop below, not here.
   PatternflowHttp::handle();
 
   // Deferred module-list rebuilds requested by uploads/deletes — run here,
   // outside any HTTP transaction.
   PatternflowPatternsHttp::tick();
-
-  // MQTT keepalive + inbound delivery. Reconnects are paced internally, so
-  // an unreachable broker costs one comparison per loop, not a stall.
 
   // Browser self-update housekeeping: boot-valid marking and the deferred
   // post-flash reboot. (Upload traffic itself arrives through the shared
@@ -982,6 +979,25 @@ void loop() {
   float dt = (now - lastMs) / 1000.0f;
   lastMs = now;
   const uint32_t frameStartedUs = micros();
+
+  // Every addon's per-frame hook: the MQTT keepalive, the show player's tick,
+  // the weather scheduler, the audio websocket's accept/handshake pump, the
+  // on-board FFT.
+  //
+  // **This was missing.** The addon port removed the concrete calls that used
+  // to live above — correctly, they belong to the addons now — and never
+  // added the dispatcher that replaced them, leaving two orphaned comments
+  // where the calls had been. Nothing failed loudly: `begin()` still ran, so
+  // :81 accepted TCP and every route answered; the websocket simply never
+  // completed a handshake because nobody was pumping it, and MQTT never
+  // reconnected. The addons were all present, all initialised, and all
+  // frozen. Ahead of the render so a slow pattern cannot starve a socket.
+  {
+    PFAddonFrame frame{dt, currentContentName(),
+                       currentMode == MODE_RUNNING, chromeVisible(),
+                       currentPatternIdx, (int)currentMode};
+    PFAddons::loop(frame);
+  }
 
   InputFrame input;
   readInputFrame(input);


### PR DESCRIPTION
`PFAddons::loop()` is not called anywhere in the tree, and never has been.

The addon port moved the per-frame work out of the sketch — correctly — and removed the concrete calls that did it. It never added the dispatcher that replaced them, leaving two orphaned comments where the calls had been.

| tag | `Audio::handle` | `Mqtt::loop` | `Show` | `PFAddons::loop` |
|---|---|---|---|---|
| v3.5.1 | ✅ | ✅ | — | — |
| v3.6.3 | ✅ | ✅ | ✅ | — |
| **v3.7.0** | ❌ | ❌ | ❌ | ❌ |

**v3.7.0 is the first release with this.** Shows do not tick, MQTT never pumps, weather never fetches, and the audio websocket never completes a handshake.

Nothing failed loudly: `onNetwork` still ran, so routes registered and port 81 opened. TCP connects. The console page loads and says DISCONNECTED forever. Every addon was present, initialised, and frozen.

On-board audio was unaffected — `audio_in` runs on a Core 0 task, not the loop hook — which is why this read as an audio-page problem rather than a seam problem.

Verified on hardware (audio bundle, v3.7.0): raw websocket handshake was an 8 s timeout before, `HTTP/1.1 101 Switching Protocols` after. 61.4 fps, unchanged.

Also in here: `/api/status` gains `audioRuntime` and `audioClients` (whether audio was even switched on was invisible from outside the device), the file picker on the audio page worked exactly once per load, one empty FFT bin froze the meters for the session, and the connected-client counter only ever went up.