### PR TITLE
contracts: what the core promises is now written, and one of them is locked

### DIFF
--- a/.github/workflows/firmware-checks.yml
+++ b/.github/workflows/firmware-checks.yml
@@ -47,5 +47,7 @@ jobs:
           python-version: "3.x"
       - name: The core names no feature
         run: python firmware/toolchain/check_boundaries.py
+      - name: The module ABI does not move silently
+        run: python firmware/toolchain/check_abi_freeze.py
       - name: No mangled literals or raw control bytes
         run: python firmware/toolchain/check_sources.py

--- a/docs/EDITIONS.md
+++ b/docs/EDITIONS.md
@@ -185,6 +185,43 @@ that the firmware never changes, but that **the files keep opening**. See
 
 ---
 
+## What is promised, and to whom
+
+"If the core keeps improving, will the things built against it keep
+working?" - the right worry, so here is the contract, strongest first.
+Everything below has an enforcer; a promise kept by memory is the kind that
+was broken three times before the boundary checker existed.
+
+**1. The module ABI (`firmware/patternflow/abi/`) - binary, strongest.**
+Consumed by installed `.pfm` files that never recompile. Frozen field
+layout, append-only growth, an explicit version handshake
+(`PF_ABI_VERSION` 1 is frozen; modules stamp `PF_ABI_MODULE_VERSION`; the
+loader accepts the range), and since 2026-08-30 a CI lock: `abi.sums` pins
+every header's hash and `check_abi_freeze.py` fails any drift that was not
+deliberately re-pinned in the same commit.
+
+**2. The hook interface (`features/pf_feature.h`) - compile-time.** For
+feature code that recompiles against a checkout, in-tree or out. Widening
+is tail-append only (the rule and its reason are written on the struct);
+the compiler surfaces every break at build, and `build.sh all` makes sure
+"builds" means all three compositions. The two composition filenames and
+their macros are the out-of-tree seam - renamed spellings are shimmed, and
+shims get deleted only after their consumers migrate.
+
+**3. The wire ([`rest-api.md`](rest-api.md), [`osc-spec.md`](osc-spec.md),
+[`audio-ws-spec.md`](audio-ws-spec.md)) - runtime.** Integrations build
+against the spec files, not the firmware source. Growth is additive; each
+spec carries its own compatibility rule (probe `caps` before assuming an
+endpoint; unknown WebSocket prefixes are ignored; new OSC addresses do not
+move old ones) and its own version history.
+
+**Explicitly not promised: everything else.** Core file layout, namespaces,
+internal helpers, what a screen draws, which serial lines print - all of it
+may change without notice, and the `addons/` -> `features/` rename is the
+standing example: forty files moved, and nothing that speaks any of the
+three contracts above noticed. That is the shape of the deal - the inside
+stays free precisely because the edges are locked.
+
 ## Building a feature
 
 Full reference, including all thirteen hooks and what proved each one:

--- a/docs/audio-ws-spec.md
+++ b/docs/audio-ws-spec.md
@@ -1,0 +1,71 @@
+# Patternflow audio WebSocket — wire protocol
+
+The low-latency path for driving the four knobs from a stream of levels:
+browser-tab audio through the Chrome extension today, anything that can open
+a WebSocket tomorrow. This document is the contract, the way
+[`osc-spec.md`](osc-spec.md) is for OSC and [`rest-api.md`](rest-api.md) is
+for HTTP — clients build against this file, not against the firmware source.
+
+Carried by the **audio feature** (Audio edition), so probe before assuming:
+`GET /api/status` lists `"audio"` in `caps` when this server exists. The
+default build does not have it, and connecting anyway just fails.
+
+## Transport
+
+| | |
+|---|---|
+| URL | `ws://<host>:81/` — plain WebSocket, no TLS, no subprotocol, no auth beyond being on the LAN (the same trust model as the rest of the device). |
+| Port | `81` (`PF_AUDIO_WS_PORT`). The HTTP API stays on 80. |
+| Frames | Text, one message per frame, ASCII. |
+| Direction | Client → device only. The device sends nothing; read device state over HTTP. |
+| Clients | Multiple connections are accepted; last write wins per knob. In practice: one. |
+
+## Messages
+
+| Message | Meaning |
+|---|---|
+| `a=F,F,F,F` | Set all four lanes at once, each `0..1`. A literal `-` in a slot leaves that lane untouched: `a=0.8,-,-,0.2`. **The message to use for continuous streams.** |
+| `k=N,v=F` | Set lane `N` (0..3) to `F` (clamped to `0..1`). |
+| `d=N,v=F` | Add a normalized delta `F` (−1..1) to knob `N` — encoder-style motion rather than a level. |
+| `off=N` | Release knob `N` back to encoder control. |
+| `off` | Release all four. |
+
+Anything else is **silently ignored** — that is the compatibility rule. A new
+message type is a new prefix, old firmware drops it, and nothing breaks.
+
+## Semantics — what a "lane" is
+
+`a=` and `k=` drive the **lane**: an absolute, continuous reading the pattern
+receives lerped into each parameter's own declared range. It is the same
+mechanism the weather feature and the on-board microphone use. Priority per
+knob, highest first (see `abi/pf_params.h`):
+
+1. the absolute bus (`POST /api/params`, OSC/MQTT absolute, shows) — exact
+   0..1000 set-points;
+2. **the lane** — what this protocol writes;
+3. encoder deltas.
+
+**Hands always win.** A physical turn of an encoder takes that knob back and
+holds it for five seconds; keep streaming and the lane resumes when the hold
+expires. `off` is the polite way to leave — send it on disconnect so the
+knobs are not parked at your last values (the firmware also releases lanes
+when the socket closes).
+
+## Why `a=` exists — pacing a one-connection server
+
+The device is small; treat the socket as having room for exactly one
+in-flight message. Check `bufferedAmount === 0` before each send and drop
+the frame otherwise — never queue. Four `k=` messages per frame is how this
+was learned: after the first send the buffer is never empty, lanes 1..3
+dropped in index order, and knob 4 never moved. One `a=` per frame carries
+everything, in order, at a quarter of the traffic.
+
+Send at your analysis rate (the extension sends per animation frame). There
+is no keep-alive requirement.
+
+## Version history
+
+- **1** — first written contract: `a=` / `k=` / `d=` / `off=N` / `off`,
+  lane semantics, the unknown-prefix rule, the one-in-flight pacing rule.
+  Matches firmware 3.8.0 (Audio edition v0.3.1) and extension as shipped in
+  `tools/patternflow-audio-extension/`.

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -13,7 +13,7 @@ Patternflow serves a plain HTTP server on port 80 over the local Wi-Fi network. 
 | | |
 |---|---|
 | Base URL | `http://patternflow.local/` — mDNS, hostname from `PF_OTA_HOSTNAME`. The raw IP works too and is the fallback on clients with poor mDNS (Android). |
-| Port | **80** for everything documented here. One server carries the console, the API and `/update`. A build with the audio feature adds a WebSocket on **81** (`PF_AUDIO_WS_PORT`) for the Chrome extension, which is not part of this contract. |
+| Port | **80** for everything documented here. One server carries the console, the API and `/update`. A build with the audio feature adds a WebSocket on **81** (`PF_AUDIO_WS_PORT`) for streaming audio clients — its wire protocol is [`audio-ws-spec.md`](audio-ws-spec.md). |
 | Advertised over mDNS | `_http._tcp` on port 80 (`core_web_update.h`, whenever `PF_WEBUPDATE_ENABLED`) and `_arduino._tcp` (ArduinoOTA, whenever `PF_OTA_ENABLED`). The first carries no TXT records at all and the second only ArduinoOTA's own (board type, auth flags) — nothing Patternflow-specific either way. A discovering client must probe `GET /api/status` to confirm what it found. |
 | Concurrency | **One connection.** See [Rules that will bite you](#rules-that-will-bite-you). |
 | Authentication | **None.** No token, no password, no session. Anyone on the LAN can call anything here, including `POST /update`. This is a deliberate trust model, the same one ArduinoOTA's empty-password default has; `PF_WEBUPDATE_ALWAYS_ARMED 0` is the one lever that narrows it. |
@@ -51,6 +51,7 @@ The numbers that explain a device when something is off. Requires `PF_STATUS_HTT
   "sleep": false,
   "knobs": [12, 0, -3, 40], "params": [500, 500, 750, 500],
   "paramActive": [false, false, true, false],
+  "lanes": [0.0, 0.0, 0.0, 0.0], "laneActive": [false, false, false, false],
   "consolePaused": false,
   "frameUs": 16400, "presentUs": 3100, "loopCore": 1,
   "colorBits": 6, "refreshHz": 121,
@@ -72,6 +73,7 @@ The numbers that explain a device when something is off. Requires `PF_STATUS_HTT
 | `knobs` | The four encoders' absolute accumulated click counts — the same numbers the running pattern sees. Signed, unbounded, and meaningful only as a difference: there is no scale and no zero. |
 | `params` | The absolute parameter bus, 0..1000 per lane. What `POST /api/params`, OSC and MQTT all write to. |
 | `paramActive` | Per lane: is a remote writer currently holding it? Goes `false` a beat after somebody turns that encoder, because a hand in the room outranks the network. |
+| `lanes` / `laneActive` | The continuous 0..1 lane per knob and whether something is driving it — the audio WebSocket, the on-board microphone, weather. Sits between the absolute bus and the encoders in priority; see [`audio-ws-spec.md`](audio-ws-spec.md) for the semantics. |
 | `consolePaused` | A pattern-install batch is in progress and the module is evicted. Not an error. (Console pages stopped pausing the pattern in 3.6.3 — the name is older than that.) |
 | `frameUs` / `presentUs` | Smoothed frame time and the part of it spent pushing pixels. `1e6 / frameUs` is the honest fps. |
 | `colorBits` / `refreshHz` | What the HUB75 driver actually settled on — it trades colour depth against the requested refresh rate, so these are read back rather than configured. |
@@ -79,6 +81,7 @@ The numbers that explain a device when something is off. Requires `PF_STATUS_HTT
 | `variant` | Which firmware this is: `"core"`, or a variant's own name. What the site's variant list matches, and what stops the update banner offering a core build on top of someone's chosen firmware. |
 | `caps` | What this build can do. **Probe this rather than assuming a feature exists.** The default build reports `["patterns","params","sleep"]` and nothing else; each [edition](EDITIONS.md) adds its own — Audio adds `osc` and `audio`, Performance adds `weather`, `mqtt` and `shows`. `patterns` and `params` are on every build. |
 | `mqttRole` | `"off"`, `"publisher"` or `"subscriber"`. Decides whether the device obeys knob and pattern topics — see [Knobs](#knobs-and-parameters). |
+| `featureNav` | `[path, label, one-line description]` per console page the loaded features serve, e.g. `[["/audio-in","Mic","The panel hears the room…"]]`. What the console header and home screen build their feature links from; empty on the default build. |
 
 ### `POST /api/params`
 
@@ -298,6 +301,22 @@ The mapping lives in `web/src/lib/patternflowControls.ts` as `LOGICAL_KNOB_TO_WE
 
 Scale constants live in the same file and are the contract for anything converting between a parameter value and encoder detents: `ENCODER_CLICKS_PER_TURN = 24`, `TURNS_PER_FULL_RANGE = 2` — so 48 detents cross a parameter's entire declared range, whatever that range is.
 
+## Microphone (Audio edition)
+
+Gated on `"audio-in"` in `caps`; the page is `/audio-in`. Settings persist in
+NVS. The live shaping UI polls the same endpoints documented here — there is
+nothing it can do that a script cannot.
+
+| Endpoint | Meaning |
+|---|---|
+| `GET /api/audio-in` | Full state: `micOn`, `source` (`"off"`, `"pdm"`, `"pdm (no mic - data pin idle)"`, `"synth"`), raw `rawPeak`/`rawDc`, per-band config (`hzMin`/`hzMax`/`inMin`/`inMax`/`gain`/`outMin`/`outMax`/`knob`/`muted`), `hzRange`, and a 40-bucket log `spec`. |
+| `GET /api/audio-in?levels=1` | The polling shape: `levels`, `outputs`, `spectrum`, `dropped` and nothing configurable — the page owns the config after reading it once. |
+| `POST /api/audio-in` | `mic=0/1` switches the whole feature (installs/releases the I2S driver). `band=N` plus any subset of the band fields updates one band; partial updates are the point, so a dragged handle cannot clobber the other three. |
+| `POST /api/audio-in/reset` | Back to the measured defaults. |
+
+`micDropped` in `/api/status`'s `audioIn` block counts capture hops discarded
+because analysis fell behind; flat is healthy, climbing means overload.
+
 ## Wi-Fi
 
 Requires `PF_WIFI_HTTP_ENABLED` (default on). Up to `PatternflowWifi::MAX_NETWORKS` are remembered and tried in order.
@@ -376,9 +395,10 @@ In short: HTTP is the management and state transport, OSC is the low-latency per
 - Parameters are query-string or form-encoded. There is no JSON request body anywhere, and adding one would need a body parser the firmware does not have.
 - Errors are `{"ok":false,"error":"<lowercase sentence>"}` with a `4xx`/`5xx` status. Success bodies vary; the ones that report a mutation start with `"ok":true`.
 - A handler must never touch FATFS, the ELF loader, the DMA engine or the CPU clock. Queue the work and let `loop()` do it; the reply then reports the pre-transition state, which callers already expect.
-- New endpoints are gated by a `PF_*_ENABLED` flag and must leave the sketch compiling when set to `0`.
+- A feature's endpoints exist only when that feature is composed in — the route itself is absent otherwise, so clients probe `caps` rather than expecting a soft 404. Core endpoints are gated by a core `PF_*_ENABLED` flag and must leave the sketch compiling at `0`.
 - Nothing here may stream per-frame pixel data. That has been tried.
 
 ## Version history
 
+- **1.1** (2026-08-30) — status gains `lanes`/`laneActive` (the continuous lane per knob) and `featureNav` (feature-served console pages); the microphone endpoints (`/api/audio-in`) are documented; port 81's WebSocket is promoted from "not part of this contract" to its own spec, [`audio-ws-spec.md`](audio-ws-spec.md); the endpoint-gating convention now describes composition gating.
 - **1.0** — first written contract for the HTTP API. Covers status, sleep, display calibration, patterns (list / select / sidecar / install / delete), the MQTT status and configuration endpoints, Wi-Fi, and firmware update; documents the single-connection rule, the console-pause rule, the queued-write rule, and the knob read/write asymmetry.

--- a/firmware/patternflow/abi/abi.sums
+++ b/firmware/patternflow/abi/abi.sums
@@ -1,0 +1,7 @@
+# sha256 of each LF-normalized header in abi/. Verified in CI by
+# check_abi_freeze.py; regenerate with --update ONLY alongside a
+# deliberate, append-only ABI change. The file exists so no change
+# to the one contract installed modules read can be an accident.
+2fdca28c596418529252f340133343c708a9a8aa11078435f5c733cbc922ec1b  pf_abi.h
+b6788eb470841b19738ce3bf2f81281903dd9839b9a87078133b0ec42460c481  pf_module.h
+5456ff3504023a7f126f57d0712085e7d6facb85f5f576e2e8fc447dec8b0b4a  pf_params.h

--- a/firmware/patternflow/abi/pf_abi.h
+++ b/firmware/patternflow/abi/pf_abi.h
@@ -1,3 +1,6 @@
+// ═══ FROZEN CONTRACT ═══ Installed .pfm modules read this layout WITHOUT
+// recompiling. Append at the tail only; bump PF_ABI_MODULE_VERSION; then
+// refresh abi.sums (check_abi_freeze.py --update) — CI fails on any drift.
 // Patternflow host <-> loadable pattern module ABI.
 //
 // Included by BOTH sides:

--- a/firmware/patternflow/abi/pf_module.h
+++ b/firmware/patternflow/abi/pf_module.h
@@ -1,3 +1,6 @@
+// ═══ FROZEN CONTRACT ═══ Installed .pfm modules read this layout WITHOUT
+// recompiling. Append at the tail only; bump PF_ABI_MODULE_VERSION; then
+// refresh abi.sums (check_abi_freeze.py --update) — CI fails on any drift.
 // Patternflow module SDK — the ONLY header a loadable pattern includes.
 //
 // It provides the firmware's familiar surface (PFCanvas, PFMath, PFColor,

--- a/firmware/patternflow/abi/pf_params.h
+++ b/firmware/patternflow/abi/pf_params.h
@@ -1,3 +1,6 @@
+// ═══ FROZEN CONTRACT ═══ Installed .pfm modules read this layout WITHOUT
+// recompiling. Append at the tail only; bump PF_ABI_MODULE_VERSION; then
+// refresh abi.sums (check_abi_freeze.py --update) — CI fails on any drift.
 // Patternflow absolute param bus helpers (0..1000 wire scale).
 //
 // Shared by firmware presets and loadable modules. Priority per channel:

--- a/firmware/patternflow/features/pf_feature.h
+++ b/firmware/patternflow/features/pf_feature.h
@@ -48,6 +48,19 @@ struct PFFeatureFrame {
   int appMode;
 };
 
+// ── Widening this struct ────────────────────────────────────────────────
+//
+// New hooks and fields go AT THE TAIL, never inserted or reordered. Every
+// descriptor is a positional aggregate initializer, and adjacent fields of
+// the same type (the nav triple, the three runtime-toggle entries) reorder
+// without a compiler diagnostic - the build stays green and every feature
+// quietly wires the wrong function to the wrong hook. Out-of-tree features
+// recompile against the checkout they are copied onto, so a tail-append is
+// always safe for them: their shorter initializer list value-initializes the
+// new tail to null, which every dispatch site treats as "not implemented".
+//
+// After widening, `./firmware/bundles/build.sh all` is the test - a hook
+// change that compiles against one composition is not tested.
 struct PFFeature {
   // Identity. `cap` is the string this feature contributes to /api/status
   // caps (null = contributes nothing) — what the site and the lab probe

--- a/firmware/toolchain/check_abi_freeze.py
+++ b/firmware/toolchain/check_abi_freeze.py
@@ -1,0 +1,107 @@
+"""The module ABI does not move silently.
+
+    python firmware/toolchain/check_abi_freeze.py            # verify
+    python firmware/toolchain/check_abi_freeze.py --update   # re-pin, deliberately
+
+firmware/patternflow/abi/ is the one contract in this repository that is
+consumed WITHOUT recompiling: every installed .pfm module on every panel was
+compiled against some version of these structs and reads their exact byte
+layout at run time. The compiler cannot defend that boundary - it never sees
+the modules - and neither can a code review that does not know the rule. A
+reordered field, a widened type, an insertion anywhere but the tail: each one
+compiles clean, links clean, and silently misreads on hardware.
+
+The versioning discipline already exists (PF_ABI_VERSION is frozen at 1,
+modules stamp PF_ABI_MODULE_VERSION, the loader accepts the range, new fields
+append at the tail so older readers see a prefix they understand). What was
+missing is enforcement that a change HAPPENED ON PURPOSE. This pins a sha256
+of every abi header; CI fails on any drift.
+
+To change the ABI legitimately:
+  1. append at the tail - never insert, reorder, retype or remove;
+  2. bump PF_ABI_MODULE_VERSION and teach the loader the new range;
+  3. run this with --update in the same commit, and say in the commit message
+     what was appended and why the layout is still a prefix of itself.
+
+A comment-only edit trips this too. That is intended: refreshing the sums is
+the two-second acknowledgement that you know which directory you are in.
+
+License: MIT
+"""
+
+from __future__ import annotations
+
+import hashlib
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+ABI = ROOT / "patternflow" / "abi"
+SUMS = ABI / "abi.sums"
+
+if hasattr(sys.stdout, "reconfigure"):
+    sys.stdout.reconfigure(errors="replace")
+
+
+def digest(path: Path) -> str:
+    # LF-normalized so a checkout's line-ending policy cannot fake a change.
+    data = path.read_bytes().replace(b"\r\n", b"\n")
+    return hashlib.sha256(data).hexdigest()
+
+
+def current() -> dict[str, str]:
+    return {p.name: digest(p) for p in sorted(ABI.glob("*.h"))}
+
+
+def main() -> int:
+    now = current()
+
+    if "--update" in sys.argv[1:]:
+        lines = ["# sha256 of each LF-normalized header in abi/. Verified in CI by",
+                 "# check_abi_freeze.py; regenerate with --update ONLY alongside a",
+                 "# deliberate, append-only ABI change. The file exists so no change",
+                 "# to the one contract installed modules read can be an accident."]
+        lines += [f"{h}  {n}" for n, h in now.items()]
+        SUMS.write_text("\n".join(lines) + "\n", encoding="utf-8")
+        print(f"pinned {len(now)} abi header(s)")
+        return 0
+
+    if not SUMS.exists():
+        print("abi/abi.sums is missing - run with --update to pin the current ABI")
+        return 1
+
+    pinned: dict[str, str] = {}
+    for line in SUMS.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        h, _, n = line.partition("  ")
+        pinned[n] = h
+
+    problems = []
+    for name, h in now.items():
+        if name not in pinned:
+            problems.append(f"  {name}: new abi header, not pinned")
+        elif pinned[name] != h:
+            problems.append(f"  {name}: content changed")
+    for name in pinned:
+        if name not in now:
+            problems.append(f"  {name}: pinned but gone")
+
+    if problems:
+        print("the module ABI moved:\n")
+        print("\n".join(problems))
+        print(
+            "\nEvery installed .pfm on every panel reads this layout without\n"
+            "recompiling. If this change is deliberate: append-only, bump\n"
+            "PF_ABI_MODULE_VERSION, teach the loader the new range, then\n"
+            "  python firmware/toolchain/check_abi_freeze.py --update\n"
+            "in the same commit. If it is not deliberate, revert it.")
+        return 1
+
+    print(f"abi frozen: {len(now)} header(s) match abi.sums")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/patternflow-audio-extension/README.md
+++ b/tools/patternflow-audio-extension/README.md
@@ -1,8 +1,9 @@
 # Patternflow Audio Chrome Extension
 
 Captures audio from the currently active Chrome/Edge tab, shows a live
-spectrum, maps editable frequency bands to Patternflow knobs, and sends
-normalized knob deltas over WebSocket.
+spectrum, maps editable frequency bands to Patternflow knobs, and streams
+the four knob lanes over WebSocket. The wire protocol is a written contract:
+[`docs/audio-ws-spec.md`](../../docs/audio-ws-spec.md).
 
 The extension uses the same Patternflow mark as the web app for its toolbar
 icon and popup header.


### PR DESCRIPTION
The question behind this is Simone's from #349: if the core keeps improving, do things built against it keep working? The promises existed in three states — one versioned and enforced, one versioned but unlocked, several unwritten. Now all are written; the strongest has an enforcer.

**The ABI lock.** `abi/` is consumed without recompiling — every installed `.pfm` reads the byte layout at run time, so the compiler can never defend it. The versioning discipline existed (frozen `PF_ABI_VERSION`, module stamps, loader range); what was missing was proof a change happened *on purpose*. `abi.sums` pins each header's hash, `check_abi_freeze.py` verifies in CI, `--update` re-pins deliberately. Proven both directions: planted drift caught, restore passes.

**The unwritten wire, written.** `docs/audio-ws-spec.md` — the :81 WebSocket had two live implementations and rest-api.md literally said "not part of this contract". Now: messages, lane semantics and priority, the five-second hands-win rule, unknown-prefix compatibility, and the one-in-flight pacing rule. `rest-api.md` 1.1 adds `lanes`/`laneActive`/`featureNav`, the `/api/audio-in` endpoints, and rewrites the endpoint-gating convention for composition gating.

**The rest stated where it's read.** The widening rule on `PFFeature` itself (tail-append only, and why a shorter out-of-tree initializer is always safe), and EDITIONS.md's new "What is promised, and to whom" — three locked edges, and the explicit non-promise for everything inside, with the rename as the standing example: forty files moved and every contract held.

Verified: boundary/console/sources checks pass, ABI freeze passes with a proven negative, all three editions build and pass the marker scan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)