### PR TITLE
core: the boundary grows teeth, and bites on its first day

### DIFF
--- a/.github/workflows/firmware-checks.yml
+++ b/.github/workflows/firmware-checks.yml
@@ -1,0 +1,51 @@
+name: Core knows no features
+
+# Two fast source-level checks on every firmware change:
+#
+#   check_boundaries.py — the core/feature boundary, mechanically. The rule
+#   ("the core names no feature") lived in comments and was violated three
+#   times before it grew teeth; on its first run the checker also found a
+#   fourth (the sketch comparing a pattern name against the show scheduler's
+#   "Black"). Prose does not hold; a failing build does.
+#
+#   check_sources.py — mangled string literals and raw control bytes, the
+#   patch-script damage that compiles into garbage or reports its error
+#   thirty lines from the cause.
+#
+# Neither needs a toolchain, so both finish in seconds. The three-edition
+# compile stays local (`firmware/bundles/build.sh all`) — the ~80 s xtensa
+# build per edition is not worth a runner on every push, and the boundary
+# violations that break only one edition are exactly what these greps catch
+# before the compiler would.
+on:
+  pull_request:
+    paths:
+      - "firmware/patternflow/**"
+      - "firmware/toolchain/check_boundaries.py"
+      - "firmware/toolchain/check_sources.py"
+      - ".github/workflows/firmware-checks.yml"
+  push:
+    branches: [main]
+    paths:
+      - "firmware/patternflow/**"
+      - "firmware/toolchain/check_boundaries.py"
+      - "firmware/toolchain/check_sources.py"
+
+concurrency:
+  group: firmware-checks-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+      - name: The core names no feature
+        run: python firmware/toolchain/check_boundaries.py
+      - name: No mangled literals or raw control bytes
+        run: python firmware/toolchain/check_sources.py

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,8 +25,8 @@ Patternflow is an open-source hardware instrument: four rotary encoders controll
 ## Common commands
 - Web dev server: `npm run dev` (inside the `web/` directory)
 - Web production build: `npm run build` (inside the `web/` directory)
-- Firmware compilation: `./firmware/bundles/build.sh` (PlatformIO, bundled toolchain — not the Arduino IDE). That builds the default: the device with no features. Named editions are `./firmware/bundles/build.sh audio` and `./firmware/bundles/build.sh performance`.
-- **Changing anything in the firmware core means building all three.** A hook change that compiles against the default is not tested — the default has no addons to break.
+- Firmware compilation: `./firmware/bundles/build.sh` (PlatformIO, bundled toolchain — not the Arduino IDE). That builds the default: the device with no features. Named editions are `./firmware/bundles/build.sh audio` and `./firmware/bundles/build.sh performance`. `./firmware/bundles/build.sh all` builds every composition and scans each binary for per-feature marker strings, proving each image carries exactly its features — run it before pushing anything that touches firmware.
+- **Changing anything in the firmware core means building all three** — `build.sh all` is that rule as one command. A hook change that compiles against the default is not tested; the default has no addons to break. The boundary rule itself is enforced by `firmware/toolchain/check_boundaries.py` in CI: core referencing a feature namespace, including from `addons/`, or branching on a feature flag fails the build.
 - KiCad exports: Export Gerbers from `hardware/pcb/kicad/patternflow.kicad_pcb`. Export STLs from `hardware/case/source/patternflow_case.blend`.
 
 ## Versioning

--- a/docs/EDITIONS.md
+++ b/docs/EDITIONS.md
@@ -251,7 +251,24 @@ Then:
 ```bash
 ./firmware/bundles/build.sh audio            # build it
 ./firmware/bundles/build.sh audio flash pf.local   # and push it to a panel
+./firmware/bundles/build.sh all              # every composition, proven
 ```
+
+`all` builds default, audio and performance, then scans each binary for one
+marker string per feature — a literal that lives only in that feature's
+sources. An edition must contain its own features' markers and none of the
+others'. That is the composition checked in the shipped bytes: `addons.h`
+catches a misspelled macro, this catches the right macro building the wrong
+thing. Run it before pushing anything that touches the core; it is the rule
+"a core change is tested against every composition" as one command.
+
+The boundary itself is mechanical too: `firmware/toolchain/check_boundaries.py`
+(run in CI on every firmware change) fails the build if a core file references
+a feature namespace, includes from the feature tree, or branches on a
+feature's flags. The rule lived in comments first and was violated three times
+before it grew teeth; on its first run the checker found a fourth, so the
+lesson is written down here: **a rule an agent must remember is a rule that
+will drift — put it where the build fails.**
 
 `overrides.h` is included before any default in `config.h`, so it reaches every
 `#ifndef`-guarded setting in the tree — panel clock, transmit power, brightness

--- a/firmware/bundles/README.md
+++ b/firmware/bundles/README.md
@@ -17,13 +17,21 @@ bundles/audio/
   overrides.h       what it calls itself, and any setting it changes
 ```
 
-That is the whole of it. The default build — what ships on the board — needs
-no bundle at all, because it is simply everything.
+That is the whole of it. The default build needs no bundle at all — and it
+is the opposite of everything: the device and nothing else. Every feature
+lives in an edition built from these two files.
 
 ```bash
-./firmware/bundles/build.sh          # the default: everything
+./firmware/bundles/build.sh          # the default: no features
 ./firmware/bundles/build.sh audio    # the audio bundle
 ./firmware/bundles/build.sh audio flash patternflow.local
+./firmware/bundles/build.sh all      # every composition + the marker scan
+                                     # proving each binary carries exactly
+                                     # its features
+./firmware/bundles/shelf.sh audio v0.4.0   # a publishable image: secrets
+                                     # moved aside, scanner proven against a
+                                     # control build, four files staged for
+                                     # the shelf
 ```
 
 ## When a bundle is worth making

--- a/firmware/bundles/audio/overrides.h
+++ b/firmware/bundles/audio/overrides.h
@@ -56,9 +56,3 @@
 // both yield to a hand on the encoder.
 #define PF_AUDIO_IN_DRIVES_KNOBS 1
 
-// ── No presets from addons this firmware does not have ──────────────────
-//
-// Core defaults this to the show player's Black pattern. There is no show
-// player here, so an empty definition: a panel running this should not carry
-// a pattern belonging to a feature it does not have.
-#define PF_ADDON_PRESETS

--- a/firmware/bundles/build.sh
+++ b/firmware/bundles/build.sh
@@ -5,6 +5,10 @@
 #   ./build.sh                       the default — no features
 #   ./build.sh audio                 the audio bundle
 #   ./build.sh audio flash <host>    build it, then push it to a panel
+#   ./build.sh all                   every composition + a marker scan
+#                                    proving each binary carries exactly
+#                                    its features — run this before pushing
+#                                    anything that touches the core
 #
 # A bundle is two files. This copies them next to the addon list, builds, and
 # takes them away again — the tree is left exactly as it was found, so the
@@ -17,6 +21,75 @@ ADDONS="$SKETCH/addons"
 # xtensa's linker cannot open output files under a path with non-ASCII in it,
 # and this repository lives under one. The build tree goes somewhere plain.
 BUILD_DIR="${PF_BUILD_DIR:-$HOME/pf-build}"
+
+# ── all: every composition, and proof each binary carries exactly its
+# features ────────────────────────────────────────────────────────────────
+#
+# "Changing the core means building all three" was a rule in prose, and a
+# rule in prose gets one of the three. This is that rule as one command:
+#
+#   ./firmware/bundles/build.sh all
+#
+# It builds default, audio and performance, then scans each image for one
+# marker string per feature — a literal that lives only in that feature's
+# sources, verified by grep before it was trusted here. An edition must
+# contain its own features' markers and NONE of the others'. That checks the
+# composition in the shipped bytes, where addons.h's #error guard cannot see:
+# the guard catches a misspelled macro, this catches the right macro building
+# the wrong thing. It is how the NETWORK screen fix was proven — "OSC / AUD"
+# absent from the default image because the compiler folded the branch away —
+# done every time instead of once by hand.
+if [ "${1:-}" = "all" ]; then
+  declare -A MARK=(
+    [osc]='/patternflow/knob'
+    [audio]='[AUDIO] Ready'
+    [audio_in]='PDM up: CLK'
+    [mqtt]='[MQTT] '
+    [show]='[SHOW] '
+    [weather]='openweathermap'
+  )
+  declare -A WANT=(
+    [default]=''
+    [audio]='osc audio audio_in'
+    [performance]='mqtt show weather'
+  )
+  # Outside PF_BUILD_DIR: PlatformIO prunes directories it does not know
+  # from its own build root, and it does not know this one.
+  OUTDIR="${BUILD_DIR}-editions"
+  mkdir -p "$OUTDIR"
+  overall=0
+  for ed in default audio performance; do
+    printf '%-12s building… ' "$ed"
+    t0=$(date +%s)
+    log="$OUTDIR/$ed.log"
+    if [ "$ed" = default ]; then ok=0; "$0" >"$log" 2>&1 || ok=$?
+    else ok=0; "$0" "$ed" >"$log" 2>&1 || ok=$?; fi
+    if [ "$ok" != 0 ]; then
+      echo "build FAILED — last lines of $log:"
+      tail -15 "$log"
+      exit 1
+    fi
+    cp "$BUILD_DIR/firmware/firmware.bin" "$OUTDIR/$ed.bin"
+    verdict=ok
+    detail=""
+    for f in osc audio audio_in mqtt show weather; do
+      case " ${WANT[$ed]} " in *" $f "*) want=1 ;; *) want=0 ;; esac
+      if grep -qaF -- "${MARK[$f]}" "$OUTDIR/$ed.bin"; then have=1; else have=0; fi
+      if [ "$want" != "$have" ]; then
+        verdict=FAIL
+        overall=1
+        if [ "$want" = 1 ]; then detail="$detail missing:$f"; else detail="$detail carries:$f"; fi
+      fi
+    done
+    printf '%3ss  %8s bytes  %s%s\n' "$(( $(date +%s) - t0 ))" \
+      "$(stat -c%s "$OUTDIR/$ed.bin")" "$verdict" "$detail"
+  done
+  if [ "$overall" != 0 ]; then
+    echo ""
+    echo "a binary does not match its composition — do not flash or publish these" >&2
+  fi
+  exit $overall
+fi
 
 BUNDLE="${1:-}"
 if [ -n "$BUNDLE" ] && [ "$BUNDLE" != "flash" ]; then

--- a/firmware/bundles/performance/overrides.h
+++ b/firmware/bundles/performance/overrides.h
@@ -17,13 +17,15 @@
 #define PF_VARIANT          "performance"
 #define PF_VARIANT_VERSION  "v0.2.1"
 
-// PF_ADDON_PRESETS is deliberately NOT defined here. Defining it as nothing
-// is how a build with no show player keeps the show player's hidden Black
-// pattern out of the carousel — but this edition HAS the show player, and its
-// night/wake scheduler switches to Black by name. Emptying it here does not
-// hide a pattern, it removes one the scheduler needs, and the build fails on
-// `'Black' has not been declared`. Inherited from a copy of the audio
-// overrides, where it was correct.
+// ── The show player's night face ────────────────────────────────────────
+//
+// The night/wake scheduler switches to Black by name, so this edition ships
+// it (addons_local.h includes the header; this names the entry). Hidden,
+// because the panel going dark is not something to land on while turning K4
+// through the list. The bare core defines PF_ADDON_PRESETS empty - a preset
+// rides with the composition that needs it, never with the default.
+#define PF_ADDON_PRESET_INCLUDE "show/preset_black.h"
+#define PF_ADDON_PRESETS PATTERN_ENTRY_HIDDEN(Black),
 
 // Nothing else is changed. The radio stays at the conformance-tested setting,
 // and a panel switching to this edition keeps its Wi-Fi, its brightness and

--- a/firmware/patternflow/abi/pf_abi.h
+++ b/firmware/patternflow/abi/pf_abi.h
@@ -47,6 +47,14 @@ typedef struct PFInputFrame {
   bool btnPressed[4];
   bool btnHeld[4];
   uint32_t now;
+  // THE NAME IS A FOSSIL AND IT IS FROZEN. These are the generic LANES: an
+  // absolute continuous reading, 0..1, that any source can put on a knob -
+  // weather drives them from a temperature, the Chrome extension from a
+  // browser tab, the microphone from the room. "Audio" is only who got here
+  // first. Do not rename them: this struct is the ABI that compiled .pfm
+  // modules read, so the name is frozen the way a wire format is - a rename
+  // is a silent field-offset change inside every module already installed
+  // on somebody's panel.
   bool knobAudioActive[4];
   float knobAudioValue[4];
   // Absolute bus 0..1000 (Director / Show manager). Appended — older

--- a/firmware/patternflow/addons/README.md
+++ b/firmware/patternflow/addons/README.md
@@ -93,6 +93,7 @@ each row says which port proved it.
 | `onSleep(bool)` | the panel slept or woke | MQTT state publishing |
 | `requestSleep(&bool)` | "sleep / wake the device, please" — again a request | MQTT sleep topic |
 | `shortName` + `isRuntimeEnabled()` + `setRuntimeEnabled(bool)` | the device's own NETWORK screen lists and toggles this addon | audio |
+| `navPath` + `navLabel` + `navDesc` | the console header links the page, and the home screen gives it a row with that one-line description — the core never learns the path | /show, /mqtt, /weather, /audio-in |
 | `appendStatus(String&)` | append `,"key":value` fields to `/api/status` | MQTT role/state |
 | `drawOverlay(frame)` | after the pattern draws, before present | scheduler clock, weather clock |
 
@@ -141,6 +142,9 @@ inline const PFAddon descriptor = {
     nullptr,       // setRuntimeEnabled
     nullptr,       // appendStatus
     drawOverlay,
+    "/yourthing",  // navPath - the console header link, or nullptr
+    "Yourthing",   // navLabel
+    "One line for the home screen's row.",   // navDesc
 };
 ```
 

--- a/firmware/patternflow/addons/addon_presets.h
+++ b/firmware/patternflow/addons/addon_presets.h
@@ -15,20 +15,33 @@
 // ═══════════════════════════════════════════════════════════
 #pragma once
 
-// A variant may define PF_ADDON_PRESETS in its overrides.h — including as
-// nothing at all — and the defaults below then do not apply. Without that
-// escape a build with no show player still carried the show player's
-// pattern, which is exactly the kind of thing nobody can explain later.
+// The default is EMPTY. It used to be the other way round: this file
+// included the show player's Black pattern unless a composition opted out,
+// so the bare core - a build with no show player at all - carried one
+// feature's pattern, and the audio edition needed an empty define to be rid
+// of it. This file's own comment called that "exactly the kind of thing
+// nobody can explain later" and then recreated it as the default.
+//
+// Now a composition that carries a preset says so in overrides.h, twice:
+//
+//   #define PF_ADDON_PRESET_INCLUDE "show/preset_black.h"
+//   #define PF_ADDON_PRESETS PATTERN_ENTRY_HIDDEN(Black),
+//
+// The include is taken HERE, not in addons_local.h, and the placement is
+// load-bearing: pattern_registry.h reaches this file immediately before it
+// expands PF_ADDON_PRESETS, and the registry's first parse happens wherever
+// some core header pulls it in - which is before the composition's own
+// includes run. An include anywhere else declares the namespace after the
+// one expansion that needed it (that build failure is how this comment got
+// written). One include; a composition with several presets points this at
+// a wrapper header of its own.
+//
+// Entries expand inside presetPatterns[] in pattern_registry.h; keep the
+// trailing comma on every entry.
+#ifdef PF_ADDON_PRESET_INCLUDE
+#include PF_ADDON_PRESET_INCLUDE
+#endif
+
 #ifndef PF_ADDON_PRESETS
-
-#include "show/preset_black.h"
-
-// Expanded inside presetPatterns[] in pattern_registry.h. Keep the trailing
-// comma on every entry; an empty definition is fine.
-// Black is hidden: the scheduler switches to it by name, and it is the
-// panel going dark rather than something anyone wants to land on while
-// turning K4 through the pattern list.
-#define PF_ADDON_PRESETS \
-  PATTERN_ENTRY_HIDDEN(Black),
-
+#define PF_ADDON_PRESETS
 #endif

--- a/firmware/patternflow/addons/audio/addon_audio.h
+++ b/firmware/patternflow/addons/audio/addon_audio.h
@@ -100,6 +100,7 @@ inline const PFAddon descriptor = {
     nullptr,       // drawOverlay
     nullptr,       // navPath - no console page
     nullptr,       // navLabel
+    nullptr,       // navDesc
 };
 
 }  // namespace PFAddonAudio

--- a/firmware/patternflow/addons/audio_in/addon_audio_in.h
+++ b/firmware/patternflow/addons/audio_in/addon_audio_in.h
@@ -220,6 +220,8 @@ inline const PFAddon descriptor = {
     nullptr,       // drawOverlay
     "/audio-in",   // navPath - the console header link
     "Mic",         // navLabel
+    "The panel hears the room — a live spectrum, and four bands you "
+    "shape into the knobs.",
 };
 
 }  // namespace PFAddonAudioIn

--- a/firmware/patternflow/addons/mqtt/addon_mqtt.h
+++ b/firmware/patternflow/addons/mqtt/addon_mqtt.h
@@ -117,6 +117,7 @@ inline const PFAddon descriptor = {
     nullptr,       // drawOverlay
     "/mqtt",       // navPath - the console header link
     "MQTT",        // navLabel
+    "Mirror one panel onto another, or hand the knobs to home automation.",
 };
 
 }  // namespace PFAddonMqtt

--- a/firmware/patternflow/addons/osc/addon_osc.h
+++ b/firmware/patternflow/addons/osc/addon_osc.h
@@ -102,6 +102,7 @@ inline const PFAddon descriptor = {
     nullptr,       // drawOverlay
     nullptr,       // navPath - no console page
     nullptr,       // navLabel
+    nullptr,       // navDesc
 };
 
 }  // namespace PFAddonOsc

--- a/firmware/patternflow/addons/pf_addon.h
+++ b/firmware/patternflow/addons/pf_addon.h
@@ -134,4 +134,14 @@ struct PFAddon {
   // fourth was the moment to stop. Null on both means no nav entry.
   const char* navPath;
   const char* navLabel;
+
+  // One plain-text line for the console home page's row under that label.
+  // This is the last thing the core used to know about features by name: the
+  // home page carried a hand-written row for /show, /mqtt and /weather -
+  // gated on caps so it degraded, but written into a core page all the same,
+  // which is how the Audio edition's Mic page ended up with a header link
+  // and no home row. Now the row travels with the feature.
+  //
+  // Plain text, no quotes - it rides inside /api/status JSON unescaped.
+  const char* navDesc;
 };

--- a/firmware/patternflow/addons/pf_addons.h
+++ b/firmware/patternflow/addons/pf_addons.h
@@ -168,6 +168,8 @@ inline void emitNav(String& json) {
     json += PF_ADDONS[i]->navPath;
     json += "\",\"";
     json += PF_ADDONS[i]->navLabel;
+    json += "\",\"";
+    if (PF_ADDONS[i]->navDesc) json += PF_ADDONS[i]->navDesc;
     json += "\"]";
   }
 }

--- a/firmware/patternflow/addons/show/addon_show.h
+++ b/firmware/patternflow/addons/show/addon_show.h
@@ -88,6 +88,8 @@ inline const PFAddon descriptor = {
     drawOverlay,
     "/show",       // navPath - the console header link
     "Sequences",   // navLabel
+    "Timed shows from .pfs tables — play one, chain a playlist, "
+    "schedule night and wake.",
 };
 
 }  // namespace PFAddonShow

--- a/firmware/patternflow/addons/weather/addon_weather.h
+++ b/firmware/patternflow/addons/weather/addon_weather.h
@@ -98,6 +98,8 @@ inline const PFAddon descriptor = {
     drawOverlay,
     "/weather",    // navPath - the console header link
     "Weather",     // navLabel
+    "Clock, timezone and local readings — can drive the knobs from "
+    "the sky outside.",
 };
 
 }  // namespace PFAddonWeather

--- a/firmware/patternflow/console/home.html
+++ b/firmware/patternflow/console/home.html
@@ -140,7 +140,6 @@
       <div class="stat"><span class="k">Wi-Fi</span><div class="v" id="s-wifi">&mdash;</div></div>
       <div class="stat"><span class="k">Address</span><div class="v" id="s-ip">&mdash;</div></div>
       <div class="stat"><span class="k">Memory</span><div class="v" id="s-heap">&mdash;</div></div>
-      <div class="stat" data-cap="mqtt"><span class="k">MQTT</span><div class="v" id="s-mqtt">&mdash;</div></div>
       <div class="stat"><span class="k">Uptime</span><div class="v" id="s-up">&mdash;</div></div>
       <div class="stat"><span class="k">Firmware</span><div class="v" id="s-fw">&mdash;</div></div>
       <!-- Which edition this panel is running. It was a line of small print in
@@ -174,12 +173,18 @@
       <div class="pf-row-t">Pattern library</div>
       <div class="pf-row-d">Drop in a <b>.pfm</b> module or a whole <b>.zip</b> pack &mdash; play, arrange, delete.</div>
     </a>
-    <a class="pf-row" href="/show" data-cap="shows">
-      <span class="pf-ghost">02</span>
-      <div class="pf-row-t">Sequences</div>
-      <div class="pf-row-d">Timed shows from <b>.pfs</b> tables &mdash; play one, chain a playlist, schedule night and wake.</div>
-    </a>
   </nav>
+
+  <!-- Whatever features this firmware carries, one row each. The rows are
+       not written into this page: they arrive from /api/status addonNav,
+       contributed by the loaded addons, so a page the core has never heard
+       of still gets a row and a build with none gets no group. This page
+       used to hand-write rows for /show, /mqtt and /weather - capability-
+       gated, so they degraded, but named in a core page all the same, and
+       the first addon page the list did not know about proved the point by
+       having no row at all. -->
+  <span class="pf-kicker" id="featKick" hidden>Features</span>
+  <nav id="featRows" hidden></nav>
 
   <span class="pf-kicker">Setup</span>
   <nav>
@@ -187,11 +192,6 @@
       <span class="pf-ghost">03</span>
       <div class="pf-row-t">Wi-Fi</div>
       <div class="pf-row-d">Remember several networks &mdash; the device joins whichever one it finds.</div>
-    </a>
-    <a class="pf-row" href="/mqtt" data-cap="mqtt">
-      <span class="pf-ghost">04</span>
-      <div class="pf-row-t">MQTT</div>
-      <div class="pf-row-d">Mirror one panel onto another, or hand the knobs to home automation.</div>
     </a>
   </nav>
 
@@ -209,14 +209,6 @@
     </a>
   </nav>
 
-  <span class="pf-kicker">Experimental</span>
-  <nav>
-    <a class="pf-row" href="/weather" data-cap="weather">
-      <span class="pf-ghost">08</span>
-      <div class="pf-row-t">Weather<span class="tag">Early</span></div>
-      <div class="pf-row-d">Clock, timezone and local readings &mdash; can drive the knobs from the sky outside.</div>
-    </a>
-  </nav>
   </div>
   </div>
 
@@ -229,23 +221,32 @@ function $(i){return document.getElementById(i)}
 $('host').textContent=location.hostname;
 
 // ── What this build actually has ───────────────────────────────
-// Features live in addons, so a panel may genuinely have no shows or
-// no MQTT. Advertising them anyway sends people to a 404 and makes the
-// device look broken. The rows are in the markup — this removes the
-// ones with no feature behind them, drops any group left empty, and
-// renumbers what remains so the list still reads 01, 02, 03.
+// Feature rows are not written into this page. Whatever addons the firmware
+// carries report their pages in /api/status addonNav — path, label, one
+// line — and the Features group is built from that. A build with none gets
+// no group, and a page the core has never heard of still gets a row. This
+// used to work the other way round: rows for every feature in the markup,
+// deleted when the capability was absent, which meant a core page naming
+// features and a new feature's page getting no row at all.
+//
+// Rebuilt from scratch on every status (gate can fire twice at load), then
+// everything renumbers so the list still reads 01, 02, 03.
 function gate(s){
-  var caps=(s&&s.caps)||null;
-  if(!caps)return;  // no answer: leave everything, a 404 beats a blank page
-  var i,n=document.querySelectorAll('[data-cap]');
-  for(i=0;i<n.length;i++)
-    if(caps.indexOf(n[i].getAttribute('data-cap'))<0)n[i].remove();
-  var groups=document.querySelectorAll('.rows nav');
-  for(i=0;i<groups.length;i++){
-    if(groups[i].querySelector('.pf-row'))continue;
-    var kicker=groups[i].previousElementSibling;
-    if(kicker&&kicker.classList.contains('pf-kicker'))kicker.remove();
-    groups[i].remove();
+  var i,nav=(s&&s.addonNav)||[];
+  var f=$('featRows'),fk=$('featKick');
+  if(f){
+    f.innerHTML='';
+    for(i=0;i<nav.length;i++){
+      var e=nav[i];if(!e||e.length<2)continue;
+      var a=document.createElement('a');
+      a.className='pf-row';a.href=e[0];
+      a.innerHTML='<span class="pf-ghost">00</span>'+
+        '<div class="pf-row-t"></div><div class="pf-row-d"></div>';
+      a.querySelector('.pf-row-t').textContent=e[1];
+      a.querySelector('.pf-row-d').textContent=e[2]||'';
+      f.appendChild(a);
+    }
+    f.hidden=fk.hidden=!f.querySelector('.pf-row');
   }
   var ghosts=document.querySelectorAll('.rows .pf-ghost');
   for(i=0;i<ghosts.length;i++)
@@ -295,8 +296,6 @@ function tick(){
     $('s-ip').textContent=s.wifi?s.ip:'—';
     $('s-heap').textContent=Math.round(s.heapInternal/1024)+'K + '+
       Math.round(s.heapPsram/1048576)+'M psram';
-    $('s-mqtt').textContent=(s.mqttRole&&s.mqttRole!=='off')?
-      (s.mqttRole+' · '+s.mqttState):'off';
     $('s-up').textContent=dur(s.uptime);
     $('s-fw').textContent='v'+s.version;
 

--- a/firmware/patternflow/console/status.html
+++ b/firmware/patternflow/console/status.html
@@ -70,7 +70,6 @@ live there. Below ~10 KB this page itself stops loading.</p></section>
   <div class="row"><dt>Network</dt><dd id="ss">-</dd></div>
   <div class="row"><dt>Signal</dt><dd id="rs">-</dd></div>
   <div class="row"><dt>Address</dt><dd id="ip">-</dd></div>
-  <div class="row" data-cap="mqtt"><dt>MQTT</dt><dd id="mq">-</dd></div>
 </dl></section>
 
 <footer>Firmware <span id="fw">-</span><span id="var"></span> &middot; panel <span id="pn">-</span>
@@ -141,21 +140,9 @@ function tick(){
     $('rs').textContent=d.wifi?d.rssi+' dBm':'-';
     $('ip').textContent=d.wifi?d.ip:'-';
 
-    // "off" is a choice, not a fault — only a role that is trying and
-    // failing gets the red treatment.
-    // Rows for features this build may not have. The device says what it
-    // actually loaded; a row for something absent is not "off", it is a
-    // question the panel cannot answer.
-    var caps=d.caps||[];
-    var gated=document.querySelectorAll('[data-cap]');
-    for(var gi=0;gi<gated.length;gi++){
-      if(caps.indexOf(gated[gi].getAttribute('data-cap'))<0)gated[gi].remove();
-    }
-    if(document.getElementById('mq')){
-    var role=d.mqttRole||'off';
-    $('mq').textContent=role==='off'?'off':(role+' · '+(d.mqttState||'-'));
-    $('mq').className=role==='off'?'':(d.mqttConnected?'ok':'bad');
-    }
+    // No feature rows here. This page had an MQTT line, capability-gated -
+    // a core page reporting one feature's state by name. A feature's state
+    // lives on that feature's own page, one click from the header.
   }).catch(function(){$('up').textContent='disconnected'});
 }
 tick();setInterval(tick,2000);

--- a/firmware/patternflow/net_config.h
+++ b/firmware/patternflow/net_config.h
@@ -28,7 +28,14 @@
 #include "patternflow_secrets.h"
 #endif
 
-// ── Wi-Fi (shared by OTA, OSC, and audio-react) ──────────────
+// ── Wi-Fi ────────────────────────────────────────────────────────────
+// Whether the panel has a radio at all. 0 makes a USB-only instrument:
+// everything network-side (console, OTA, every feature that dials out)
+// compiles out behind PF_WIFI_NEEDED in core_wifi.h.
+#ifndef PF_WIFI_ENABLED
+#define PF_WIFI_ENABLED 1
+#endif
+
 // Credentials normally come from patternflow_secrets.h. The placeholders
 // here only keep a secret-less checkout compiling.
 #ifndef PF_WIFI_SSID

--- a/firmware/patternflow/patternflow.ino
+++ b/firmware/patternflow/patternflow.ino
@@ -1576,8 +1576,13 @@ void loop() {
     if (activatePattern(addonPatternIdx)) {
       currentPatternIdx = addonPatternIdx;
       currentMode = MODE_RUNNING;
-      if (!patterns[addonPatternIdx].name ||
-          strcmp(patterns[addonPatternIdx].name, "Black") != 0) {
+      // Hidden patterns arrive unannounced. This used to compare the name
+      // against "Black" - the show scheduler's night face - which was the
+      // core knowing one feature's pattern by name (check_boundaries.py
+      // caught it on its first run). `hidden` is the property that
+      // comparison was reaching for: a pattern nobody can browse to is not
+      // an arrival worth flashing a name for, whichever feature brought it.
+      if (!patterns[addonPatternIdx].hidden) {
         contentNoticeTimer = CONTENT_NOTICE_SECONDS;
       }
       CalibPattern::overrideOn = false;

--- a/firmware/patternflow/src/core_wifi.h
+++ b/firmware/patternflow/src/core_wifi.h
@@ -1,6 +1,6 @@
 // Patternflow - shared Wi-Fi bring-up (non-blocking + auto-reconnect)
 //
-// OSC, OTA, and the audio-react server all ride on one STA connection.
+// Everything network-side rides on one STA connection.
 // This module owns it so there is exactly one WiFi.begin() in flight and
 // one place that handles dropouts.
 //
@@ -22,7 +22,13 @@
 #include <Arduino.h>
 #include "config.h"
 
-#if PF_OSC_ENABLED || PF_OTA_ENABLED || PF_AUDIO_ENABLED || PF_WEBUPDATE_ENABLED
+// One core switch, not a disjunction of feature flags. This used to read
+// `#if PF_OSC_ENABLED || PF_OTA_ENABLED || PF_AUDIO_ENABLED || ...`, which
+// was the core deciding whether the radio exists by enumerating features —
+// and a stale enumeration at that: the console, MQTT and weather all need
+// Wi-Fi and were never in the list. Whether this panel has a radio is the
+// core's own question; PF_WIFI_ENABLED answers it in net_config.h.
+#if PF_WIFI_ENABLED
 #define PF_WIFI_NEEDED 1
 #include <WiFi.h>
 #include <Preferences.h>

--- a/firmware/patternflow/src/home_index.h
+++ b/firmware/patternflow/src/home_index.h
@@ -171,7 +171,6 @@ const char HOME_INDEX_HTML[] PROGMEM = R"HTML(<!doctype html>
       <div class="stat"><span class="k">Wi-Fi</span><div class="v" id="s-wifi">&mdash;</div></div>
       <div class="stat"><span class="k">Address</span><div class="v" id="s-ip">&mdash;</div></div>
       <div class="stat"><span class="k">Memory</span><div class="v" id="s-heap">&mdash;</div></div>
-      <div class="stat" data-cap="mqtt"><span class="k">MQTT</span><div class="v" id="s-mqtt">&mdash;</div></div>
       <div class="stat"><span class="k">Uptime</span><div class="v" id="s-up">&mdash;</div></div>
       <div class="stat"><span class="k">Firmware</span><div class="v" id="s-fw">&mdash;</div></div>
       <!-- Which edition this panel is running. It was a line of small print in
@@ -205,12 +204,18 @@ const char HOME_INDEX_HTML[] PROGMEM = R"HTML(<!doctype html>
       <div class="pf-row-t">Pattern library</div>
       <div class="pf-row-d">Drop in a <b>.pfm</b> module or a whole <b>.zip</b> pack &mdash; play, arrange, delete.</div>
     </a>
-    <a class="pf-row" href="/show" data-cap="shows">
-      <span class="pf-ghost">02</span>
-      <div class="pf-row-t">Sequences</div>
-      <div class="pf-row-d">Timed shows from <b>.pfs</b> tables &mdash; play one, chain a playlist, schedule night and wake.</div>
-    </a>
   </nav>
+
+  <!-- Whatever features this firmware carries, one row each. The rows are
+       not written into this page: they arrive from /api/status addonNav,
+       contributed by the loaded addons, so a page the core has never heard
+       of still gets a row and a build with none gets no group. This page
+       used to hand-write rows for /show, /mqtt and /weather - capability-
+       gated, so they degraded, but named in a core page all the same, and
+       the first addon page the list did not know about proved the point by
+       having no row at all. -->
+  <span class="pf-kicker" id="featKick" hidden>Features</span>
+  <nav id="featRows" hidden></nav>
 
   <span class="pf-kicker">Setup</span>
   <nav>
@@ -218,11 +223,6 @@ const char HOME_INDEX_HTML[] PROGMEM = R"HTML(<!doctype html>
       <span class="pf-ghost">03</span>
       <div class="pf-row-t">Wi-Fi</div>
       <div class="pf-row-d">Remember several networks &mdash; the device joins whichever one it finds.</div>
-    </a>
-    <a class="pf-row" href="/mqtt" data-cap="mqtt">
-      <span class="pf-ghost">04</span>
-      <div class="pf-row-t">MQTT</div>
-      <div class="pf-row-d">Mirror one panel onto another, or hand the knobs to home automation.</div>
     </a>
   </nav>
 
@@ -240,14 +240,6 @@ const char HOME_INDEX_HTML[] PROGMEM = R"HTML(<!doctype html>
     </a>
   </nav>
 
-  <span class="pf-kicker">Experimental</span>
-  <nav>
-    <a class="pf-row" href="/weather" data-cap="weather">
-      <span class="pf-ghost">08</span>
-      <div class="pf-row-t">Weather<span class="tag">Early</span></div>
-      <div class="pf-row-d">Clock, timezone and local readings &mdash; can drive the knobs from the sky outside.</div>
-    </a>
-  </nav>
   </div>
   </div>
 
@@ -260,23 +252,32 @@ function $(i){return document.getElementById(i)}
 $('host').textContent=location.hostname;
 
 // ── What this build actually has ───────────────────────────────
-// Features live in addons, so a panel may genuinely have no shows or
-// no MQTT. Advertising them anyway sends people to a 404 and makes the
-// device look broken. The rows are in the markup — this removes the
-// ones with no feature behind them, drops any group left empty, and
-// renumbers what remains so the list still reads 01, 02, 03.
+// Feature rows are not written into this page. Whatever addons the firmware
+// carries report their pages in /api/status addonNav — path, label, one
+// line — and the Features group is built from that. A build with none gets
+// no group, and a page the core has never heard of still gets a row. This
+// used to work the other way round: rows for every feature in the markup,
+// deleted when the capability was absent, which meant a core page naming
+// features and a new feature's page getting no row at all.
+//
+// Rebuilt from scratch on every status (gate can fire twice at load), then
+// everything renumbers so the list still reads 01, 02, 03.
 function gate(s){
-  var caps=(s&&s.caps)||null;
-  if(!caps)return;  // no answer: leave everything, a 404 beats a blank page
-  var i,n=document.querySelectorAll('[data-cap]');
-  for(i=0;i<n.length;i++)
-    if(caps.indexOf(n[i].getAttribute('data-cap'))<0)n[i].remove();
-  var groups=document.querySelectorAll('.rows nav');
-  for(i=0;i<groups.length;i++){
-    if(groups[i].querySelector('.pf-row'))continue;
-    var kicker=groups[i].previousElementSibling;
-    if(kicker&&kicker.classList.contains('pf-kicker'))kicker.remove();
-    groups[i].remove();
+  var i,nav=(s&&s.addonNav)||[];
+  var f=$('featRows'),fk=$('featKick');
+  if(f){
+    f.innerHTML='';
+    for(i=0;i<nav.length;i++){
+      var e=nav[i];if(!e||e.length<2)continue;
+      var a=document.createElement('a');
+      a.className='pf-row';a.href=e[0];
+      a.innerHTML='<span class="pf-ghost">00</span>'+
+        '<div class="pf-row-t"></div><div class="pf-row-d"></div>';
+      a.querySelector('.pf-row-t').textContent=e[1];
+      a.querySelector('.pf-row-d').textContent=e[2]||'';
+      f.appendChild(a);
+    }
+    f.hidden=fk.hidden=!f.querySelector('.pf-row');
   }
   var ghosts=document.querySelectorAll('.rows .pf-ghost');
   for(i=0;i<ghosts.length;i++)
@@ -326,8 +327,6 @@ function tick(){
     $('s-ip').textContent=s.wifi?s.ip:'—';
     $('s-heap').textContent=Math.round(s.heapInternal/1024)+'K + '+
       Math.round(s.heapPsram/1048576)+'M psram';
-    $('s-mqtt').textContent=(s.mqttRole&&s.mqttRole!=='off')?
-      (s.mqttRole+' · '+s.mqttState):'off';
     $('s-up').textContent=dur(s.uptime);
     $('s-fw').textContent='v'+s.version;
 

--- a/firmware/patternflow/src/status_index.h
+++ b/firmware/patternflow/src/status_index.h
@@ -81,7 +81,6 @@ live there. Below ~10 KB this page itself stops loading.</p></section>
   <div class="row"><dt>Network</dt><dd id="ss">-</dd></div>
   <div class="row"><dt>Signal</dt><dd id="rs">-</dd></div>
   <div class="row"><dt>Address</dt><dd id="ip">-</dd></div>
-  <div class="row" data-cap="mqtt"><dt>MQTT</dt><dd id="mq">-</dd></div>
 </dl></section>
 
 <footer>Firmware <span id="fw">-</span><span id="var"></span> &middot; panel <span id="pn">-</span>
@@ -152,21 +151,9 @@ function tick(){
     $('rs').textContent=d.wifi?d.rssi+' dBm':'-';
     $('ip').textContent=d.wifi?d.ip:'-';
 
-    // "off" is a choice, not a fault — only a role that is trying and
-    // failing gets the red treatment.
-    // Rows for features this build may not have. The device says what it
-    // actually loaded; a row for something absent is not "off", it is a
-    // question the panel cannot answer.
-    var caps=d.caps||[];
-    var gated=document.querySelectorAll('[data-cap]');
-    for(var gi=0;gi<gated.length;gi++){
-      if(caps.indexOf(gated[gi].getAttribute('data-cap'))<0)gated[gi].remove();
-    }
-    if(document.getElementById('mq')){
-    var role=d.mqttRole||'off';
-    $('mq').textContent=role==='off'?'off':(role+' · '+(d.mqttState||'-'));
-    $('mq').className=role==='off'?'':(d.mqttConnected?'ok':'bad');
-    }
+    // No feature rows here. This page had an MQTT line, capability-gated -
+    // a core page reporting one feature's state by name. A feature's state
+    // lives on that feature's own page, one click from the header.
   }).catch(function(){$('up').textContent='disconnected'});
 }
 tick();setInterval(tick,2000);

--- a/firmware/toolchain/check_boundaries.py
+++ b/firmware/toolchain/check_boundaries.py
@@ -1,0 +1,217 @@
+"""The core/feature boundary, enforced mechanically.
+
+    python firmware/toolchain/check_boundaries.py
+
+The rule this checks is written at the top of patternflow.ino and in
+docs/EDITIONS.md: the core names no feature. Not in an #include, not in an
+#if, not by namespace. Every published firmware compiles the core unchanged,
+so a feature that leaks into it ships to every edition at once.
+
+The rule needed a checker because prose does not hold. It was violated three
+separate times before this existed - the NETWORK screen's hard-coded
+"OSC / AUD" hint, the console header's nav table, and the home page's feature
+rows - each one capability-gated and well-intentioned, each one a core file
+that knew a feature by name, and none of them caught by anything until a
+person tripped over the symptom. The guards that DID hold all had teeth:
+addons.h refuses a composition that defines neither macro, CI refuses a
+console header that drifted from its HTML, platformio.ini names libraries
+because the dependency finder cannot. This is the same idea aimed at the
+boundary itself.
+
+Four rules:
+
+  R1  Core references no addon namespace. The namespace list is read from
+      the addon directories themselves, so a brand-new feature is guarded
+      the moment it declares `namespace PFAddonWhatever`.
+  R2  Core includes nothing from the addon tree, except the two seams that
+      ARE the boundary: the sketch includes the dispatcher, the pattern
+      registry includes the preset seam.
+  R3  Behavioural core - the sketch, src/, abi/ - takes no #if / #ifdef
+      branch on a feature's flags: which features exist must not change what
+      the core compiles to. config.h and net_config.h are exempt, because
+      providing feature DEFAULTS is their entire job ("settings tune a
+      feature, they never add one") and every #ifndef there is that.
+  R4  Features do not include each other. Six directories, zero coupling;
+      an edition is a set, not a stack.
+
+License: MIT
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SKETCH = ROOT / "patternflow"
+
+# The one constant to touch if the directory is ever renamed (features/?).
+ADDON_DIR = "addons"
+
+# Files under addons/ that are the interface rather than a feature: the hook
+# struct, the dispatcher, the composition, and the preset seam.
+SEAM_FILES = {"pf_addon.h", "pf_addons.h", "addons.h", "addon_presets.h"}
+
+# The two sanctioned core -> addons includes (core file, included seam file).
+CORE_INCLUDE_ALLOW = {
+    ("patternflow.ino", "pf_addons.h"),
+    ("pattern_registry.h", "addon_presets.h"),
+    # overrides.h is the composition's second file - config.h includes it
+    # before any default precisely so an edition can reach every #ifndef.
+    ("config.h", "overrides.h"),
+}
+
+if hasattr(sys.stdout, "reconfigure"):
+    sys.stdout.reconfigure(errors="replace")
+
+# Same stripping check_sources.py uses: comments and raw strings blanked to
+# same-length spaces so line numbers survive. A comment may mention an addon
+# namespace freely - core_bus.h explains its own history that way.
+RAW_STRING = re.compile(r'R"([A-Za-z_]*)\(.*?\)\1"', re.DOTALL)
+LINE_COMMENT = re.compile(r"//[^\n]*")
+BLOCK_COMMENT = re.compile(r"/\*.*?\*/", re.DOTALL)
+
+
+def blank_out(text: str, pattern: re.Pattern[str]) -> str:
+    return pattern.sub(lambda m: re.sub(r"[^\n]", " ", m.group(0)), text)
+
+
+def stripped(path: Path) -> str:
+    text = path.read_text(encoding="utf-8", errors="replace")
+    for pattern in (RAW_STRING, BLOCK_COMMENT, LINE_COMMENT):
+        text = blank_out(text, pattern)
+    return text
+
+
+def core_files() -> list[Path]:
+    files = [SKETCH / "patternflow.ino"]
+    for name in ("config.h", "net_config.h", "pattern_registry.h",
+                 "patternflow_secrets.example.h"):
+        p = SKETCH / name
+        if p.exists():
+            files.append(p)
+    for sub in ("src", "abi"):
+        files.extend(sorted((SKETCH / sub).rglob("*.h")))
+    return files
+
+
+def addon_subdirs() -> list[Path]:
+    root = SKETCH / ADDON_DIR
+    return sorted(d for d in root.iterdir() if d.is_dir())
+
+
+def addon_namespaces(cores: list[Path]) -> dict[str, str]:
+    """namespace name -> feature directory that declares it.
+
+    A namespace the CORE declares belongs to the core, even where an addon
+    re-opens it - core_audio_ws.h re-opens PatternflowPatternsHttp to
+    forward-declare server(), which is the addon reaching toward the core
+    (the allowed direction), not the core toward the addon. The first run
+    of this checker attributed that namespace to addons/audio/ and flagged
+    every legitimate core use of the core's own web server.
+    """
+    decl = re.compile(r"^\s*namespace\s+(\w+)", re.M)
+    core_owned: set[str] = set()
+    for p in cores:
+        core_owned.update(decl.findall(stripped(p)))
+    ns: dict[str, str] = {}
+    for d in addon_subdirs():
+        for h in d.rglob("*.h"):
+            for name in decl.findall(stripped(h)):
+                if name not in core_owned:
+                    ns[name] = d.name
+    return ns
+
+
+def feature_flag_prefixes() -> list[str]:
+    """PF_OSC, PF_AUDIO, ... derived from the directory names, so a new
+    feature's flags are guarded without anyone editing this file."""
+    return sorted({"PF_" + d.name.upper() for d in addon_subdirs()})
+
+
+def main() -> int:
+    violations: list[str] = []
+    cores = core_files()
+    namespaces = addon_namespaces(cores)
+    prefixes = feature_flag_prefixes()
+
+    ns_pattern = re.compile(
+        r"\b(" + "|".join(re.escape(n) for n in sorted(namespaces)) + r")\b")
+    include_pattern = re.compile(
+        r'#\s*include\s+"([^"]*' + re.escape(ADDON_DIR) + r'/[^"]+)"')
+    cond_pattern = re.compile(r"^\s*#\s*(if|elif|ifdef|ifndef)\b(.*)$", re.M)
+    flag_pattern = re.compile(
+        r"\b(" + "|".join(prefixes) + r")\w*\b")
+
+    for path in cores:
+        rel = path.relative_to(SKETCH).as_posix()
+        text = stripped(path)
+        raw = path.read_text(encoding="utf-8", errors="replace")
+        lines = text.splitlines()
+
+        # R1 - namespaces
+        for m in ns_pattern.finditer(text):
+            line = text.count("\n", 0, m.start()) + 1
+            violations.append(
+                f"{rel}:{line}: core references {m.group(1)} "
+                f"(a namespace of {ADDON_DIR}/{namespaces[m.group(1)]}/) - "
+                f"reach it through a hook in pf_addon.h instead")
+
+        # R2 - includes (checked on raw text: includes never sit in comments
+        # we care about, and the historical ones are stripped anyway)
+        for m in include_pattern.finditer(text):
+            target = Path(m.group(1)).name
+            if (path.name, target) in CORE_INCLUDE_ALLOW:
+                continue
+            line = text.count("\n", 0, m.start()) + 1
+            violations.append(
+                f"{rel}:{line}: core includes {m.group(1)} - only the "
+                f"dispatcher and the preset seam cross this line")
+
+        # R3 - branching on feature flags, in behavioural core only.
+        if path.name not in ("config.h", "net_config.h"):
+            for m in cond_pattern.finditer(text):
+                flag = flag_pattern.search(m.group(2))
+                if not flag:
+                    continue
+                line_no = text.count("\n", 0, m.start()) + 1
+                violations.append(
+                    f"{rel}:{line_no}: core branches on {flag.group(0)} - "
+                    f"which features exist must not change what the core "
+                    f"compiles to")
+
+        _ = (raw, lines)  # raw text kept for future raw-only rules
+
+    # R4 - feature isolation
+    cross = re.compile(r'#\s*include\s+"\.\./([\w-]+)/')
+    for d in addon_subdirs():
+        for h in sorted(d.rglob("*.h")):
+            text = stripped(h)
+            for m in cross.finditer(text):
+                target = m.group(1)
+                if target == d.name:
+                    continue
+                line = text.count("\n", 0, m.start()) + 1
+                rel = h.relative_to(SKETCH).as_posix()
+                violations.append(
+                    f"{rel}:{line}: feature {d.name} includes from "
+                    f"{ADDON_DIR}/{target}/ - features do not know each "
+                    f"other; an edition is a set, not a stack")
+
+    if violations:
+        print("the core/feature boundary is breached:\n")
+        for v in violations:
+            print("  " + v)
+        print(f"\n{len(violations)} violation(s). The rule and its reasons: "
+              f"docs/EDITIONS.md and the patternflow.ino header.")
+        return 1
+
+    print(f"boundary holds: {len(cores)} core files know none of "
+          f"{len(namespaces)} feature namespaces across "
+          f"{len(addon_subdirs())} features")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
A mechanical audit of the core/feature split came back clean — zero real namespace references in core, zero cross-feature includes, two sanctioned seams — with one drift pattern: every violation to date was a core file naming features, comment-enforced, caught only when somebody tripped over the symptom. The guards that held all had teeth. So the boundary gets the same, three ways.

### `check_boundaries.py`, in CI

Four rules: core references no feature namespace (the list is read from the addon directories, so a brand-new feature is guarded the moment it declares one); core includes nothing from the feature tree beyond the seams; the behavioural core takes no `#if` on a feature's flags (`config.h`/`net_config.h` exempt — providing defaults is their job); features do not include each other. Planted violations of each rule are caught; the tree passes: **58 core files, 22 feature namespaces, 6 features.**

On its first run it found a real one: the sketch strcmp'ing a pattern name against `"Black"` — the show scheduler's night face, known to the core by name. The property it was reaching for is `hidden`, which is core's own; any feature's hidden pattern now arrives unannounced.

Also settled: `core_wifi.h` decided whether the radio exists by enumerating feature flags — a stale list that never included the console, MQTT or weather. `PF_WIFI_ENABLED` is the core's own answer now.

### `build.sh all`

"A core change is tested against every composition" was prose, and prose gets one build of three. Now: three builds plus a marker scan — one literal per feature, living only in that feature's sources; an edition must carry its own and none of the others'. The scan earned its keep within the hour: my first weather marker (`open-meteo`) was never in the sources — the API is openweathermap — and performance failed until the marker told the truth.

```
default      building…  70s   1,096,816 bytes  ok
audio        building…  79s   1,185,936 bytes  ok
performance  building…  14s   1,380,096 bytes  ok
```

### The home console stops naming features

Home carried hand-written rows for `/show`, `/mqtt`, `/weather` — gated, but named in a core page — and the first page the list didn't know proved the point: the Mic page had a header link and no home row. The descriptor gains `navDesc`, `addonNav` becomes `[path, label, line]`, and home builds its Features group at runtime. The MQTT stat tile and the status page's MQTT row go too — a feature's state lives on its own page. `data-cap` is gone from every core page.

Verified on the audio edition's hardware: home reads Patterns 01 / **Features 02 Mic** (with its line) / Setup / Device, numbering continuous. All nine console pages match their HTML.

Naming note: the eventual `addons/` → `features/` rename stays cheap — the checker keeps the directory name in one constant, and the external contract (the two composition filenames + `PF_ADDON_LIST` macros Simone's out-of-tree recipe uses) is documented in EDITIONS.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)