### PR TITLE
audio: the microphone gets a gain stage, because Espressif says so

### DIFF
--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -309,9 +309,9 @@ nothing it can do that a script cannot.
 
 | Endpoint | Meaning |
 |---|---|
-| `GET /api/audio-in` | Full state: `micOn`, `source` (`"off"`, `"pdm"`, `"pdm (no mic - data pin idle)"`, `"synth"`), raw `rawPeak`/`rawDc`, per-band config (`hzMin`/`hzMax`/`inMin`/`inMax`/`gain`/`outMin`/`outMax`/`knob`/`muted`), `hzRange`, and a 40-bucket log `spec`. |
+| `GET /api/audio-in` | Full state: `micOn`, `micGain` (input gain, 1..16, applied to mic samples before analysis - raw fields stay unscaled), `source` (`"off"`, `"pdm"`, `"pdm (no mic - data pin idle)"`, `"synth"`), raw `rawPeak`/`rawDc`, per-band config (`hzMin`/`hzMax`/`inMin`/`inMax`/`gain`/`outMin`/`outMax`/`knob`/`muted`), `hzRange`, and a 40-bucket log `spec`. |
 | `GET /api/audio-in?levels=1` | The polling shape: `levels`, `outputs`, `spectrum`, `dropped` and nothing configurable — the page owns the config after reading it once. |
-| `POST /api/audio-in` | `mic=0/1` switches the whole feature (installs/releases the I2S driver). `band=N` plus any subset of the band fields updates one band; partial updates are the point, so a dragged handle cannot clobber the other three. |
+| `POST /api/audio-in` | `mic=0/1` switches the whole feature (installs/releases the I2S driver). `micGain=1..16` sets the input gain. `band=N` plus any subset of the band fields updates one band; partial updates are the point, so a dragged handle cannot clobber the other three. |
 | `POST /api/audio-in/reset` | Back to the measured defaults. |
 
 `micDropped` in `/api/status`'s `audioIn` block counts capture hops discarded

--- a/firmware/patternflow/console/audio-in.html
+++ b/firmware/patternflow/console/audio-in.html
@@ -707,6 +707,15 @@ padding:6px 0;margin-bottom:12px}
 <p class="wrap-note" id="heapline"></p>
 
 <label class="drive"><input type="checkbox" id="mic"> <b>Microphone</b></label>
+<div class="global" style="margin:2px 0 8px">
+  <label><span>Mic gain</span>
+    <input id="micGain" type="range" min="1" max="16" step="0.5" value="8"></label>
+  <output id="micGainOut" class="value">8.0x</output>
+</div>
+<p class="wrap-note">The S3's PDM input runs quiet by design (a loud room peaks near 3% of
+full scale), so samples are multiplied before analysis. Raise this if quiet sounds barely
+register, lower it if everything slams the top. Raw peak/dc in the header stay unscaled so
+a wiring problem still looks like one.</p>
 <p class="wrap-note">The panel listens, and the four bands below turn the four knobs, so patterns
 react to the room with no computer in it.
 <br><br>
@@ -1368,6 +1377,10 @@ function paintLive() {
                knob: b.knob, muted: b.muted === true };
     });
     $('mic').checked = !!d.micOn;
+    if (typeof d.micGain === 'number'){
+      $('micGain').value = d.micGain;
+      $('micGainOut').textContent = d.micGain.toFixed(1) + 'x';
+    }
     paintHeap();
     buildBands();
     renderBandTabs();
@@ -1396,6 +1409,17 @@ function paintHeap(){
   };
   x.send();
 }
+
+$('micGain').addEventListener('input', function(){
+  $('micGainOut').textContent = Number($('micGain').value).toFixed(1) + 'x';
+});
+// Send on release, not per pixel: one slider, one save, one NVS write.
+$('micGain').addEventListener('change', function(){
+  var x = new XMLHttpRequest();
+  x.open('POST', '/api/audio-in');
+  x.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded');
+  x.send('micGain=' + Number($('micGain').value).toFixed(1));
+});
 
 $('mic').addEventListener('change', function(){
   var on = $('mic').checked;

--- a/firmware/patternflow/features/audio_in/audio_in_index.h
+++ b/firmware/patternflow/features/audio_in/audio_in_index.h
@@ -717,6 +717,15 @@ padding:6px 0;margin-bottom:12px}
 <p class="wrap-note" id="heapline"></p>
 
 <label class="drive"><input type="checkbox" id="mic"> <b>Microphone</b></label>
+<div class="global" style="margin:2px 0 8px">
+  <label><span>Mic gain</span>
+    <input id="micGain" type="range" min="1" max="16" step="0.5" value="8"></label>
+  <output id="micGainOut" class="value">8.0x</output>
+</div>
+<p class="wrap-note">The S3's PDM input runs quiet by design (a loud room peaks near 3% of
+full scale), so samples are multiplied before analysis. Raise this if quiet sounds barely
+register, lower it if everything slams the top. Raw peak/dc in the header stay unscaled so
+a wiring problem still looks like one.</p>
 <p class="wrap-note">The panel listens, and the four bands below turn the four knobs, so patterns
 react to the room with no computer in it.
 <br><br>
@@ -1378,6 +1387,10 @@ function paintLive() {
                knob: b.knob, muted: b.muted === true };
     });
     $('mic').checked = !!d.micOn;
+    if (typeof d.micGain === 'number'){
+      $('micGain').value = d.micGain;
+      $('micGainOut').textContent = d.micGain.toFixed(1) + 'x';
+    }
     paintHeap();
     buildBands();
     renderBandTabs();
@@ -1406,6 +1419,17 @@ function paintHeap(){
   };
   x.send();
 }
+
+$('micGain').addEventListener('input', function(){
+  $('micGainOut').textContent = Number($('micGain').value).toFixed(1) + 'x';
+});
+// Send on release, not per pixel: one slider, one save, one NVS write.
+$('micGain').addEventListener('change', function(){
+  var x = new XMLHttpRequest();
+  x.open('POST', '/api/audio-in');
+  x.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded');
+  x.send('micGain=' + Number($('micGain').value).toFixed(1));
+});
 
 $('mic').addEventListener('change', function(){
   var on = $('mic').checked;

--- a/firmware/patternflow/features/audio_in/core_audio_fft.h
+++ b/firmware/patternflow/features/audio_in/core_audio_fft.h
@@ -245,11 +245,23 @@ inline void analyze(uint32_t tick) {
 
   const uint32_t t0 = micros();
   fill(tick);
+  // Peak and DC are measured BEFORE the gain, then the gain is applied in
+  // the same pass. Order matters twice over: rawPeak/rawDc stay what the
+  // silicon returned (the diagnostic /api/status documents them as), and the
+  // dead-rail detector keeps its physical threshold - a floating pin reads
+  // |dc| ~0.94 and a real mic ~0.005, and gaining both before the comparison
+  // would push a healthy mic toward the trip point instead of away from it.
+  // Gain is microphone-only: the synthetic source is already full-scale.
+  const float g = PFAudioPdm::available() ? PFAudioInMap::micGain : 1.0f;
   float pk = 0.0f, sum = 0.0f;
   for (int i = 0; i < N; i++) {
     const float a = fabsf(re[i]);
     if (a > pk) pk = a;
     sum += re[i];
+    float v = re[i] * g;
+    if (v > 1.0f) v = 1.0f;
+    if (v < -1.0f) v = -1.0f;
+    re[i] = v;
   }
   rawPeak = pk;
   rawDc = sum / (float)N;

--- a/firmware/patternflow/features/audio_in/core_audio_in_http.h
+++ b/firmware/patternflow/features/audio_in/core_audio_in_http.h
@@ -101,6 +101,8 @@ inline void handleGet() {
   j += PFAudioFFT::sourceLabel();
   j += "\",\"micOn\":";
   j += PFAudioInMap::micOn ? "true" : "false";
+  j += ",\"micGain\":";
+  j += String(PFAudioInMap::micGain, 1);
   j += ",\"rawPeak\":";
   j += String(PFAudioFFT::rawPeak, 5);
   j += ",\"rawDc\":";
@@ -180,6 +182,11 @@ inline void handleSet() {
     const String v = server().arg("mic");
     PFAudioInMap::micOn = (v == "1" || v == "true");
   }
+  if (server().hasArg("micGain")) {
+    PFAudioInMap::micGain = constrain(server().arg("micGain").toFloat(),
+                                      PFAudioInMap::MIC_GAIN_MIN,
+                                      PFAudioInMap::MIC_GAIN_MAX);
+  }
 
   if (server().hasArg("band")) {
     const int b = server().arg("band").toInt();
@@ -213,13 +220,8 @@ inline void handleSet() {
 }
 
 inline void handleReset() {
-  PFAudioInMap::Band d[4] = {
-      {   62.0f,  375.0f, 0.010f, 0.150f, 1.0f, 0.30f, 0.85f, 0, false},
-      {  375.0f, 1500.0f, 0.008f, 0.120f, 1.2f, 0.30f, 0.85f, 1, false},
-      { 1500.0f, 5000.0f, 0.004f, 0.050f, 1.6f, 0.30f, 0.85f, 2, false},
-      { 5000.0f, 8000.0f, 0.003f, 0.030f, 1.8f, 0.30f, 0.85f, 3, false},
-  };
-  for (int i = 0; i < 4; i++) PFAudioInMap::bands[i] = d[i];
+  PFAudioInMap::resetBands();
+  PFAudioInMap::micGain = 8.0f;
   PFAudioInMap::save();
   server().sendHeader("Cache-Control", "no-store");
   server().send(200, "application/json", "{\"ok\":true}");

--- a/firmware/patternflow/features/audio_in/core_audio_in_map.h
+++ b/firmware/patternflow/features/audio_in/core_audio_in_map.h
@@ -75,15 +75,37 @@ struct Band {
   bool muted;
 };
 
-// Defaults sized from the measurement above, not from taste. inMax descends
-// across the bands because the energy does: a hi-hat at the same loudness as
-// a kick puts a fraction of the level into band 4.
-inline Band bands[4] = {
-    {   62.0f,  375.0f, 0.010f, 0.150f, 1.0f, 0.30f, 0.85f, 0, false},
-    {  375.0f, 1500.0f, 0.008f, 0.120f, 1.2f, 0.30f, 0.85f, 1, false},
-    { 1500.0f, 5000.0f, 0.004f, 0.050f, 1.6f, 0.30f, 0.85f, 2, false},
-    { 5000.0f, 8000.0f, 0.003f, 0.030f, 1.8f, 0.30f, 0.85f, 3, false},
-};
+// Input gain, applied to microphone samples before the FFT. The S3's PDM
+// path is documented-quiet (esp-idf#8660: a tone that is uncomfortable in
+// the room peaks at 0.03 of full scale) and Espressif's own answer in that
+// thread is "apply the gain to the data that I2S read" - the IDF 5 driver
+// later grew a hardware amplify_num (1..15) that its header admits is the
+// same digital multiply. So: a runtime gain, WLED-style, user-tunable on
+// /audio-in. Applied only to the microphone - the synthetic source is
+// already full-scale and would clip.
+inline float micGain = 8.0f;
+constexpr float MIC_GAIN_MIN = 1.0f;
+constexpr float MIC_GAIN_MAX = 16.0f;
+
+inline Band bands[4];  // filled by resetBands() or load(); see below
+
+// Defaults sized from the measurement above, not from taste - and sized for
+// micGain 8, which is why they look 8x the numbers in that note. inMax
+// descends across the bands because the energy does: a hi-hat at the same
+// loudness as a kick puts a fraction of the level into band 4.
+//
+// One function rather than two literal tables: the HTTP reset handler and
+// the fresh-boot path both call this, and the two copies they used to keep
+// in sync are exactly the kind of pair that drifts.
+inline void resetBands() {
+  const Band d[4] = {
+      {   62.0f,  375.0f, 0.08f, 1.00f, 1.0f, 0.30f, 0.85f, 0, false},
+      {  375.0f, 1500.0f, 0.06f, 0.95f, 1.2f, 0.30f, 0.85f, 1, false},
+      { 1500.0f, 5000.0f, 0.03f, 0.40f, 1.6f, 0.30f, 0.85f, 2, false},
+      { 5000.0f, 8000.0f, 0.02f, 0.25f, 1.8f, 0.30f, 0.85f, 3, false},
+  };
+  for (int i = 0; i < 4; i++) bands[i] = d[i];
+}
 
 // The analysis is 512 points at 16 kHz, so a bin is 31.25 Hz and the last
 // usable one is 8 kHz. Bin 0 is DC and never counted: a PDM mic has a
@@ -171,18 +193,26 @@ inline float travel(int b, float peakLevel) {
 // so adding a field to Band cannot resurrect somebody's old settings as
 // garbage - they get the defaults and retune, which is the safe direction.
 constexpr const char* NVS_NS = "pf-audioin";
-constexpr const char* NVS_KEY = "bands";
+// "bands8", not "bands": the shaping numbers only mean anything at a given
+// input gain, and gain landed after people had already tuned against the
+// ungained scale. Reading those old values under 8x gain would saturate
+// every band, so the key changed and the old blob is simply orphaned -
+// defaults and a retune, the same safe direction as a size mismatch.
+constexpr const char* NVS_KEY = "bands8";
 constexpr const char* NVS_MIC = "mic";
+constexpr const char* NVS_GAIN = "igain";
 
 inline void save() {
   Preferences p;
   if (!p.begin(NVS_NS, false)) return;
   p.putBytes(NVS_KEY, bands, sizeof(bands));
   p.putBool(NVS_MIC, micOn);
+  p.putFloat(NVS_GAIN, micGain);
   p.end();
 }
 
 inline void load() {
+  resetBands();  // the baseline; NVS overwrites it when a saved set exists
   Preferences p;
   if (!p.begin(NVS_NS, true)) return;
   if (p.getBytesLength(NVS_KEY) == sizeof(bands)) {
@@ -196,6 +226,7 @@ inline void load() {
     }
   }
   micOn = p.getBool(NVS_MIC, false);
+  micGain = constrain(p.getFloat(NVS_GAIN, micGain), MIC_GAIN_MIN, MIC_GAIN_MAX);
   p.end();
 }
 

--- a/firmware/patternflow/features/audio_in/core_audio_pdm.h
+++ b/firmware/patternflow/features/audio_in/core_audio_pdm.h
@@ -81,6 +81,18 @@
 #define PF_AUDIO_IN_PDM_ENABLED 1
 #endif
 
+// Downsample-ratio experiment, CLOSED. DSR_16S doubles the PDM clock
+// (fs*64 -> fs*128, 1.024 -> 2.048 MHz at 16 kHz); the hope was a mic whose
+// low-power threshold sits near 1 MHz waking up. Measured 2026-08-30 on this
+// hardware, same tone, same volume: tone rawPeak 0.0059 (DSR16) vs 0.0052
+// (DSR8) - inside run-to-run noise, matching esp-idf#8660's finding - and
+// DSR16 dragged the window rate to 56.6/s against DSR8's 60.6. So 8 stays
+// the default; the define stays because the experiment cost one flag and the
+// next microphone model may answer differently.
+#ifndef PF_AUDIO_IN_PDM_DSR16
+#define PF_AUDIO_IN_PDM_DSR16 0
+#endif
+
 #if PF_AUDIO_IN_PDM_ENABLED
 #include <driver/i2s.h>
 #if !SOC_I2S_SUPPORTS_PDM_RX
@@ -198,10 +210,15 @@ inline void begin() {
     return;
   }
 
+#if PF_AUDIO_IN_PDM_DSR16
+  i2s_set_pdm_rx_down_sample(PORT, I2S_PDM_DSR_16S);
+#endif
+
   for (int i = 0; i < WINDOW; i++) ring[i] = 0.0f;
   live = true;
-  Serial.printf("[AUDIO-IN] PDM up: CLK=%d DAT=%d %luHz mono left\n",
-                PF_AUDIO_IN_PDM_CLK, PF_AUDIO_IN_PDM_DAT, (unsigned long)RATE);
+  Serial.printf("[AUDIO-IN] PDM up: CLK=%d DAT=%d %luHz mono left dsr=%d\n",
+                PF_AUDIO_IN_PDM_CLK, PF_AUDIO_IN_PDM_DAT, (unsigned long)RATE,
+                PF_AUDIO_IN_PDM_DSR16 ? 16 : 8);
 }
 
 // Read one hop, slide it into the ring, and hand back a whole window.
@@ -265,11 +282,11 @@ inline bool readWindow(float* dst) {
 
   // Slide: the previous hop becomes the window's first half.
   for (int i = 0; i < WINDOW - HOP; i++) ring[i] = ring[i + HOP];
-  // int16 full scale to roughly +/-1. Do NOT normalise or auto-gain here: the
-  // S3's PDM input is documented low-amplitude (esp-idf#8660), and rawPeak at
-  // /api/status is how anyone finds that out. A scaled signal would report a
-  // healthy peak from nothing. Gain belongs downstream, once there is a real
-  // number to size it against.
+  // int16 full scale to roughly +/-1, and nothing else: no gain here. The
+  // real number the silicon returned has to survive to the diagnostics
+  // (rawPeak/rawDc are documented as raw) and to the dead-rail check. The
+  // user-tunable microphone gain is applied downstream in analyze(), after
+  // those are measured from the same window.
   const float k = 1.0f / 32768.0f;
   const int n = samples < HOP ? samples : HOP;
   for (int i = 0; i < n; i++) ring[WINDOW - HOP + i] = (float)raw[i] * k;

--- a/firmware/toolchain/port_audio_ui.py
+++ b/firmware/toolchain/port_audio_ui.py
@@ -161,6 +161,15 @@ padding:6px 0;margin-bottom:12px}
 <p class="wrap-note" id="heapline"></p>
 
 <label class="drive"><input type="checkbox" id="mic"> <b>Microphone</b></label>
+<div class="global" style="margin:2px 0 8px">
+  <label><span>Mic gain</span>
+    <input id="micGain" type="range" min="1" max="16" step="0.5" value="8"></label>
+  <output id="micGainOut" class="value">8.0x</output>
+</div>
+<p class="wrap-note">The S3's PDM input runs quiet by design (a loud room peaks near 3% of
+full scale), so samples are multiplied before analysis. Raise this if quiet sounds barely
+register, lower it if everything slams the top. Raw peak/dc in the header stay unscaled so
+a wiring problem still looks like one.</p>
 <p class="wrap-note">The panel listens, and the four bands below turn the four knobs, so patterns
 react to the room with no computer in it.
 <br><br>
@@ -326,6 +335,10 @@ function paintLive() {
                knob: b.knob, muted: b.muted === true };
     });
     $('mic').checked = !!d.micOn;
+    if (typeof d.micGain === 'number'){
+      $('micGain').value = d.micGain;
+      $('micGainOut').textContent = d.micGain.toFixed(1) + 'x';
+    }
     paintHeap();
     buildBands();
     renderBandTabs();
@@ -354,6 +367,17 @@ function paintHeap(){
   };
   x.send();
 }
+
+$('micGain').addEventListener('input', function(){
+  $('micGainOut').textContent = Number($('micGain').value).toFixed(1) + 'x';
+});
+// Send on release, not per pixel: one slider, one save, one NVS write.
+$('micGain').addEventListener('change', function(){
+  var x = new XMLHttpRequest();
+  x.open('POST', '/api/audio-in');
+  x.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded');
+  x.send('micGain=' + Number($('micGain').value).toFixed(1));
+});
 
 $('mic').addEventListener('change', function(){
   var on = $('mic').checked;


### PR DESCRIPTION
"Sensitivity feels weak" turns out to be the S3's documented PDM behaviour ([esp-idf#8660](https://github.com/espressif/esp-idf/issues/8660)): DSR changes were tested there and did nothing, and Espressif's own engineer closes with *"the only way might be applying the gain to the data that I2S read"*. The IDF 5 driver later grew a hardware `amplify_num` (1..15) whose header admits it is the same digital multiply. WLED-SR runs 0.1–6.5× manual gain for exactly this class of hardware.

**The stage:** `micGain`, runtime 1..16, default 8, NVS-persisted, slider on `/audio-in`. Applied in `analyze()`'s existing per-sample pass — peak/DC measured first, then multiply+clamp in the same loop, so it costs nothing. `rawPeak`/`rawDc` stay what the silicon returned (they're documented as raw, and the dead-rail detector's physical threshold must not move). Mic-only — synth is already full-scale.

Band defaults retuned for the gained scale, the two shadowing default tables unified into one `resetBands()`, and the NVS key moves `bands` → `bands8` on purpose: shaping tuned against the ungained scale would saturate under 8×, so old tunings are orphaned the same safe direction as a size mismatch.

**Hardware:** slider round-trip measures exactly 8.0× between gain 16 and 2; quiet room sits at 0.02–0.15 instead of 0.003–0.02; a modest tone drives band1 to 0.87; settings survive two reflashes.

**DSR_16S experiment, closed with numbers:** same tone, same volume — tone rawPeak 0.0059 (DSR16) vs 0.0052 (DSR8), run-to-run noise, and DSR16 dragged the window rate to 56.6/s vs 60.6. DSR8 stays; the define and the measurements stay beside it.

All three editions build and pass the marker scan; boundary and console checks green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)