### PR TITLE
firmware: the binary must believe the version the shelf gives it

### DIFF
--- a/firmware/bundles/audio/overrides.h
+++ b/firmware/bundles/audio/overrides.h
@@ -42,8 +42,11 @@
 // running this claims to be core, which is the one thing a variant must
 // never do: somebody who did not flash it has no other way to find out what
 // is on it, and the update banner would offer them a core release on top.
+// This define IS the version — shelf.sh's argument only names the folder.
+// v0.4.0 shipped still believing it was v0.3.1 because nothing tied the two
+// together; shelf.sh now refuses an image that does not contain its version.
 #define PF_VARIANT "audio"
-#define PF_VARIANT_VERSION "v0.3.1"
+#define PF_VARIANT_VERSION "v0.4.0"
 
 // ── The on-board microphone drives the knobs ────────────────────────────
 //

--- a/firmware/bundles/shelf.sh
+++ b/firmware/bundles/shelf.sh
@@ -136,6 +136,19 @@ if ! scan "$BIN"; then
 fi
 echo "  scan clean"
 
+# ── The version the binary believes ─────────────────────────────────────
+#
+# The version argument only names the folder. What the panel actually reports
+# at /api/status is PF_VARIANT_VERSION from the bundle's overrides.h — and
+# audio v0.4.0 shipped still believing it was v0.3.1, because nothing tied
+# the two together. Editions bake the exact string, so demand it. (Core's
+# version lives elsewhere and its release flow already stamps it.)
+if [ "$NAME" != "core" ] && ! grep -qaF -- "$VERSION" "$BIN"; then
+  echo "  the image does not contain \"$VERSION\" — the binary believes another version." >&2
+  echo "  Set PF_VARIANT_VERSION in firmware/bundles/$NAME/overrides.h to $VERSION and rerun." >&2
+  exit 1
+fi
+
 # ── Stage ───────────────────────────────────────────────────────────────
 #
 # Four parts, and boot_app0 is the one people forget. It is not a build


### PR DESCRIPTION
The published audio v0.4.0 image still reports `variantVersion: v0.3.1` — nobody bumped `PF_VARIANT_VERSION` in the bundle's overrides.h, and shelf.sh's version argument only names the folder. Display-only (the console home line is the sole consumer; nothing compares it), but a panel freshly flashed with v0.4.0 introducing itself as v0.3.1 reads as a failed flash.

- `bundles/audio/overrides.h`: v0.3.1 → **v0.4.0** (performance already matches its published v0.2.1)
- `shelf.sh`: refuses to stage an edition whose image does not contain the exact version string — checked against the shipped binaries: the mis-stamped v0.4.0 image would have been refused, performance passes clean

Verified: audio edition builds, and the fresh binary contains `v0.4.0` and no `v0.3.1`. The already-published image stays as-is (version paths are never overwritten); the label heals at the next audio publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)