### PR TITLE
audio: bands ride their own envelopes, and the gate learned the hard way

### DIFF
--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -309,9 +309,9 @@ nothing it can do that a script cannot.
 
 | Endpoint | Meaning |
 |---|---|
-| `GET /api/audio-in` | Full state: `micOn`, `micGain` (input gain, 1..16, applied to mic samples before analysis - raw fields stay unscaled), `source` (`"off"`, `"pdm"`, `"pdm (no mic - data pin idle)"`, `"synth"`), raw `rawPeak`/`rawDc`, per-band config (`hzMin`/`hzMax`/`inMin`/`inMax`/`gain`/`outMin`/`outMax`/`knob`/`muted`), `hzRange`, and a 40-bucket log `spec`. |
-| `GET /api/audio-in?levels=1` | The polling shape: `levels`, `outputs`, `spectrum`, `dropped` and nothing configurable — the page owns the config after reading it once. |
-| `POST /api/audio-in` | `mic=0/1` switches the whole feature (installs/releases the I2S driver). `micGain=1..16` sets the input gain. `band=N` plus any subset of the band fields updates one band; partial updates are the point, so a dragged handle cannot clobber the other three. |
+| `GET /api/audio-in` | Full state: `micOn`, `micGain` (input gain, 1..16, applied to mic samples before analysis - raw fields stay unscaled), `autoRange` (each band self-normalizes against its tracked floor/peak envelope; on by default), `source` (`"off"`, `"pdm"`, `"pdm (no mic - data pin idle)"`, `"synth"`), raw `rawPeak`/`rawDc`, per-band config (`hzMin`/`hzMax`/`inMin`/`inMax`/`gain`/`outMin`/`outMax`/`knob`/`muted`), `hzRange`, and a 40-bucket log `spec`. |
+| `GET /api/audio-in?levels=1` | The polling shape: `levels`, `levelsN` (the level normalized inside the band's tracked range - what the mapping consumes in auto mode), `outputs`, `spectrum`, `dropped` and nothing configurable — the page owns the config after reading it once. |
+| `POST /api/audio-in` | `mic=0/1` switches the whole feature (installs/releases the I2S driver). `micGain=1..16` sets the input gain; `auto=0/1` switches per-band auto-ranging. `band=N` plus any subset of the band fields updates one band; partial updates are the point, so a dragged handle cannot clobber the other three. |
 | `POST /api/audio-in/reset` | Back to the measured defaults. |
 
 `micDropped` in `/api/status`'s `audioIn` block counts capture hops discarded

--- a/firmware/patternflow/console/audio-in.html
+++ b/firmware/patternflow/console/audio-in.html
@@ -699,6 +699,8 @@ color:var(--faint);margin-left:auto}
 .drive{display:flex;gap:8px;align-items:center;font-size:13px;color:var(--muted);
 padding:6px 0;margin-bottom:12px}
 .drive input{accent-color:var(--led)}
+/* Auto range: the absolute in-window is not in the path, so its handles go. */
+body.auto-on .h-in-min, body.auto-on .h-in-max { display:none }
 </style>
 </head>
 <body>
@@ -716,6 +718,14 @@ padding:6px 0;margin-bottom:12px}
 full scale), so samples are multiplied before analysis. Raise this if quiet sounds barely
 register, lower it if everything slams the top. Raw peak/dc in the header stay unscaled so
 a wiring problem still looks like one.</p>
+
+<label class="drive"><input type="checkbox" id="autoRange"> <b>Auto range</b></label>
+<p class="wrap-note">Each band tracks its own recent floor and peak and rides inside that
+window, so a quiet verse, a loud chorus and the next track all fill the same knob range a
+few seconds after they start. Two measurements half an hour apart put the same band's
+level four-to-one apart on the same stereo, which is why fixed ranges kept going dead.
+Off, the graph's left and right handles are absolute again, extension-style, for tuning
+against one known source.</p>
 <p class="wrap-note">The panel listens, and the four bands below turn the four knobs, so patterns
 react to the room with no computer in it.
 <br><br>
@@ -1003,7 +1013,7 @@ function buildPlot(el, band) {
       ['inMax', Math.abs(x - band.inMax)],
       ['outMin', Math.abs(y - band.outMin) + 0.04],
       ['outMax', Math.abs(y - band.outMax) + 0.04]
-    ].sort((a, b) => a[1] - b[1])[0][0];
+    ].filter(function(c){ return !window.AUTO_ON || (c[0] !== 'inMin' && c[0] !== 'inMax'); }).sort(function(a, b){ return a[1] - b[1]; })[0][0];
     handles[dragging].classList.add('on');
     plot.setPointerCapture(event.pointerId);
     event.preventDefault();
@@ -1289,11 +1299,18 @@ function persistConfig() {
     saveTimer = null;
     var jobs = Object.keys(pending);
     pending = {};
+    // While auto displays, the bands carry the fixed relative window for the
+    // graph - so those two fields are simply not sent, and the server keeps
+    // the manual tuning underneath. Everything else (frequency range, boost,
+    // knob range, knob, mute) still saves; the first version of this guard
+    // returned early and silently dropped all of it.
+    var auto = $('autoRange').checked;
     jobs.forEach(function(i){
       var b = config.bands[i];
       var body = 'band=' + i +
         '&hzMin=' + b.hzMin.toFixed(1) + '&hzMax=' + b.hzMax.toFixed(1) +
-        '&inMin=' + b.inMin.toFixed(4) + '&inMax=' + b.inMax.toFixed(4) +
+        (auto ? '' :
+        '&inMin=' + b.inMin.toFixed(4) + '&inMax=' + b.inMax.toFixed(4)) +
         '&gain=' + b.gain.toFixed(3) +
         '&outMin=' + b.outMin.toFixed(3) + '&outMax=' + b.outMax.toFixed(3) +
         '&knob=' + b.knob + '&muted=' + (b.muted ? '1' : '0');
@@ -1329,6 +1346,31 @@ function poll() {
 // about capture status. Kept in the extension's own terms — levels, outputs,
 // spectrum, entry.plot.live, the 0.995 peak decay — so it stays comparable to
 // the file it came from.
+// In auto mode the mapping consumes the NORMALIZED level, so the dot, the
+// meters and the travel readout paint from levelsN - what you see is what
+// the knob gets - and the in-handles are hidden because the window they set
+// is not in the path. The lifted extension code is untouched: we swap what
+// "the level" means and which inMin/inMax the local bands carry for display.
+var AUTO_LO = 0.10, AUTO_HI = 0.95;
+var manualIn = null;   // saved [inMin,inMax] per band while auto displays
+function applyAutoDisplay(on){
+  if (!config.bands.length) return;
+  if (on && !manualIn){
+    manualIn = config.bands.map(function(b){ return [b.inMin, b.inMax]; });
+    config.bands.forEach(function(b){ b.inMin = AUTO_LO; b.inMax = AUTO_HI; });
+  } else if (!on && manualIn){
+    config.bands.forEach(function(b, i){
+      b.inMin = manualIn[i][0]; b.inMax = manualIn[i][1];
+    });
+    manualIn = null;
+  }
+  window.AUTO_ON = on;
+  document.body.classList.toggle('auto-on', on);
+  buildBands();
+  renderBandTabs();
+  renderSpectrumBands();
+}
+
 function paintLive() {
   if (!state) return;
 
@@ -1338,7 +1380,13 @@ function paintLive() {
   $('srcRaw').textContent = 'peak ' + Number(state.rawPeak).toFixed(5) +
                             '  dc ' + Number(state.rawDc).toFixed(5);
 
-  var levels = state.levels || [];
+  if ($('autoRange').checked && config.bands.length){
+    for (var ai = 0; ai < config.bands.length; ai++){
+      config.bands[ai].inMin = AUTO_LO;
+      config.bands[ai].inMax = AUTO_HI;
+    }
+  }
+  var levels = ($('autoRange').checked ? state.levelsN : state.levels) || [];
   var outputs = state.outputs || [];
   for (var i = 0; i < bandEls.length; i++) {
     var entry = bandEls[i];
@@ -1377,6 +1425,8 @@ function paintLive() {
                knob: b.knob, muted: b.muted === true };
     });
     $('mic').checked = !!d.micOn;
+    $('autoRange').checked = !!d.autoRange;
+    if (d.autoRange) applyAutoDisplay(true);
     if (typeof d.micGain === 'number'){
       $('micGain').value = d.micGain;
       $('micGainOut').textContent = d.micGain.toFixed(1) + 'x';
@@ -1419,6 +1469,15 @@ $('micGain').addEventListener('change', function(){
   x.open('POST', '/api/audio-in');
   x.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded');
   x.send('micGain=' + Number($('micGain').value).toFixed(1));
+});
+
+$('autoRange').addEventListener('change', function(){
+  var on = $('autoRange').checked;
+  var x = new XMLHttpRequest();
+  x.open('POST', '/api/audio-in');
+  x.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded');
+  x.send('auto=' + (on ? '1' : '0'));
+  applyAutoDisplay(on);
 });
 
 $('mic').addEventListener('change', function(){

--- a/firmware/patternflow/features/audio_in/audio_in_index.h
+++ b/firmware/patternflow/features/audio_in/audio_in_index.h
@@ -709,6 +709,8 @@ color:var(--faint);margin-left:auto}
 .drive{display:flex;gap:8px;align-items:center;font-size:13px;color:var(--muted);
 padding:6px 0;margin-bottom:12px}
 .drive input{accent-color:var(--led)}
+/* Auto range: the absolute in-window is not in the path, so its handles go. */
+body.auto-on .h-in-min, body.auto-on .h-in-max { display:none }
 </style>
 </head>
 <body>
@@ -726,6 +728,14 @@ padding:6px 0;margin-bottom:12px}
 full scale), so samples are multiplied before analysis. Raise this if quiet sounds barely
 register, lower it if everything slams the top. Raw peak/dc in the header stay unscaled so
 a wiring problem still looks like one.</p>
+
+<label class="drive"><input type="checkbox" id="autoRange"> <b>Auto range</b></label>
+<p class="wrap-note">Each band tracks its own recent floor and peak and rides inside that
+window, so a quiet verse, a loud chorus and the next track all fill the same knob range a
+few seconds after they start. Two measurements half an hour apart put the same band's
+level four-to-one apart on the same stereo, which is why fixed ranges kept going dead.
+Off, the graph's left and right handles are absolute again, extension-style, for tuning
+against one known source.</p>
 <p class="wrap-note">The panel listens, and the four bands below turn the four knobs, so patterns
 react to the room with no computer in it.
 <br><br>
@@ -1013,7 +1023,7 @@ function buildPlot(el, band) {
       ['inMax', Math.abs(x - band.inMax)],
       ['outMin', Math.abs(y - band.outMin) + 0.04],
       ['outMax', Math.abs(y - band.outMax) + 0.04]
-    ].sort((a, b) => a[1] - b[1])[0][0];
+    ].filter(function(c){ return !window.AUTO_ON || (c[0] !== 'inMin' && c[0] !== 'inMax'); }).sort(function(a, b){ return a[1] - b[1]; })[0][0];
     handles[dragging].classList.add('on');
     plot.setPointerCapture(event.pointerId);
     event.preventDefault();
@@ -1299,11 +1309,18 @@ function persistConfig() {
     saveTimer = null;
     var jobs = Object.keys(pending);
     pending = {};
+    // While auto displays, the bands carry the fixed relative window for the
+    // graph - so those two fields are simply not sent, and the server keeps
+    // the manual tuning underneath. Everything else (frequency range, boost,
+    // knob range, knob, mute) still saves; the first version of this guard
+    // returned early and silently dropped all of it.
+    var auto = $('autoRange').checked;
     jobs.forEach(function(i){
       var b = config.bands[i];
       var body = 'band=' + i +
         '&hzMin=' + b.hzMin.toFixed(1) + '&hzMax=' + b.hzMax.toFixed(1) +
-        '&inMin=' + b.inMin.toFixed(4) + '&inMax=' + b.inMax.toFixed(4) +
+        (auto ? '' :
+        '&inMin=' + b.inMin.toFixed(4) + '&inMax=' + b.inMax.toFixed(4)) +
         '&gain=' + b.gain.toFixed(3) +
         '&outMin=' + b.outMin.toFixed(3) + '&outMax=' + b.outMax.toFixed(3) +
         '&knob=' + b.knob + '&muted=' + (b.muted ? '1' : '0');
@@ -1339,6 +1356,31 @@ function poll() {
 // about capture status. Kept in the extension's own terms — levels, outputs,
 // spectrum, entry.plot.live, the 0.995 peak decay — so it stays comparable to
 // the file it came from.
+// In auto mode the mapping consumes the NORMALIZED level, so the dot, the
+// meters and the travel readout paint from levelsN - what you see is what
+// the knob gets - and the in-handles are hidden because the window they set
+// is not in the path. The lifted extension code is untouched: we swap what
+// "the level" means and which inMin/inMax the local bands carry for display.
+var AUTO_LO = 0.10, AUTO_HI = 0.95;
+var manualIn = null;   // saved [inMin,inMax] per band while auto displays
+function applyAutoDisplay(on){
+  if (!config.bands.length) return;
+  if (on && !manualIn){
+    manualIn = config.bands.map(function(b){ return [b.inMin, b.inMax]; });
+    config.bands.forEach(function(b){ b.inMin = AUTO_LO; b.inMax = AUTO_HI; });
+  } else if (!on && manualIn){
+    config.bands.forEach(function(b, i){
+      b.inMin = manualIn[i][0]; b.inMax = manualIn[i][1];
+    });
+    manualIn = null;
+  }
+  window.AUTO_ON = on;
+  document.body.classList.toggle('auto-on', on);
+  buildBands();
+  renderBandTabs();
+  renderSpectrumBands();
+}
+
 function paintLive() {
   if (!state) return;
 
@@ -1348,7 +1390,13 @@ function paintLive() {
   $('srcRaw').textContent = 'peak ' + Number(state.rawPeak).toFixed(5) +
                             '  dc ' + Number(state.rawDc).toFixed(5);
 
-  var levels = state.levels || [];
+  if ($('autoRange').checked && config.bands.length){
+    for (var ai = 0; ai < config.bands.length; ai++){
+      config.bands[ai].inMin = AUTO_LO;
+      config.bands[ai].inMax = AUTO_HI;
+    }
+  }
+  var levels = ($('autoRange').checked ? state.levelsN : state.levels) || [];
   var outputs = state.outputs || [];
   for (var i = 0; i < bandEls.length; i++) {
     var entry = bandEls[i];
@@ -1387,6 +1435,8 @@ function paintLive() {
                knob: b.knob, muted: b.muted === true };
     });
     $('mic').checked = !!d.micOn;
+    $('autoRange').checked = !!d.autoRange;
+    if (d.autoRange) applyAutoDisplay(true);
     if (typeof d.micGain === 'number'){
       $('micGain').value = d.micGain;
       $('micGainOut').textContent = d.micGain.toFixed(1) + 'x';
@@ -1429,6 +1479,15 @@ $('micGain').addEventListener('change', function(){
   x.open('POST', '/api/audio-in');
   x.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded');
   x.send('micGain=' + Number($('micGain').value).toFixed(1));
+});
+
+$('autoRange').addEventListener('change', function(){
+  var on = $('autoRange').checked;
+  var x = new XMLHttpRequest();
+  x.open('POST', '/api/audio-in');
+  x.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded');
+  x.send('auto=' + (on ? '1' : '0'));
+  applyAutoDisplay(on);
 });
 
 $('mic').addEventListener('change', function(){

--- a/firmware/patternflow/features/audio_in/core_audio_fft.h
+++ b/firmware/patternflow/features/audio_in/core_audio_fft.h
@@ -42,6 +42,7 @@ constexpr int LOG2N = 9;
 constexpr float SAMPLE_HZ = 16000.0f;
 
 inline float re[N], im[N];
+inline float hann[N];
 inline float twCos[N / 2], twSin[N / 2];
 inline uint16_t brev[N];
 inline bool ready = false;
@@ -85,6 +86,12 @@ inline void begin() {
     brev[i] = (uint16_t)r;
   }
   for (int i = 0; i < N; i++) { re[i] = 0.0f; im[i] = 0.0f; }
+  // Hann, times 2: the window kills the rectangular-window leakage that was
+  // smearing strong bass into the high bands (there was no window at all
+  // before), and the factor 2 undoes its coherent gain of 0.5 so band
+  // levels keep the scale everything downstream was tuned against.
+  for (int i = 0; i < N; i++)
+    hann[i] = (1.0f - cosf(2.0f * (float)M_PI * i / (N - 1)));
   buildSource();
   // The microphone is NOT started here. It is installed and released by the
   // analysis task as the switch on /audio-in moves, so that a panel with the
@@ -261,7 +268,9 @@ inline void analyze(uint32_t tick) {
     float v = re[i] * g;
     if (v > 1.0f) v = 1.0f;
     if (v < -1.0f) v = -1.0f;
-    re[i] = v;
+    // Gain saturates BEFORE the window shapes the frame - a clipped loud
+    // sample still tapers at the edges, which is the point of the window.
+    re[i] = v * hann[i];
   }
   rawPeak = pk;
   rawDc = sum / (float)N;

--- a/firmware/patternflow/features/audio_in/core_audio_in_http.h
+++ b/firmware/patternflow/features/audio_in/core_audio_in_http.h
@@ -77,6 +77,13 @@ inline void handleGet() {
       if (i) j += ',';
       j += String(PFAudioFFT::bands[i], 4);
     }
+    // The level as the mapping consumes it in auto mode - the page paints
+    // its dot and meters from this so what you see is what the knob gets.
+    j += "],\"levelsN\":[";
+    for (int i = 0; i < 4; i++) {
+      if (i) j += ',';
+      j += String(PFAudioInMap::normalized(i, PFAudioFFT::bands[i]), 4);
+    }
     j += "],\"outputs\":[";
     for (int i = 0; i < 4; i++) {
       if (i) j += ',';
@@ -103,6 +110,8 @@ inline void handleGet() {
   j += PFAudioInMap::micOn ? "true" : "false";
   j += ",\"micGain\":";
   j += String(PFAudioInMap::micGain, 1);
+  j += ",\"autoRange\":";
+  j += PFAudioInMap::autoRange ? "true" : "false";
   j += ",\"rawPeak\":";
   j += String(PFAudioFFT::rawPeak, 5);
   j += ",\"rawDc\":";
@@ -181,6 +190,10 @@ inline void handleSet() {
   if (server().hasArg("mic")) {
     const String v = server().arg("mic");
     PFAudioInMap::micOn = (v == "1" || v == "true");
+  }
+  if (server().hasArg("auto")) {
+    const String v = server().arg("auto");
+    PFAudioInMap::autoRange = (v == "1" || v == "true");
   }
   if (server().hasArg("micGain")) {
     PFAudioInMap::micGain = constrain(server().arg("micGain").toFloat(),

--- a/firmware/patternflow/features/audio_in/core_audio_in_map.h
+++ b/firmware/patternflow/features/audio_in/core_audio_in_map.h
@@ -89,20 +89,36 @@ constexpr float MIC_GAIN_MAX = 16.0f;
 
 inline Band bands[4];  // filled by resetBands() or load(); see below
 
-// Defaults sized from the measurement above, not from taste - and sized for
-// micGain 8, which is why they look 8x the numbers in that note. inMax
-// descends across the bands because the energy does: a hi-hat at the same
-// loudness as a kick puts a fraction of the level into band 4.
+// Defaults sized from MUSIC, measured 2026-08-30: thirty seconds of a real
+// track at listening volume, per-band p10/p90 quantiles, at micGain 8.
+//
+//     band      p10..p90 measured     defaults below
+//     62-375    0.24 .. 0.66          0.20 .. 0.90
+//     375-1.5k  0.16 .. 0.49          0.12 .. 0.65
+//     1.5k-5k   0.05 .. 0.12          0.045 .. 0.16
+//     5k-8k     0.011 .. 0.019        0.012 .. 0.030
+//
+// The top band's numbers are microscopic and that is CONTENT, not silicon:
+// a white-noise sweep the same day measured the mic + PDM decimator flat to
+// within about 6 dB up to 7.5 kHz, so there is no hardware roll-off to
+// boost away. Music itself carries a fraction of its energy above 5 kHz
+// (the 1/f tilt), and the previous defaults - sized from a synthetic tone -
+// left inMax 8..10x above where music actually reaches, which read as "the
+// top band does not respond". Ranges sized to the content are the fix; a
+// hardware-response EQ would have been correcting a curve that is not there.
+//
+// inMin also clears the measured quiet-room floor per band (0.135/0.088/
+// 0.024/0.010) so silence does not wobble the knobs.
 //
 // One function rather than two literal tables: the HTTP reset handler and
 // the fresh-boot path both call this, and the two copies they used to keep
 // in sync are exactly the kind of pair that drifts.
 inline void resetBands() {
   const Band d[4] = {
-      {   62.0f,  375.0f, 0.08f, 1.00f, 1.0f, 0.30f, 0.85f, 0, false},
-      {  375.0f, 1500.0f, 0.06f, 0.95f, 1.2f, 0.30f, 0.85f, 1, false},
-      { 1500.0f, 5000.0f, 0.03f, 0.40f, 1.6f, 0.30f, 0.85f, 2, false},
-      { 5000.0f, 8000.0f, 0.02f, 0.25f, 1.8f, 0.30f, 0.85f, 3, false},
+      {   62.0f,  375.0f, 0.200f, 0.900f, 1.0f, 0.30f, 0.85f, 0, false},
+      {  375.0f, 1500.0f, 0.120f, 0.650f, 1.2f, 0.30f, 0.85f, 1, false},
+      { 1500.0f, 5000.0f, 0.045f, 0.160f, 1.6f, 0.30f, 0.85f, 2, false},
+      { 5000.0f, 8000.0f, 0.012f, 0.030f, 1.8f, 0.30f, 0.85f, 3, false},
   };
   for (int i = 0; i < 4; i++) bands[i] = d[i];
 }
@@ -161,17 +177,172 @@ inline float clamp01(float v) {
   return v;
 }
 
+// ── Auto range ──────────────────────────────────────────────────────────
+//
+// Static in-ranges cannot fit music. Two 30-second windows of the same
+// listening session, half an hour apart, measured band 2's level 4x apart -
+// verse against chorus, one track against the next - so ranges sized to any
+// one window leave bands dead in the next. This is the problem WLED's AGC
+// exists for, and this is the same idea per band: track a slow envelope of
+// each band's own floor and peak, normalize the level inside it, and let
+// the passage define the range instead of a constant.
+//
+// Attack is instant on both edges (a peak claims the top immediately, a
+// dropout claims the floor); release is a slow exponential, about eight
+// seconds to cross most of a gap at 60 analyses/second, so the range
+// breathes with the song without pumping on every bar. The span never
+// shrinks below MIN_SPAN: in silence both envelopes converge and the
+// division would otherwise amplify noise into a full-scale flutter.
+//
+// In auto mode the band's own inMin/inMax are NOT used - the normalized
+// level runs through a fixed relative window (squelch AUTO_LO, full at
+// AUTO_HI) and then the band's boost curve and knob range as always. Manual
+// mode is untouched and remains the extension-style absolute shaping.
+inline bool autoRange = true;
+
+// ── How the gate learned what it knows ──────────────────────────────────
+//
+// Three designs died on this hardware before this one, all measured:
+//
+//   v1  normalized against min/max envelopes. In silence the envelopes hug
+//       the noise floor and division turns its flutter into full-scale knob
+//       motion - all four knobs swinging 0.30..0.85 in a room with the
+//       keyboard untouched.
+//   v2  gated on envelope span. Better, but the span statistic is recent
+//       max minus recent min, and this board supplies spikes on schedule:
+//       every HTTP poll is a Wi-Fi burst, every burst makes the regulator
+//       whine audibly, and the mic hears it. One-frame spikes latched the
+//       instant-attack envelope for the whole release.
+//   v3  per-band span thresholds. Uncomparable 20-second runs - the noise
+//       is non-stationary, so constants tuned against one snapshot lost to
+//       the next.
+//
+// So the noise itself was finally measured (100 samples, silent room, the
+// worst case of a page polling at 10 Hz):
+//
+//   band    median   p95      max     music median (listening volume)
+//   62-375   0.146   0.204    0.271   0.37
+//   375-1.5k 0.040   0.085    0.228   0.30
+//   1.5k-5k  0.020   0.048    0.082   0.074
+//   5k-8k    0.017   0.021    0.042   0.015  <- at or below its own noise
+//
+// Which says: the spikes are rare and one sample long (p95 to max is a
+// cliff), music stands 2..7x above the noise MEDIAN in the three lower
+// bands, and band 4 at listening volume has no level story at all - it
+// only rises above its floor on genuinely strong treble, and pretending
+// otherwise is how v1 danced to hiss. Hence:
+//
+//   - a slow noise reference that learns only from quiet-zone samples,
+//   - a gate on sustained exceedance of that reference (three consecutive
+//     frames to open - a one-frame RF spike cannot vote three times),
+//   - a slow close (25 quiet frames) so musical gaps do not chatter it,
+//   - normalization from the reference to a peak envelope, never from a
+//     tracked minimum.
+inline float noiseRef[4] = {-1.0f, -1.0f, -1.0f, -1.0f};  // <0 = unlearned
+inline float envHi[4] = {0.0f, 0.0f, 0.0f, 0.0f};
+inline bool gateOpen[4] = {false, false, false, false};
+inline int gateVotes[4] = {0, 0, 0, 0};
+
+constexpr float NOISE_LEARN = 0.005f;  // reference EMA, ~3 s to settle
+// 1.5, not wider: the bass band's music floor sits only ~1.6x above its
+// noise reference, so a wider zone let quiet musical frames TEACH the
+// reference, which climbed toward the music and dragged the open threshold
+// with it - measured as the bass gate never opening while mids danced.
+constexpr float LEARN_ZONE = 1.5f;     // learn only when level < ref * this
+constexpr int WARMUP_FRAMES = 120;     // ~2 s of min-tracking at boot
+constexpr float OPEN_K = 1.8f;         // active when level > ref*K + ABS
+// Per band, one number, for one reason: the board's own Wi-Fi whine lives
+// in 375-1500 Hz, and its bursts turned out to be an HTTP transaction long
+// - several analysis frames, not one - so the mid band alone gets an
+// absolute floor its spikes cannot reach (they top out ~0.23; music sits
+// at 0.30+ there). Measured, like every other constant in this block.
+constexpr float OPEN_ABS[4] = {0.012f, 0.050f, 0.015f, 0.012f};
+constexpr int OPEN_VOTES = 8;          // ~130 ms sustained - outlasts a burst
+constexpr float CLOSE_K = 1.4f;        // below this counts as quiet
+constexpr int CLOSE_VOTES = 25;        // ~0.4 s of quiet to close
+constexpr float NORM_LO_K = 1.5f;      // normalization floor = ref * this
+constexpr float NORM_MIN_SPAN = 0.02f;
+constexpr float ENV_ATTACK = 0.3f;
+constexpr float ENV_RELEASE = 0.002f;
+// The relative response window the normalized level runs through (the
+// page shows the same 0.10..0.95 as the fixed in-handles in auto mode).
+constexpr float AUTO_LO = 0.10f;
+constexpr float AUTO_HI = 0.95f;
+
+inline int warmup = WARMUP_FRAMES;
+
+inline void trackEnvelopes(const float* level) {
+  const bool warming = warmup > 0;
+  if (warming) warmup--;
+  for (int i = 0; i < 4; i++) {
+    const float v = clamp01(level[i]);
+
+    // The reference learns the FLOOR, three rules deep: during warmup it
+    // takes the running minimum (so booting mid-song does not seed it with
+    // a bass hit); after that it moves only while the gate is CLOSED (an
+    // open gate means signal, and signal never teaches the floor); and only
+    // from samples inside the learn zone (a spike during silence is not the
+    // floor either).
+    if (noiseRef[i] < 0.0f) noiseRef[i] = v;
+    else if (warming) noiseRef[i] = min(noiseRef[i], v);
+    else if (!gateOpen[i] && v < noiseRef[i] * LEARN_ZONE + 0.005f)
+      noiseRef[i] += (v - noiseRef[i]) * NOISE_LEARN;
+
+    if (v > envHi[i]) envHi[i] += (v - envHi[i]) * ENV_ATTACK;
+    else envHi[i] += (v - envHi[i]) * ENV_RELEASE;
+    const float lo = noiseRef[i] * NORM_LO_K;
+    if (envHi[i] < lo + NORM_MIN_SPAN) envHi[i] = lo + NORM_MIN_SPAN;
+
+    const bool loud = v > noiseRef[i] * OPEN_K + OPEN_ABS[i];
+    const bool quiet = v < noiseRef[i] * CLOSE_K + OPEN_ABS[i];
+    if (!gateOpen[i]) {
+      // Opening stays strict-consecutive: an RF spike is one frame long and
+      // cannot vote three times in a row.
+      gateVotes[i] = loud ? gateVotes[i] + 1 : 0;
+      if (gateVotes[i] >= OPEN_VOTES) { gateOpen[i] = true; gateVotes[i] = 0; }
+    } else {
+      // Closing counts down by MAJORITY, not by consecutive quiet. The whine
+      // band's bursts kept resetting a consecutive counter in the tail right
+      // after music stopped, holding the gate open for noise to ride through
+      // (measured: one 0.85 knob jump in that window). A burst now costs
+      // three votes instead of all of them, so ~10% burst duty still closes
+      // the gate in about a second, while real music - mostly loud frames -
+      // drives the count straight back to zero.
+      if (quiet) gateVotes[i]++;
+      else gateVotes[i] = max(0, gateVotes[i] - 3);
+      if (gateVotes[i] >= CLOSE_VOTES) { gateOpen[i] = false; gateVotes[i] = 0; }
+    }
+  }
+}
+
+// The band's level as a position between its noise reference and its peak
+// envelope, 0..1. Zero while the gate is closed: the page paints its dot
+// from this, and a dot dancing to amplified hiss while the knob rests would
+// read as a bug in whichever half you looked at second.
+inline float normalized(int b, float level) {
+  if (!gateOpen[b]) return 0.0f;
+  const float lo = noiseRef[b] * NORM_LO_K;
+  return clamp01((level - lo) / max(envHi[b] - lo, NORM_MIN_SPAN));
+}
+
 // The extension's mapBandOutput, in C++. Same clamps, same order, same edge
 // cases - including inMax being forced at least 0.01 above inMin, which is
 // what stops a dragged handle pair from dividing by zero.
-inline float mapped(int b, float level) {
+inline float mappedWindow(int b, float level, float inMinRaw, float inMaxRaw) {
   const Band& x = bands[b];
-  const float inMin = clamp01(x.inMin);
-  const float inMax = max(inMin + 0.01f, clamp01(x.inMax));
+  const float inMin = clamp01(inMinRaw);
+  const float inMax = max(inMin + 0.01f, clamp01(inMaxRaw));
   const float gain = constrain(x.gain, 0.2f, 4.0f);
   float u = clamp01((level - inMin) / (inMax - inMin));
   u = powf(u, 1.0f / gain);
   return x.outMin + u * (x.outMax - x.outMin);
+}
+
+inline float mapped(int b, float level) {
+  if (autoRange)
+    return mappedWindow(b, normalized(b, level), AUTO_LO, AUTO_HI);
+  const Band& x = bands[b];
+  return mappedWindow(b, level, x.inMin, x.inMax);
 }
 
 // How much of its knob a band actually uses between silence and its own
@@ -184,6 +355,8 @@ inline float travel(int b, float peakLevel) {
   if (span < 0.001f) return 0.0f;
   return clamp01(fabsf(mapped(b, peakLevel) - mapped(b, 0.0f)) / span);
 }
+// (mapped() already routes through the auto window when autoRange is on, so
+// travel and the page's readouts follow whichever mode is live.)
 
 // ── Persistence ─────────────────────────────────────────────────────────
 //
@@ -198,9 +371,13 @@ constexpr const char* NVS_NS = "pf-audioin";
 // ungained scale. Reading those old values under 8x gain would saturate
 // every band, so the key changed and the old blob is simply orphaned -
 // defaults and a retune, the same safe direction as a size mismatch.
-constexpr const char* NVS_KEY = "bands8";
+// bands9: the defaults' meaning changed again (music-sized ranges), and a
+// saved set tuned against the tone-sized scale would leave the top bands
+// dead in exactly the way this change fixes.
+constexpr const char* NVS_KEY = "bands9";
 constexpr const char* NVS_MIC = "mic";
 constexpr const char* NVS_GAIN = "igain";
+constexpr const char* NVS_AUTO = "auto";
 
 inline void save() {
   Preferences p;
@@ -208,6 +385,7 @@ inline void save() {
   p.putBytes(NVS_KEY, bands, sizeof(bands));
   p.putBool(NVS_MIC, micOn);
   p.putFloat(NVS_GAIN, micGain);
+  p.putBool(NVS_AUTO, autoRange);
   p.end();
 }
 
@@ -227,6 +405,7 @@ inline void load() {
   }
   micOn = p.getBool(NVS_MIC, false);
   micGain = constrain(p.getFloat(NVS_GAIN, micGain), MIC_GAIN_MIN, MIC_GAIN_MAX);
+  autoRange = p.getBool(NVS_AUTO, autoRange);
   p.end();
 }
 

--- a/firmware/patternflow/features/audio_in/feature_audio_in.h
+++ b/firmware/patternflow/features/audio_in/feature_audio_in.h
@@ -66,6 +66,10 @@ inline void analysisTask(void*) {
     if (!PFAudioPdm::live) PFAudioPdm::begin();
 
     PFAudioFFT::analyze(tick++);
+    // Envelope tracking rides the analysis clock - once per window, here,
+    // never from the mapping (which also runs from HTTP polls and would
+    // double-count the release).
+    if (PFAudioInMap::micOn) PFAudioInMap::trackEnvelopes(PFAudioFFT::bands);
     // With a microphone the I2S read paces this loop, and without one nothing
     // blocks at all, so the synthetic path keeps the old 16 ms tick.
     //

--- a/firmware/toolchain/port_audio_ui.py
+++ b/firmware/toolchain/port_audio_ui.py
@@ -97,6 +97,11 @@ lifted = lift(js, [
 # Substituted here rather than in the extension: the extension is not wrong,
 # it simply has one theme. themeColor() is defined in the device half below
 # and re-reads on a theme change.
+# In auto-range mode the two in-handles are hidden, but buildPlot's
+# nearest-handle pick does not know about visibility - a drag near the right
+# edge would grab the invisible inMax and go nowhere. Filter them out of the
+# candidate list when AUTO_ON, substituted here for the same reason as
+# themeColor: the extension is not wrong, it just has no auto mode.
 for literal, name, why in [
     ("'#fbf7ef'", "--field", "the panel behind the bars"),
     ("'#d9d1c0'", "--rule", "the quarter lines"),
@@ -105,6 +110,13 @@ for literal, name, why in [
 ]:
     assert literal in lifted, "drawSpectrum no longer uses %s" % literal
     lifted = lifted.replace(literal, "themeColor('%s')" % name)
+
+_PICK_OLD = "].sort((a, b) => a[1] - b[1])[0][0];"
+_PICK_NEW = ("].filter(function(c){ return !window.AUTO_ON || "
+             "(c[0] !== 'inMin' && c[0] !== 'inMax'); })"
+             ".sort(function(a, b){ return a[1] - b[1]; })[0][0];")
+assert _PICK_OLD in lifted, "buildPlot's handle pick moved"
+lifted = lifted.replace(_PICK_OLD, _PICK_NEW)
 
 PAGE_TMPL = u'''<!doctype html>
 <html lang="en">
@@ -153,6 +165,8 @@ color:var(--faint);margin-left:auto}
 .drive{display:flex;gap:8px;align-items:center;font-size:13px;color:var(--muted);
 padding:6px 0;margin-bottom:12px}
 .drive input{accent-color:var(--led)}
+/* Auto range: the absolute in-window is not in the path, so its handles go. */
+body.auto-on .h-in-min, body.auto-on .h-in-max { display:none }
 </style>
 </head>
 <body>
@@ -170,6 +184,14 @@ padding:6px 0;margin-bottom:12px}
 full scale), so samples are multiplied before analysis. Raise this if quiet sounds barely
 register, lower it if everything slams the top. Raw peak/dc in the header stay unscaled so
 a wiring problem still looks like one.</p>
+
+<label class="drive"><input type="checkbox" id="autoRange"> <b>Auto range</b></label>
+<p class="wrap-note">Each band tracks its own recent floor and peak and rides inside that
+window, so a quiet verse, a loud chorus and the next track all fill the same knob range a
+few seconds after they start. Two measurements half an hour apart put the same band's
+level four-to-one apart on the same stereo, which is why fixed ranges kept going dead.
+Off, the graph's left and right handles are absolute again, extension-style, for tuning
+against one known source.</p>
 <p class="wrap-note">The panel listens, and the four bands below turn the four knobs, so patterns
 react to the room with no computer in it.
 <br><br>
@@ -247,11 +269,18 @@ function persistConfig() {
     saveTimer = null;
     var jobs = Object.keys(pending);
     pending = {};
+    // While auto displays, the bands carry the fixed relative window for the
+    // graph - so those two fields are simply not sent, and the server keeps
+    // the manual tuning underneath. Everything else (frequency range, boost,
+    // knob range, knob, mute) still saves; the first version of this guard
+    // returned early and silently dropped all of it.
+    var auto = $('autoRange').checked;
     jobs.forEach(function(i){
       var b = config.bands[i];
       var body = 'band=' + i +
         '&hzMin=' + b.hzMin.toFixed(1) + '&hzMax=' + b.hzMax.toFixed(1) +
-        '&inMin=' + b.inMin.toFixed(4) + '&inMax=' + b.inMax.toFixed(4) +
+        (auto ? '' :
+        '&inMin=' + b.inMin.toFixed(4) + '&inMax=' + b.inMax.toFixed(4)) +
         '&gain=' + b.gain.toFixed(3) +
         '&outMin=' + b.outMin.toFixed(3) + '&outMax=' + b.outMax.toFixed(3) +
         '&knob=' + b.knob + '&muted=' + (b.muted ? '1' : '0');
@@ -287,6 +316,31 @@ function poll() {
 // about capture status. Kept in the extension's own terms — levels, outputs,
 // spectrum, entry.plot.live, the 0.995 peak decay — so it stays comparable to
 // the file it came from.
+// In auto mode the mapping consumes the NORMALIZED level, so the dot, the
+// meters and the travel readout paint from levelsN - what you see is what
+// the knob gets - and the in-handles are hidden because the window they set
+// is not in the path. The lifted extension code is untouched: we swap what
+// "the level" means and which inMin/inMax the local bands carry for display.
+var AUTO_LO = 0.10, AUTO_HI = 0.95;
+var manualIn = null;   // saved [inMin,inMax] per band while auto displays
+function applyAutoDisplay(on){
+  if (!config.bands.length) return;
+  if (on && !manualIn){
+    manualIn = config.bands.map(function(b){ return [b.inMin, b.inMax]; });
+    config.bands.forEach(function(b){ b.inMin = AUTO_LO; b.inMax = AUTO_HI; });
+  } else if (!on && manualIn){
+    config.bands.forEach(function(b, i){
+      b.inMin = manualIn[i][0]; b.inMax = manualIn[i][1];
+    });
+    manualIn = null;
+  }
+  window.AUTO_ON = on;
+  document.body.classList.toggle('auto-on', on);
+  buildBands();
+  renderBandTabs();
+  renderSpectrumBands();
+}
+
 function paintLive() {
   if (!state) return;
 
@@ -296,7 +350,13 @@ function paintLive() {
   $('srcRaw').textContent = 'peak ' + Number(state.rawPeak).toFixed(5) +
                             '  dc ' + Number(state.rawDc).toFixed(5);
 
-  var levels = state.levels || [];
+  if ($('autoRange').checked && config.bands.length){
+    for (var ai = 0; ai < config.bands.length; ai++){
+      config.bands[ai].inMin = AUTO_LO;
+      config.bands[ai].inMax = AUTO_HI;
+    }
+  }
+  var levels = ($('autoRange').checked ? state.levelsN : state.levels) || [];
   var outputs = state.outputs || [];
   for (var i = 0; i < bandEls.length; i++) {
     var entry = bandEls[i];
@@ -335,6 +395,8 @@ function paintLive() {
                knob: b.knob, muted: b.muted === true };
     });
     $('mic').checked = !!d.micOn;
+    $('autoRange').checked = !!d.autoRange;
+    if (d.autoRange) applyAutoDisplay(true);
     if (typeof d.micGain === 'number'){
       $('micGain').value = d.micGain;
       $('micGainOut').textContent = d.micGain.toFixed(1) + 'x';
@@ -377,6 +439,15 @@ $('micGain').addEventListener('change', function(){
   x.open('POST', '/api/audio-in');
   x.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded');
   x.send('micGain=' + Number($('micGain').value).toFixed(1));
+});
+
+$('autoRange').addEventListener('change', function(){
+  var on = $('autoRange').checked;
+  var x = new XMLHttpRequest();
+  x.open('POST', '/api/audio-in');
+  x.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded');
+  x.send('auto=' + (on ? '1' : '0'));
+  applyAutoDisplay(on);
 });
 
 $('mic').addEventListener('change', function(){


### PR DESCRIPTION
Static in-ranges cannot fit music: two windows of one listening session measured the same band's level **4:1 apart**, so ranges sized to either window left bands dead in the other. This adds per-band auto-ranging (noise reference + peak envelope, normalized inside), a Hann window (with 2× coherent-gain compensation) to stop bass leakage inflating the high bands, and an activity gate whose every constant was measured on hardware — mostly after the previous design failed there. The four-design chronicle lives in the source comments; the short version:

- the board's own Wi-Fi bursts make the regulator whine audibly, the mic hears it, and those bursts turned out to be an HTTP transaction long — so the gate opens on 8 sustained frames, closes by majority countdown, and the mid band (where the whine lives) carries an absolute floor its spikes cannot reach;
- the noise reference learns only from quiet-zone samples while the gate is closed, and boot warmup takes a running minimum so starting mid-song cannot seed it with a bass hit.

**Verified both directions on hardware:** silence at worst case (page polling 10 Hz) pins all four knobs at 0.300 for 25 s including the after-music tail; music drives bands 1–3 at 100% travel, 73–97% active. Band 4 resting at listening volume is measurement, not a bug: its music median (0.015) sits at its own noise median (0.017) — a white-noise sweep proved the mic + decimator flat to ~7.5 kHz, so the treble deficit is the music's 1/f tilt, and only genuinely strong treble should open it. What the first design danced to up there was hiss.

Also: music-sized manual defaults (bands9), and the page's auto mode — in-handles hidden and excluded from the drag picker, dot painted from the normalized level the mapping consumes, manual tuning preserved underneath.

All three editions build and pass the marker scan; boundary and console checks green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)