### PR TITLE
community: the sandbox cache-bust is a hash, and phones get their ramps back

### DIFF
--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -1,8 +1,32 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
 import type { NextConfig } from "next";
 import createMDX from "@next/mdx";
 import { CAMPAIGN_ROUTES } from "./src/lib/campaignRoutes";
 
+const isProd = process.env.NODE_ENV === "production";
+
+// The ?v= on the sandbox iframe URL, derived from the sandbox document itself.
+//
+// It used to be a number a human bumped by hand, and the hand forgot: the
+// OKLab/OKLCH ramp modes (9413106) edited public/pattern-sandbox.html without
+// touching lib/community/sandboxUrl.ts, and because this file is served
+// immutable for a year, every browser that had ever loaded ?v=5 kept running
+// the pre-OKLab runtime — which does not know the mode names, so it dropped
+// every `// @ramp oklch…` annotation on the floor and painted those patterns
+// with the default ramp instead. Desktop looked fine (a fresh cache), phones
+// did not (a warm one). A hash cannot forget.
+const PATTERN_SANDBOX_VERSION = crypto
+  .createHash("sha256")
+  .update(fs.readFileSync(path.join(process.cwd(), "public", "pattern-sandbox.html")))
+  .digest("hex")
+  .slice(0, 10);
+
 const nextConfig: NextConfig = {
+  // Inlined into the client bundle at build time; read by
+  // lib/community/sandboxUrl.ts, which is the only thing that should use it.
+  env: { PATTERN_SANDBOX_VERSION },
   pageExtensions: ["js", "jsx", "md", "mdx", "ts", "tsx"],
   // Native module — must stay a runtime require, not a bundled dependency.
   serverExternalPackages: ["better-sqlite3"],
@@ -128,11 +152,21 @@ const nextConfig: NextConfig = {
         // Every pattern card boots its own sandboxed iframe from this one
         // document, so the feed loads it dozens of times per visit. Without
         // this header each load is a round trip to the origin (a Raspberry
-        // Pi), and the cards visibly warm up one by one. Safe to cache hard:
-        // the URL carries ?v= (see lib/community/sandboxUrl.ts), and bumping
-        // it on change is already the rule.
+        // Pi), and the cards visibly warm up one by one. Safe to cache hard
+        // in production: the URL carries ?v=<hash of this very file>, so a
+        // changed document is a changed URL by construction.
+        //
+        // Not in development, though. The hash is computed once when the
+        // config loads, and editing public/ does not reload the config — so a
+        // year-long immutable copy of the file you are editing is exactly
+        // wrong. `next dev` revalidates instead.
         source: "/pattern-sandbox.html",
-        headers: [{ key: "Cache-Control", value: "public, max-age=31536000, immutable" }],
+        headers: [
+          {
+            key: "Cache-Control",
+            value: isProd ? "public, max-age=31536000, immutable" : "no-store",
+          },
+        ],
       },
     ];
   },

--- a/web/src/lib/community/sandboxUrl.ts
+++ b/web/src/lib/community/sandboxUrl.ts
@@ -1,10 +1,18 @@
 // Single source of the sandbox iframe URL. The ?v= param cache-busts the
-// static /pattern-sandbox.html — bump it whenever that file changes, or stale
-// browser caches will keep running the old runtime (and silently ignore new
-// protocol features like the @ramp annotation).
-//
-// Bumping is not optional: next.config serves this file with a year-long
+// static /pattern-sandbox.html, which next.config serves with a year-long
 // immutable Cache-Control (every feed card boots an iframe from it, and
-// without the cache each boot is a round trip to the Pi). An edit without a
-// bump ships to nobody who has ever visited.
-export const PATTERN_SANDBOX_URL = "/pattern-sandbox.html?v=5";
+// without the cache each boot is a round trip to the Pi).
+//
+// The token is a hash of that document, computed by next.config at build time
+// and inlined here — NOT a number anyone has to remember to bump. It was a
+// hand-bumped number until the OKLab/OKLCH ramp modes shipped a rewritten
+// runtime under an unchanged ?v=5: browsers with a warm cache kept the old
+// one, which does not know those mode names, so it dropped their `// @ramp`
+// lines and painted those patterns with the default ramp. Phones showed it
+// (a cache months old), the machine it was written on did not.
+//
+// The fallback only applies where next.config did not do the inlining — a
+// unit test importing this module, say. Nothing serves the site that way.
+export const PATTERN_SANDBOX_VERSION = process.env.PATTERN_SANDBOX_VERSION || "dev";
+
+export const PATTERN_SANDBOX_URL = `/pattern-sandbox.html?v=${PATTERN_SANDBOX_VERSION}`;


### PR DESCRIPTION
Patterns published with an OKLab/OKLCH ramp rendered in the default blue-orange ramp on a phone, while the same wall looked correct on the machine they were written on.

## What was actually wrong

Nothing in the ramp code. `web/public/pattern-sandbox.html` — the runtime that draws every card, both the still thumbnail and the hover preview — is served `max-age=31536000, immutable` and cache-busted by a hand-written `?v=` in `lib/community/sandboxUrl.ts`.

`9413106` (perceptual OKLab/OKLCH ramp interpolation) rewrote that document to add `oklab` / `oklchShort` / `oklchLong` and **did not bump the token**. The last `?v=` change was two days earlier, in `df30ed6`.

So every browser that had ever loaded `?v=5` kept the pre-OKLab document for a year. Its `RAMP_MODES` is `["linear","smooth","step","hsvShort","hsvLong"]`, so `parseRampAnnotation()` returns `null` for an `// @ramp oklchShort …` line, the runtime falls back to `DEFAULT_RAMP_LUT`, and the `recolor` flag is dropped with it.

Not a mobile bug — a warm-cache bug. A phone is just where the caches are old.

## The fix

The token is now the sha256 of the sandbox document itself, computed in `next.config.ts` and inlined into the client bundle via `env`. A changed runtime is a changed URL by construction; there is no step left to forget.

Development stops caching it hard (`no-store`). The hash is computed once when the config loads and editing `public/` does not reload the config, so pinning an immutable copy of the file you are actively editing is exactly wrong there.

## Verified

- `npm run build` passes; the production chunk carries `/pattern-sandbox.html?v=2d98474be8` and no `?v=5` survives anywhere in `.next/static`.
- Dev server serves the same hashed URL with `Cache-Control: no-store`.
- `scripts/ramp-oklab-smoke.ts` passes — the shipped sandbox's OKLab/OKLCH LUT is byte-identical to the TypeScript one, so the ramps are correct as soon as the cache breaks.
- The Home Assistant card's copy of the runtime was already current (CI's `check:ha-card` guards it) and serves from its own path with no `?v=`, so it is unaffected.

Deploying is what heals it: phones fetch the new URL on their own, with no cache clearing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
