### PR TITLE
lab: a poster is not an LED panel, so it gets its own renderer

### DIFF
--- a/web/scripts/lab-capture-smoke.ts
+++ b/web/scripts/lab-capture-smoke.ts
@@ -12,7 +12,19 @@ import {
   unmultiply,
   unpremultiply,
 } from "../src/lib/lab/capture/core";
-import { probeScaling } from "../src/lib/lab/capture/probe";
+import { blockDetail, PROBE_LAYOUT_MAX, probeScaling } from "../src/lib/lab/capture/probe";
+import {
+  buildFragmentSource,
+  checkShaderSource,
+  declaresPass,
+  remapShaderLog,
+  SHADER_PREAMBLE,
+} from "../src/lib/lab/capture/shaderSource";
+import { buildShaderPrompt } from "../src/lib/lab/capture/shaderPrompt";
+import { SHADER_RAMP_SIZE, buildShaderRampLUT } from "../src/lib/lab/capture/shaderRamp";
+import { rampStateToHarness } from "../src/lib/lab/engine";
+import { sampleRampRGBA } from "../src/lib/patternHarness";
+import { DEFAULT_RAMP_STATE, type RampState } from "../src/lib/lab/types";
 import { normalizeCaptureSettings } from "../src/lib/lab/capture/settings";
 import { DEFAULT_CAPTURE_SETTINGS, type WireProject } from "../src/lib/lab/capture/types";
 import { codeLayerFromSource } from "../src/lib/lab/store";
@@ -112,6 +124,62 @@ export function draw(display, params, time) {
   for (let y = 0; y < display.height; y++) for (let x = 0; x < display.width; x++) display.setValue(x, y, 0.01);
 }`));
   assert(dark.verdict === "upscale" && dark.reason === "too-dark", `dark pattern: ${dark.reason}`);
+
+  // The blind spot the "no-detail" verdict closes: this one re-renders happily
+  // at any size and draws the SAME picture in bigger blocks, because it samples
+  // a fixed internal field. Layout and density score it perfect — a block
+  // upscale box-filters back to exactly the original — so only the detail
+  // metric catches it. (This is the shape an AI "any size" rewrite of a
+  // simulation pattern comes back in.)
+  const upsampler = probeScaling(project(`export function setup(params) {
+  params.W = 32; params.H = 16;
+  params.field = new Float32Array(params.W * params.H);
+  for (let y = 0; y < params.H; y++) for (let x = 0; x < params.W; x++)
+    params.field[y * params.W + x] = ((x * 7 + y * 13) % 11) / 10;
+}
+export function draw(display, params, time) {
+  for (let y = 0; y < display.height; y++) {
+    const sy = Math.min(params.H - 1, (y * params.H / display.height) | 0);
+    for (let x = 0; x < display.width; x++) {
+      const sx = Math.min(params.W - 1, (x * params.W / display.width) | 0);
+      display.setValue(x, y, params.field[sy * params.W + sx]);
+    }
+  }
+}`));
+  assert(
+    upsampler.verdict === "upscale" && upsampler.reason === "no-detail",
+    `self-upscaling pattern: ${upsampler.reason} ${JSON.stringify(upsampler.metrics)}`,
+  );
+  assert(
+    upsampler.metrics.layout < PROBE_LAYOUT_MAX && upsampler.metrics.density > 0.55,
+    "and it got there past a perfect layout/density score",
+  );
+  assert(safe.metrics.detail > 0.2, `a real re-render carries detail: ${safe.metrics.detail}`);
+}
+
+// ── block detail ──
+{
+  const grid = (width: number, height: number, fill: (x: number, y: number) => number) => {
+    const data = new Uint8ClampedArray(width * height * 4);
+    for (let y = 0; y < height; y++) {
+      for (let x = 0; x < width; x++) {
+        const value = fill(x, y);
+        const index = (y * width + x) * 4;
+        data[index] = value;
+        data[index + 1] = value;
+        data[index + 2] = value;
+        data[index + 3] = 255;
+      }
+    }
+    return data;
+  };
+  // A 4× nearest blow-up: every 4×4 cell is one colour.
+  const blown = grid(32, 32, (x, y) => (((x >> 2) + (y >> 2)) % 2) * 200);
+  assert(blockDetail(blown, 32, 32, 4) === 0, "an exact block upscale has no detail");
+  // The same picture actually re-rendered finer.
+  const fine = grid(32, 32, (x, y) => ((x + y) % 2) * 200);
+  assert(blockDetail(fine, 32, 32, 4) === 1, "a per-pixel picture is all detail");
+  assert(blockDetail(fine, 32, 32, 1) === 1, "factor 1 cannot judge and says so");
 }
 
 // ── stretch ──
@@ -256,6 +324,113 @@ export function draw(display, params, time) {
   assert(core.time === 0, "reset zeroes time");
   const fresh = core.step(0);
   assert(fresh && fresh.time === 0, "fresh frame at t=0");
+}
+
+// ── shader twin: the half that runs without a GPU ──
+{
+  const image = "void mainImage(out vec4 fragColor, in vec2 fragCoord) { fragColor = vec4(1.0); }";
+  const ok = checkShaderSource(image);
+  assert(ok.ok && !ok.hasState, "a bare image shader passes with no state pass");
+
+  const withState = `${image}
+void mainState(out vec4 stateOut, in vec2 fragCoord) { stateOut = stateAt(fragCoord); }`;
+  const both = checkShaderSource(withState);
+  assert(both.ok && both.hasState, "a feedback shader declares both passes");
+  assert(declaresPass(withState, "state") && declaresPass(image, "image"), "entry detection");
+
+  // A mention in a comment is not a declaration.
+  assert(
+    !declaresPass(`// void mainState(out vec4 s, in vec2 f) — not implemented
+${image}`, "state"),
+    "a commented-out entry does not count",
+  );
+
+  assert(!checkShaderSource("").ok, "an empty shader is refused");
+  assert(!checkShaderSource("void main() {}").ok, "a shader with no mainImage is refused");
+  const versioned = checkShaderSource(`#version 300 es
+${image}`);
+  assert(!versioned.ok && versioned.error.includes("#version"), "the version line is the stage's job");
+  const declared = checkShaderSource(`out vec4 fragColor;
+${image}`);
+  assert(!declared.ok && declared.error.includes("out vec4"), "the output is the stage's job");
+
+  const built = buildFragmentSource(withState, "state");
+  assert(built.startsWith("#version 300 es"), "version first");
+  assert(built.includes(SHADER_PREAMBLE), "preamble intact");
+  assert(built.includes(withState), "the user's source goes in verbatim");
+  assert(built.includes("mainState(pfOut, gl_FragCoord.xy);"), "the state pass calls mainState");
+  assert(
+    buildFragmentSource(withState, "image").includes("mainImage(pfOut, gl_FragCoord.xy);"),
+    "the image pass calls mainImage",
+  );
+  // #line 1 after the preamble means driver line numbers are the user's own.
+  assert(built.includes("#line 1"), "user line numbering is restored");
+  assert(
+    remapShaderLog("ERROR: 0:7: 'x' : undeclared identifier") === "ERROR: line 7: 'x' : undeclared identifier",
+    "a fault in the user's code is reported at the line they wrote",
+  );
+  // Drivers pad their logs with NULs; the text goes straight into the panel.
+  assert(!remapShaderLog("ERROR: 0:7: bad" + String.fromCharCode(0)).includes(String.fromCharCode(0)), "control characters are stripped");
+  assert(
+    remapShaderLog("ERROR: 0:100003: syntax error").startsWith("ERROR: wrapper:"),
+    "a fault in the wrapper is not reported as line 100003",
+  );
+
+  // The prompt carries the contract, the knob ranges and the ramp.
+  const prompt = buildShaderPrompt(
+    "export function draw(display, params, time) { display.setValue(0, 0, 1); }",
+    matrix,
+    DEFAULT_RAMP_STATE,
+    [[0.04, 0.059], [0, 1], [0, 1], [0, 1]],
+  );
+  assert(prompt.includes("void mainImage(out vec4 fragColor, in vec2 fragCoord)"), "prompt states the entry point");
+  assert(prompt.includes("0.04") && prompt.includes("0.059"), "prompt carries the real knob range");
+  assert(prompt.includes("#000000") && prompt.includes("#ffffff"), "prompt describes the ramp");
+  assert(prompt.includes("ramp(v)") && prompt.includes("DO NOT bake"), "prompt sends colour through the live ramp");
+  assert(prompt.includes("uState"), "prompt documents the feedback texture");
+}
+
+// ── the ramp as a texture ──
+{
+  assert(SHADER_PREAMBLE.includes("uniform sampler2D uRamp"), "the ramp uniform is in the contract");
+  assert(SHADER_PREAMBLE.includes("vec4 ramp(float v)"), "so is the helper");
+  // The helper must land on texel centres, or ramp(0) and ramp(1) read short.
+  assert(
+    SHADER_PREAMBLE.includes(`${SHADER_RAMP_SIZE - 1}.0 + 0.5) / ${SHADER_RAMP_SIZE}.0`),
+    "the helper maps 0..1 onto texel centres",
+  );
+
+  const ramp: RampState = {
+    stops: [
+      { position: 0, color: "#000000", alpha: 1 },
+      { position: 0.4, color: "#ff5500", alpha: 0.5 },
+      { position: 1, color: "#00ccff", alpha: 1 },
+    ],
+    mode: "oklab",
+    wrap: false,
+  };
+  const lut = buildShaderRampLUT(ramp);
+  assert(lut.length === SHADER_RAMP_SIZE * 4, "one RGBA row");
+  // Every entry is the runtime's own sampler, so the twin cannot drift from
+  // the panel: same evaluator, same modes, same alpha, only more finely cut.
+  const harness = rampStateToHarness(ramp);
+  for (const index of [0, 1, 137, SHADER_RAMP_SIZE >> 1, SHADER_RAMP_SIZE - 1]) {
+    const [r, g, b, a] = sampleRampRGBA(harness, index / (SHADER_RAMP_SIZE - 1));
+    const got = [lut[index * 4], lut[index * 4 + 1], lut[index * 4 + 2], lut[index * 4 + 3]];
+    const want = [Math.round(r), Math.round(g), Math.round(b), Math.round(a * 255)];
+    assert(
+      got.every((value, channel) => value === want[channel]),
+      `ramp LUT entry ${index}: ${got} vs ${want}`,
+    );
+  }
+  const midStop = Math.round(0.4 * (SHADER_RAMP_SIZE - 1));
+  assert(
+    lut[3] === 255 && Math.abs(lut[midStop * 4 + 3] - 128) <= 1,
+    `alpha stops travel: ends ${lut[3]}, 0.4 stop ${lut[midStop * 4 + 3]}`,
+  );
+  // A ramp with no stops must still be readable rather than transparent black.
+  const empty = buildShaderRampLUT({ stops: [], mode: "linear", wrap: false });
+  assert(empty[0] === 255 && empty[3] === 255, "an empty ramp reads white, not garbage");
 }
 
 console.log("lab-capture-smoke: OK");

--- a/web/src/app/pattern-lab/PatternLabClient.tsx
+++ b/web/src/app/pattern-lab/PatternLabClient.tsx
@@ -4,7 +4,7 @@
 //
 // The old lab was one pattern + one fixed two-column layout. This shell hosts
 // eight dockable panels (dockview) over a layer-stack project (zustand):
-// Preview, Layers, Code, Pixel, Gallery, Knobs, Color Ramp, Capture. Panels rearrange
+// Preview, Layers, Code, Pixel, Gallery, Knobs, Color Ramp, Graphic Export. Panels rearrange
 // Photoshop-style — drag tabs, split groups, float — and the arrangement
 // persists to localStorage alongside the project itself.
 //
@@ -72,7 +72,7 @@ const PANEL_DEFS = [
   { id: "ramp", title: "Color Ramp" },
   // Output stage (stills/clips at print sizes) — an add-on module, see
   // lib/lab/capture. Registered here and nowhere else.
-  { id: "capture", title: "Capture" },
+  { id: "capture", title: "Graphic Export" },
   // Knob automation over time (lib/lab/director) — the show that publishes
   // alongside the pattern.
   { id: "director", title: "Director" },
@@ -126,7 +126,7 @@ function buildDefaultLayout(api: DockviewApi) {
   api.addPanel({
     id: "capture",
     component: "capture",
-    title: "Capture",
+    title: "Graphic Export",
     position: { referencePanel: "code", direction: "within" },
   });
   api.addPanel({
@@ -404,6 +404,14 @@ export default function PatternLabClient() {
         } catch {
           // A half-built layout is still usable; panels can be opened manually.
         }
+      }
+      // Titles belong to PANEL_DEFS, not to the saved layout: a restored dock
+      // remembers the name a panel had when it was last moved, so a rename
+      // (Capture → Graphic Export, 2026-09) would only reach people who reset
+      // their layout otherwise.
+      for (const def of PANEL_DEFS) {
+        const panel = api.getPanel(def.id);
+        if (panel && panel.title !== def.title) panel.api.setTitle(def.title);
       }
       syncOpenPanels(api);
 

--- a/web/src/app/pattern-lab/panels/CapturePanel.module.css
+++ b/web/src/app/pattern-lab/panels/CapturePanel.module.css
@@ -168,3 +168,49 @@
   font-size: 11px;
   line-height: 1.6;
 }
+
+/* ── the shader twin's editor ──
+   Only shown while the source is Shader: a bar (prompt, status, clear) over a
+   plain monospace box. Deliberately not Monaco — a shader arrives by paste,
+   and a second editor instance costs more than it gives here. */
+.shader {
+  display: grid;
+  gap: 8px;
+  padding: 10px 14px 0;
+}
+
+.shaderBar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+}
+
+.shaderBar .readout[data-state="error"] {
+  color: #8a5a10;
+}
+
+.shaderEditor {
+  width: 100%;
+  min-height: 160px;
+  resize: vertical;
+  padding: 10px 12px;
+  border: 1px solid rgba(23, 21, 18, 0.15);
+  border-radius: 4px;
+  background: rgba(23, 21, 18, 0.03);
+  color: rgba(23, 21, 18, 0.9);
+  font-family: var(--font-jetbrains), monospace;
+  font-size: 11px;
+  line-height: 1.6;
+  tab-size: 2;
+}
+
+.shaderEditor:focus {
+  outline: none;
+  border-color: rgba(23, 21, 18, 0.4);
+  background: rgba(23, 21, 18, 0.02);
+}
+
+.shaderEditor::placeholder {
+  color: rgba(23, 21, 18, 0.35);
+}

--- a/web/src/app/pattern-lab/panels/CapturePanel.tsx
+++ b/web/src/app/pattern-lab/panels/CapturePanel.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-// Capture — the camera back: settings and the shutter, no window of its own.
+// Graphic Export — the camera back: settings and the shutter, no window of its
+// own.
 // The picture lives where pictures live: the Preview panel, whose 📷 camera
 // view (the viewfinder) shows the output render when you ask for it. This
 // panel picks the output (size, look, turn, backdrop), owns the 🔗 Director
@@ -17,6 +18,8 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { useLabStore } from "@/lib/lab/store";
 import { isCodeLayer } from "@/lib/lab/types";
 import { buildAnySizePrompt } from "@/lib/lab/capture/anySizePrompt";
+import { buildShaderPrompt } from "@/lib/lab/capture/shaderPrompt";
+import { loadShaderSource, saveShaderSource } from "@/lib/lab/capture/shaderStore";
 import { captureSession } from "@/lib/lab/capture/session";
 import { resolveGeometry } from "@/lib/lab/capture/core";
 import { captureFileName, downloadBlob } from "@/lib/lab/capture/download";
@@ -35,6 +38,7 @@ import {
   SIZED_STYLES,
   type AutoVerdict,
   type CaptureSettings,
+  type ShaderStatus,
 } from "@/lib/lab/capture/types";
 import { bakeShowV2 } from "@/lib/lab/director/bake";
 import { sampleShow, toKnobFrames } from "@/lib/lab/director/sample";
@@ -53,6 +57,19 @@ const SHOW_RENDER_MAX_SECONDS = 600;
 const FRESH_TAKE_WARM_SECONDS = 2;
 /** Linked stills replay the show at this rate — state-exact by playhead. */
 const STILL_REPLAY_FPS = 30;
+/** A paste settles before it costs a compile. */
+const SHADER_SEND_DEBOUNCE_MS = 400;
+
+const SHADER_PLACEHOLDER = [
+  "Paste the shader here.",
+  "",
+  "void mainImage(out vec4 fragColor, in vec2 fragCoord) { … }",
+  "and, for anything that carries state between frames,",
+  "void mainState(out vec4 stateOut, in vec2 fragCoord) { … }",
+  "",
+  "uResolution · uTime · uFrame · uKnob · uKnobNorm · uBtnPressed · uBtnHeld",
+  "stateAt(fragCoord) · stateOffset(fragCoord, vec2(1.0, 0.0))",
+].join("\n");
 
 type LayerError = { id: string; name: string; text: string };
 
@@ -79,6 +96,13 @@ function focusCodeLayer() {
   return isCodeLayer(active) ? active : state.layers.find(isCodeLayer);
 }
 
+/** The same layer's id, as a store selector — the shader twin is filed under it. */
+function selectFocusCodeLayerId(state: ReturnType<typeof useLabStore.getState>): string | null {
+  const active = state.layers.find((layer) => layer.id === state.activeLayerId);
+  const layer = isCodeLayer(active) ? active : state.layers.find(isCodeLayer);
+  return layer?.id ?? null;
+}
+
 export default function CapturePanel() {
   const supported = captureSession.supported;
   const [settings, setSettings] = useState<CaptureSettings>(() => captureSession.settings());
@@ -88,6 +112,25 @@ export default function CapturePanel() {
   const [message, setMessage] = useState<{ text: string; error: boolean } | null>(null);
   const [fatal, setFatal] = useState<string | null>(null);
   const [promptCopied, setPromptCopied] = useState(false);
+  const [shaderPromptCopied, setShaderPromptCopied] = useState(false);
+
+  // ── the shader twin ──
+  // Source lives per code layer in the capture module's own storage; the panel
+  // is its editor, the worker compiles it, and the pattern never notices.
+  const focusLayerId = useLabStore(selectFocusCodeLayerId);
+  const [shaderText, setShaderText] = useState("");
+  const [shaderStatus, setShaderStatus] = useState<ShaderStatus | null>(null);
+  const [shaderFor, setShaderFor] = useState<string | null>(null);
+  const shaderSent = useRef<{ id: string | null; source: string } | null>(null);
+  // A different code layer is a different twin. Adjusting state during the
+  // render that noticed is React's own answer here — an effect for it would
+  // paint one frame of the previous layer's shader first.
+  if (focusLayerId !== shaderFor) {
+    const layer = focusCodeLayer();
+    setShaderFor(focusLayerId);
+    setShaderText(focusLayerId && layer ? loadShaderSource(focusLayerId, layer.code) : "");
+    setShaderStatus(null);
+  }
 
   // 🔗 Director link — linked, the show is the truth for every export; the
   // link lives on the shared show transport so the Director's Render…
@@ -106,7 +149,13 @@ export default function CapturePanel() {
   const matrix = useLabStore((state) => state.matrix);
   const exportingRef = useRef(false);
 
-  const geometry = resolveGeometry(settings, matrix);
+  // A shader always renders the output frame itself — the matrix looks
+  // (pixel, LED, the auto fallback) describe the lab's engine, not this one.
+  const shaderMode = settings.source === "shader";
+  const geometry = resolveGeometry(
+    shaderMode ? { ...settings, style: "native" } : settings,
+    matrix,
+  );
 
   const update = useCallback((patch: Partial<CaptureSettings>) => {
     setSettings((current) => normalizeCaptureSettings({ ...current, ...patch }));
@@ -123,6 +172,7 @@ export default function CapturePanel() {
     if (!supported) return;
     return captureSession.on({
       auto: setVerdict,
+      shader: setShaderStatus,
       errors: (raw) => setErrors(nameErrors(raw)),
       progress: (done, total) => {
         setExporting((current) => (current ? { ...current, done, total } : current));
@@ -136,6 +186,25 @@ export default function CapturePanel() {
     captureSession.applySettings(settings);
     saveCaptureSettings(settings);
   }, [settings]);
+
+  // The shader reaches the worker (and disk) on a trailing timer, so a paste
+  // costs one compile rather than one per keystroke — except when the layer
+  // itself changed, which is a swap, not an edit.
+  useEffect(() => {
+    const send = () => {
+      shaderSent.current = { id: focusLayerId, source: shaderText };
+      const layer = focusCodeLayer();
+      if (focusLayerId && layer) saveShaderSource(focusLayerId, layer.code, shaderText);
+      captureSession.setShaderSource(shaderText || null, focusLayerId);
+    };
+    if (shaderSent.current?.id !== focusLayerId) {
+      send();
+      return;
+    }
+    if (shaderSent.current.source === shaderText) return;
+    const timer = window.setTimeout(send, SHADER_SEND_DEBOUNCE_MS);
+    return () => window.clearTimeout(timer);
+  }, [shaderText, focusLayerId]);
 
   // ── exports ──
   const saveImage = async () => {
@@ -264,6 +333,28 @@ export default function CapturePanel() {
     }
   };
 
+  const copyShaderPrompt = async () => {
+    const layer = focusCodeLayer();
+    if (!layer) {
+      setMessage({ text: "No code layer to convert.", error: true });
+      return;
+    }
+    const state = useLabStore.getState();
+    try {
+      await navigator.clipboard.writeText(
+        buildShaderPrompt(layer.code, matrix, layer.ramp, state.ranges),
+      );
+      setShaderPromptCopied(true);
+      window.setTimeout(() => setShaderPromptCopied(false), 1200);
+      setMessage({
+        text: `GLSL prompt for "${layer.name}" copied — paste it into any AI, then paste the shader it returns into the box below. The pattern itself is left alone.`,
+        error: false,
+      });
+    } catch {
+      setMessage({ text: "Clipboard access was refused.", error: true });
+    }
+  };
+
   // ── native size entry ──
   const widthRef = useRef<HTMLInputElement | null>(null);
   const heightRef = useRef<HTMLInputElement | null>(null);
@@ -280,7 +371,7 @@ export default function CapturePanel() {
     return (
       <div className={dock.panel}>
         <div className={local.hint}>
-          Capture needs Web Workers and OffscreenCanvas — a current Chrome, Edge, Firefox or Safari.
+          Graphic Export needs Web Workers and OffscreenCanvas — a current Chrome, Edge, Firefox or Safari.
         </div>
       </div>
     );
@@ -304,21 +395,36 @@ export default function CapturePanel() {
           📷 Viewfinder
         </button>
         <label>
-          look
+          source
           <select
-            value={settings.style}
-            aria-label="Output look"
-            title="Auto re-runs the pattern at the output size when a test render shows its code scales, and upscales the panel frame otherwise. Native always re-runs it. Pixel scales the panel frame up as crisp blocks. LED draws each pixel as a round light."
-            onChange={(event) => update({ style: event.target.value as CaptureSettings["style"] })}
+            value={settings.source}
+            aria-label="Render source"
+            title="Pattern renders the layer stack with the lab's own engine — the panel's picture, and what the hardware export bakes. Shader renders a GLSL twin of it on the GPU instead: output only, for sizes and frame rates the JS cannot reach."
+            onChange={(event) => update({ source: event.target.value as CaptureSettings["source"] })}
           >
-            <option value="auto">Auto</option>
-            <option value="native">Native (re-rendered)</option>
-            <option value="pixel">Pixel blocks</option>
-            <option value="led">LED dots</option>
+            <option value="pattern">Pattern (JS)</option>
+            <option value="shader">Shader (GLSL)</option>
           </select>
         </label>
 
-        {SIZED_STYLES.includes(settings.style) ? (
+        {!shaderMode && (
+          <label>
+            look
+            <select
+              value={settings.style}
+              aria-label="Output look"
+              title="Auto re-runs the pattern at the output size when a test render shows its code scales, and upscales the panel frame otherwise. Native always re-runs it. Pixel scales the panel frame up as crisp blocks. LED draws each pixel as a round light."
+              onChange={(event) => update({ style: event.target.value as CaptureSettings["style"] })}
+            >
+              <option value="auto">Auto</option>
+              <option value="native">Native (re-rendered)</option>
+              <option value="pixel">Pixel blocks</option>
+              <option value="led">LED dots</option>
+            </select>
+          </label>
+        )}
+
+        {shaderMode || SIZED_STYLES.includes(settings.style) ? (
           <span className={local.group}>
             <select
               value={preset?.id ?? "custom"}
@@ -425,10 +531,18 @@ export default function CapturePanel() {
           backdrop
           <select
             value={
-              settings.backdrop === "black" ? "black" : `${settings.backdrop}-${settings.cutout}`
+              settings.backdrop === "black"
+                ? "black"
+                : // A shader writes its own alpha, so it has no cutout model to
+                  // pick — the two transparency rows collapse into one option.
+                  `${settings.backdrop}-${shaderMode ? "dark" : settings.cutout}`
             }
             aria-label="Backdrop"
-            title="What sits behind the picture. 'Unpainted' keeps black paint and clears only untouched pixels; 'dark → clear' fades black away like light on paper."
+            title={
+              shaderMode
+                ? "What sits behind the picture. Transparency comes from the shader's own alpha."
+                : "What sits behind the picture. 'Unpainted' keeps black paint and clears only untouched pixels; 'dark → clear' fades black away like light on paper."
+            }
             onChange={(event) => {
               const value = event.target.value;
               if (value === "black") {
@@ -443,7 +557,12 @@ export default function CapturePanel() {
             }}
           >
             <option value="black">Panel black</option>
-            {settings.style === "led" ? (
+            {shaderMode ? (
+              <>
+                <option value="transparent-dark">Transparent</option>
+                <option value="color-dark">Solid color</option>
+              </>
+            ) : settings.style === "led" ? (
               <>
                 <option value="transparent-dark">Transparent</option>
                 <option value="color-dark">Solid color</option>
@@ -468,7 +587,7 @@ export default function CapturePanel() {
           />
         )}
 
-        {settings.style === "led" && (
+        {!shaderMode && settings.style === "led" && (
           <>
             <span className={local.slider} title="Dot diameter as a share of the cell">
               dot
@@ -497,7 +616,7 @@ export default function CapturePanel() {
           </>
         )}
 
-        {settings.style === "auto" && verdict && (
+        {!shaderMode && settings.style === "auto" && verdict && (
           <span className={local.verdict} data-verdict={verdict.verdict} title={verdict.detail}>
             auto → {verdict.description}
             {verdict.verdict === "upscale" &&
@@ -511,6 +630,17 @@ export default function CapturePanel() {
                   {promptCopied ? "Copied" : "Copy any-size prompt"}
                 </button>
               )}
+            {/* The one verdict a rewrite usually cannot lift: the code already
+                re-renders at any size, it just has nothing finer to draw. */}
+            {verdict.reason === "no-detail" && (
+              <button
+                type="button"
+                title="Switch this panel to a GLSL twin of the pattern — the way to fill a print size with real detail when the pattern samples a fixed internal grid"
+                onClick={() => update({ source: "shader" })}
+              >
+                Try a shader twin
+              </button>
+            )}
           </span>
         )}
       </div>
@@ -634,8 +764,54 @@ export default function CapturePanel() {
       </div>
 
       <div className={local.body}>
+        {shaderMode && (
+          <div className={local.shader}>
+            <div className={local.shaderBar}>
+              <button
+                type="button"
+                title="Copy a prompt that asks an AI to write this pattern as a GLSL fragment shader — same composition, resolution-independent, with the knobs and the ramp carried over. The pattern itself is never edited."
+                onClick={() => void copyShaderPrompt()}
+              >
+                {shaderPromptCopied ? "Copied" : "Copy GLSL prompt"}
+              </button>
+              <span className={local.readout} data-state={shaderStatus?.error ? "error" : undefined}>
+                {!shaderText.trim()
+                  ? "no shader yet — the stage is showing the pattern"
+                  : shaderStatus?.error
+                    ? "compile failed — the stage is showing the pattern"
+                    : shaderStatus?.loaded
+                      ? `compiled${shaderStatus.feedback ? ` · feedback pass (${shaderStatus.floatFeedback ? "float" : "8-bit"})` : ""}`
+                      : "compiling…"}
+              </span>
+              {shaderText.trim().length > 0 && (
+                <button
+                  type="button"
+                  title="Drop this layer's shader twin and go back to the pattern"
+                  onClick={() => setShaderText("")}
+                >
+                  Clear
+                </button>
+              )}
+            </div>
+            <textarea
+              className={local.shaderEditor}
+              value={shaderText}
+              spellCheck={false}
+              aria-label="Shader source"
+              placeholder={SHADER_PLACEHOLDER}
+              onChange={(event) => setShaderText(event.target.value)}
+            />
+            {shaderStatus?.error && (
+              <div className={styles.errorBox} style={{ marginTop: 0 }}>
+                {shaderStatus.error}
+              </div>
+            )}
+          </div>
+        )}
         <div className={local.hint}>
-          {linked
+          {shaderMode
+            ? "The shader is output only: the panel, the Director and the hardware export all keep running the pattern. Sizes, turns and the knobs work exactly as they do for one, and a shader that calls ramp(v) follows the Color Ramp panel live — the difference is that it fills a print size with real detail, at speed."
+            : linked
             ? "🔗 Linked — the show is the truth: Record renders the whole timeline, Save PNG the playhead's frame. Scrub in the Director, watch in the Preview."
             : view
               ? "📷 Camera view is on — the Preview panel shows this output render; exports capture the moment you see."

--- a/web/src/app/pattern-lab/panels/DirectorPanel.tsx
+++ b/web/src/app/pattern-lab/panels/DirectorPanel.tsx
@@ -642,7 +642,7 @@ export default function DirectorPanel(props: IDockviewPanelProps) {
         <button
           type="button"
           disabled={!hasContent}
-          title="Open Capture linked to the Director (🔗) — render the show to video there, with the automation driving the knobs"
+          title="Open Graphic Export linked to the Director (🔗) — render the show to video there, with the automation driving the knobs"
           onClick={() => {
             // A shortcut, not a hierarchy: flip the shared link on and front
             // the Capture panel (if the user closed it, the link still holds

--- a/web/src/app/pattern-lab/panels/KnobsPanel.tsx
+++ b/web/src/app/pattern-lab/panels/KnobsPanel.tsx
@@ -7,6 +7,7 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import { labEngine } from "@/lib/lab/engine";
+import { captureSession } from "@/lib/lab/capture/session";
 import { useLabStore } from "@/lib/lab/store";
 import styles from "../PatternLab.module.css";
 import dock from "../LabPanels.module.css";
@@ -51,6 +52,28 @@ function getDigitStep(text: string, index: number) {
   }
 
   return 10 ** -(index - decimalIndex);
+}
+
+/**
+ * A press goes to both engines: the live preview's, and — when the Graphic
+ * Export stage is running — its own. They are separate engines with separate
+ * pattern state, so a button that reseeds or triggers has to be told twice or
+ * the export never sees the moment you pressed for. The session ignores the
+ * call when no stage exists.
+ */
+function pressKnobButton(index: number) {
+  labEngine.pressButton(index);
+  captureSession.pressButton(index);
+}
+
+function releaseKnobButton(index: number) {
+  labEngine.releaseButton(index);
+  captureSession.releaseButton(index);
+}
+
+function releaseAllKnobButtons() {
+  labEngine.releaseAllButtons();
+  captureSession.releaseAllButtons();
 }
 
 export default function KnobsPanel() {
@@ -113,7 +136,7 @@ export default function KnobsPanel() {
 
   // Encoder buttons release on any global pointer-up, mirroring hardware.
   useEffect(() => {
-    const releaseAll = () => labEngine.releaseAllButtons();
+    const releaseAll = () => releaseAllKnobButtons();
     window.addEventListener("pointerup", releaseAll);
     window.addEventListener("pointercancel", releaseAll);
     window.addEventListener("blur", releaseAll);
@@ -234,19 +257,19 @@ export default function KnobsPanel() {
                   title="Encoder button (short press) — hits the active code layer"
                   onPointerDown={(event) => {
                     event.preventDefault();
-                    labEngine.pressButton(index);
+                    pressKnobButton(index);
                   }}
-                  onPointerUp={() => labEngine.releaseButton(index)}
-                  onPointerLeave={() => labEngine.releaseButton(index)}
+                  onPointerUp={() => releaseKnobButton(index)}
+                  onPointerLeave={() => releaseKnobButton(index)}
                   onKeyDown={(event) => {
                     if (event.key === "Enter" || event.key === " ") {
                       event.preventDefault();
-                      labEngine.pressButton(index);
+                      pressKnobButton(index);
                     }
                   }}
                   onKeyUp={(event) => {
                     if (event.key === "Enter" || event.key === " ") {
-                      labEngine.releaseButton(index);
+                      releaseKnobButton(index);
                     }
                   }}
                 >

--- a/web/src/app/pattern-lab/panels/PreviewPanel.tsx
+++ b/web/src/app/pattern-lab/panels/PreviewPanel.tsx
@@ -5,7 +5,7 @@
 // LabEngine, paints the composite, and mirrors per-layer errors back into the
 // store (throttled) for the Layers/Code panels.
 //
-// Camera view (📷): Blender's numpad-0 for the lab. When the Capture panel's
+// Camera view (📷): Blender's numpad-0 for the lab. When the Graphic Export
 // viewfinder is on, this panel shows the CAPTURE OUTPUT render — the capture
 // worker's frames at the output size, look, backdrop and turn — instead of
 // the matrix composite; a chip in the header names the borrowed view and
@@ -212,7 +212,7 @@ export default function PreviewPanel() {
           <button
             type="button"
             className={styles.cameraChip}
-            title="Camera view — showing the Capture output render. The project frame stays as picked here; click to go back to it."
+            title="Camera view — showing the Graphic Export render. The project frame stays as picked here; click to go back to it."
             onClick={() => captureSession.setView(false)}
           >
             📷 {camera.output ? `${camera.output.width} × ${camera.output.height}` : "output"} · exit

--- a/web/src/lib/lab/capture/anySizePrompt.ts
+++ b/web/src/lib/lab/capture/anySizePrompt.ts
@@ -9,6 +9,13 @@
 // model you like, paste the answer back into the Code panel. The probe re-runs
 // on the new code, and if it now scales, Auto switches to a native re-render
 // by itself — the HUD is the verification.
+//
+// The rewrite has a ceiling, and the SIMULATIONS rule below is where it shows.
+// A pattern that integrates a field per frame cannot be made to fill a poster
+// by JavaScript alone: run the field at 4K and one frame is seconds of CPU;
+// leave it small and the picture is a block enlargement whatever draw() does.
+// That is the case the shader twin exists for (shaderPrompt.ts) — this prompt
+// is the one to reach for when a pattern is merely written in pixel units.
 
 import type { MatrixSize } from "@/lib/patternMatrix";
 
@@ -24,6 +31,10 @@ RULES
 - Replace every literal that encodes the frame (${width}, ${height}, ${width / 2}, ${height / 2}, ${width * height}, strides like y * ${width} + x, bounds like x < ${width}) with the display dimensions. Buffers that hold one value per pixel must be allocated for display.width * display.height; if their size is fixed in setup(), allocate lazily in update()/draw() when the frame size is first known or changes.
 - Pixel-unit frequencies become frame-unit frequencies: Math.sin(x * 0.1) → Math.sin(u * (0.1 * ${width})). Keep the numbers that produce the original look.
 - Integer-pixel idioms (checkerboards, dithers, scanlines, 1-pixel lines) must keep their visual density: scale the cell size with the frame instead of testing x % 2 in raw pixels.
+- SIMULATIONS — read this if the pattern integrates a field between frames (reaction–diffusion, cellular automata, fluid, trails, phosphor decay) in a buffer whose size is fixed in setup(). Sampling that fixed grid with nearest lookups inside draw() SATISFIES NOTHING: the picture is then a block enlargement of a ${width} × ${height} image at every output size — the same pixels, hundreds of times the work. Do one of these instead, in this order:
+  1. Allocate the field for display.width × display.height and keep the structures the same size in the frame: read neighbours at a spacing of h = max(1, floor(min(display.width / ${width}, display.height / ${height}))) pixels rather than 1, and use a 9-tap Laplacian at that spacing (edges 0.2, corners 0.05, centre −1) so a wide stencil does not alias into grid-scale noise. Keep the time step, the coefficients, the clamps and the non-finite guards exactly as they are.
+  2. If that is not numerically viable for this model, keep the small field but make the extra pixels carry real information: resample it smoothly (bilinear or bicubic, in frame units) AND add detail derived from the field itself — iso-contour lines, gradient-shaded filaments, noise modulated by the local value — calibrated so that at ${width} × ${height} the picture is unchanged. Say which you did in ONE added comment line.
+  Do not simply blur the upscale, and do not leave the nearest-neighbour lookup in place.
 - Keep the pattern's name, structure, knob handling and behaviour. Keep every comment line that begins with // @ (annotations such as // @knobs and // @matrix) exactly as it is, and keep the license header and footer comments exactly as they are.
 - Do not add features, do not change colours, do not rename the exported functions. Prefer minimal, surgical edits.
 - Plain JavaScript, no imports, no TypeScript.

--- a/web/src/lib/lab/capture/capture.worker.ts
+++ b/web/src/lib/lab/capture/capture.worker.ts
@@ -12,10 +12,13 @@
 // encodes it; a clip steps the clock at a fixed 1/fps from the current
 // moment, so what the stage shows when you press Record is the first frame.
 
-import { CaptureCore, clampScale, mergeWireProject, resolveGeometry, type CaptureFrame } from "./core";
+import { CaptureCore, clampScale, mergeWireProject, resolveGeometry } from "./core";
 import type { MatrixSize } from "@/lib/patternMatrix";
 import { StagePainter } from "./paint";
 import { describeProbe, probeKey, probeScaling, type ProbeResult } from "./probe";
+import { ShaderStage } from "./shaderStage";
+import { buildShaderRampLUT } from "./shaderRamp";
+import { isCodeLayer, type RampState } from "../types";
 import {
   DEFAULT_CAPTURE_SETTINGS,
   type AutoVerdict,
@@ -23,6 +26,7 @@ import {
   type CaptureProject,
   type CaptureSettings,
   type FromWorker,
+  type ShaderStatus,
   type ShowAutomation,
   type ToWorker,
   type VideoRequest,
@@ -43,6 +47,7 @@ const EXPORT_PREVIEW_INTERVAL_MS = 120;
 const PREVIEW_PIXEL_BUDGET = 1_200_000;
 
 const core = new CaptureCore(DEFAULT_CAPTURE_SETTINGS);
+const shader = new ShaderStage((width, height) => new OffscreenCanvas(width, height));
 const painter = new StagePainter((width, height) => new OffscreenCanvas(width, height));
 const stage = new OffscreenCanvas(1, 1);
 
@@ -68,7 +73,155 @@ function post(message: FromWorker, transfer?: Transferable[]) {
 }
 
 function postState() {
-  post({ type: "state", time: core.time, playing });
+  post({ type: "state", time: stageTime(), playing });
+}
+
+// ── the two renderers, behind one shape ──
+// Everything below this line — the live tick, stills, clips, show automation,
+// warm-ups — drives `stepStage` and never asks which renderer answered.
+
+/**
+ * A frame from whichever stage is running: enough for the frame message plus
+ * the one thing only the renderer knows, how to put itself on a canvas.
+ */
+type StageStep = {
+  geometry: CaptureGeometry;
+  time: number;
+  renderMs: number;
+  errors: Record<string, string>;
+  paint(target: OffscreenCanvas, settings: CaptureSettings): void;
+};
+
+/**
+ * The shader answers only when the panel asked for it AND it compiled: a
+ * broken twin falls back to the pattern rather than showing black, and the
+ * panel says why through the shader status.
+ */
+function usingShader(): boolean {
+  return core.settings.source === "shader" && shader.hasSource && shader.error === null;
+}
+
+/**
+ * The layer whose colour ramp the twin reads: the one the panel filed it
+ * under, else the active code layer, else the topmost — the same rule the
+ * panel uses to pick what a prompt targets.
+ */
+function shaderLayer() {
+  if (!project) return null;
+  const named = project.layers.find((layer) => layer.id === shaderLayerId);
+  if (isCodeLayer(named)) return named;
+  const active = project.layers.find((layer) => layer.id === project!.activeLayerId);
+  if (isCodeLayer(active)) return active;
+  return project.layers.find(isCodeLayer) ?? null;
+}
+
+/**
+ * Keep the shader's ramp texture in step with the panel. Ramp state is
+ * immutable in the store, so identity is enough to tell an edit from a
+ * re-render — no rebuild while a knob is being dragged.
+ */
+function syncShaderRamp(): boolean {
+  const layer = shaderLayer();
+  const ramp: RampState | null = layer ? layer.ramp : null;
+  if (ramp === shaderRamp) return false;
+  shaderRamp = ramp;
+  if (ramp) shader.setRamp(buildShaderRampLUT(ramp), ramp.mode !== "step");
+  return true;
+}
+
+function shaderStatus(): ShaderStatus {
+  return {
+    loaded: shader.hasSource,
+    error: shader.error,
+    floatFeedback: shader.floatFeedback,
+    feedback: shader.hasFeedback,
+  };
+}
+
+function postShaderStatus() {
+  post({ type: "shader-status", status: shaderStatus() });
+}
+
+/**
+ * Knobs a render drives itself — a show's automation frame by frame, a clip's
+ * pinned values — overriding the live project's for the length of the export.
+ * Null outside one, so the stage follows the panel again the moment it ends.
+ */
+let knobOverride: number[] | null = null;
+
+/** The code layer the twin belongs to, and the ramp last uploaded for it. */
+let shaderLayerId: string | null = null;
+let shaderRamp: RampState | null = null;
+
+function setStageKnobs(knobs: number[] | null) {
+  knobOverride = knobs;
+  if (knobs) core.setKnobs(knobs);
+}
+
+/** Knobs as the shader wants them: the real values, and the same 0..1. */
+function shaderKnobs() {
+  if (!project) return;
+  const values = knobOverride ?? project.knobs;
+  const normalized = values.map((value, index) => {
+    const range = project!.ranges[index] ?? [0, 1];
+    const span = Math.max(0.0001, range[1] - range[0]);
+    return (value - range[0]) / span;
+  });
+  shader.setKnobs(values, normalized);
+}
+
+/**
+ * The shader always renders at the output size — a GPU has no reason to be
+ * spared, and its feedback state is bound to the grid it runs on, so a
+ * reduced preview would be a different simulation, not a smaller picture.
+ * Rotation still turns the frame, exactly as it does for a pattern.
+ */
+function shaderGeometry(): CaptureGeometry | null {
+  if (!project) return null;
+  return resolveGeometry({ ...core.settings, style: "native" }, project.matrix);
+}
+
+function stageTime(): number {
+  return usingShader() ? shader.time : core.time;
+}
+
+function stageGeometry(): CaptureGeometry | null {
+  return usingShader() ? shaderGeometry() : core.geometry();
+}
+
+/** Fresh take on whichever stage is running. */
+function resetStage() {
+  if (usingShader()) {
+    shader.reset();
+    return;
+  }
+  core.reset();
+}
+
+function stepStage(dt: number, geometryOverride?: CaptureGeometry): StageStep | null {
+  if (usingShader()) {
+    const geometry = geometryOverride ?? shaderGeometry();
+    if (!geometry) return null;
+    shaderKnobs();
+    const frame = shader.step(dt, geometry);
+    if (!frame) return null;
+    return {
+      geometry: frame.geometry,
+      time: frame.time,
+      renderMs: frame.renderMs,
+      errors: {},
+      paint: (target, settings) => painter.paintCanvas(target, frame.canvas, frame.geometry, settings),
+    };
+  }
+  const frame = core.step(dt, geometryOverride);
+  if (!frame) return null;
+  return {
+    geometry: frame.geometry,
+    time: frame.time,
+    renderMs: frame.renderMs,
+    errors: frame.errors,
+    paint: (target, settings) => painter.paint(target, frame, settings),
+  };
 }
 
 /**
@@ -77,7 +230,7 @@ function postState() {
  * hiccup on the stage, never on the lab.
  */
 function refreshProbe() {
-  if (!project || core.settings.style !== "auto") return;
+  if (!project || core.settings.style !== "auto" || usingShader()) return;
   const key = probeKey(project);
   if (probe && probe.key === key) return;
   probe = { key, result: probeScaling(project) };
@@ -117,12 +270,16 @@ const WARM_STEP = 1 / 30;
 /** How far the stage runs in when it wakes cold (matches fresh takes). */
 const STAGE_WARM_SECONDS = 2;
 
-/** Run a fresh-take warm-up: `seconds` of pattern time at matrix size. */
+/**
+ * Run a fresh-take warm-up: `seconds` of pattern time at matrix size — or,
+ * for a shader, at the output size, because its feedback state IS the frame
+ * and warming a smaller one would warm a different simulation.
+ */
 function warmTo(seconds: number) {
   if (!project) return;
-  const warm = warmGeometry(project.matrix);
   const steps = Math.max(1, Math.round(seconds / WARM_STEP));
-  for (let index = 0; index < steps; index++) core.step(WARM_STEP, warm);
+  const warm = usingShader() ? shaderGeometry() ?? undefined : warmGeometry(project.matrix);
+  for (let index = 0; index < steps; index++) stepStage(WARM_STEP, warm);
 }
 
 /** The verdict travels on its own: the controls need it with no frames flowing. */
@@ -131,18 +288,18 @@ function postAuto() {
 }
 
 function autoVerdict(): AutoVerdict | null {
-  if (core.settings.style !== "auto" || !probe) return null;
+  if (core.settings.style !== "auto" || !probe || usingShader()) return null;
   const { metrics, probed } = probe.result;
   return {
     verdict: probe.result.verdict,
     reason: probe.result.reason,
     description: describeProbe(probe.result),
-    detail: `probed at ${probed.width}×${probed.height} · layout ${metrics.layout.toFixed(1)} · density ×${metrics.density.toFixed(2)} · luminance ${metrics.luminance.toFixed(0)} · noise ${metrics.noise.toFixed(1)}`,
+    detail: `probed at ${probed.width}×${probed.height} · layout ${metrics.layout.toFixed(1)} · density ×${metrics.density.toFixed(2)} · detail ${(metrics.detail * 100).toFixed(0)}% · luminance ${metrics.luminance.toFixed(0)} · noise ${metrics.noise.toFixed(1)}`,
   };
 }
 
 function frameMessage(
-  frame: CaptureFrame,
+  frame: StageStep,
   bitmap: ImageBitmap,
   preview: number | null = null,
 ): FromWorker {
@@ -168,7 +325,7 @@ function frameMessage(
  * so cover fits, offsets and rotation stay exactly the export's, smaller.
  */
 function previewFor(full: CaptureGeometry): { geometry: CaptureGeometry; factor: number } | null {
-  if (!project) return null;
+  if (!project || usingShader()) return null;
   // Native re-runs the pattern code on the stage grid: shrink that grid and
   // pixel-unit math draws a different picture, not a smaller one. Never
   // reduce it — a slow exact stage is a preview, a fast different one isn't.
@@ -196,12 +353,12 @@ function previewFor(full: CaptureGeometry): { geometry: CaptureGeometry; factor:
 }
 
 function renderAndPost(dt: number) {
-  const full = core.geometry();
+  const full = stageGeometry();
   if (!full) return;
   const preview = previewFor(full);
-  const frame = core.step(dt, preview?.geometry);
+  const frame = stepStage(dt, preview?.geometry);
   if (!frame) return;
-  painter.paint(stage, frame, core.settings);
+  frame.paint(stage, core.settings);
   const bitmap = stage.transferToImageBitmap();
   awaitingAck = true;
   post(frameMessage(frame, bitmap, preview?.factor ?? null), [bitmap]);
@@ -216,6 +373,8 @@ function requestTick() {
 function tick() {
   tickScheduled = false;
   if (exporting || awaitingAck || !visible || !core.ready) return;
+  // A shader take is exact, so the pattern's frame-shown pacing is all the
+  // budget it needs; nothing else about the loop changes.
   const now = performance.now();
   if (playing) {
     const dt = Math.min(MAX_DT, Math.max(0, (now - lastTick) / 1000));
@@ -245,42 +404,45 @@ async function exportImage(
   exporting = true;
   try {
     if (!project) throw new Error("Nothing to capture yet.");
-    let frame: CaptureFrame | null = null;
+    let frame: StageStep | null = null;
     if (automation) {
       // The show's frame at the playhead: replay the automation from t = 0 —
       // state and all — at matrix size, and render only the last frame big.
-      // Frame-exact with what a show render shows at that moment.
-      core.reset();
+      // Frame-exact with what a show render shows at that moment. A shader
+      // replays at the output size throughout: its state lives on that grid.
+      resetStage();
       const dt = 1 / automation.fps;
-      const warm = warmGeometry(project.matrix);
+      const warm = usingShader() ? shaderGeometry() ?? undefined : warmGeometry(project.matrix);
       for (let index = 0; index < automation.frames; index++) {
         const base = index * 4;
-        core.setKnobs([
+        setStageKnobs([
           automation.knobs[base],
           automation.knobs[base + 1],
           automation.knobs[base + 2],
           automation.knobs[base + 3],
         ]);
-        frame = core.step(dt, index < automation.frames - 1 ? warm : undefined);
+        frame = stepStage(dt, index < automation.frames - 1 ? warm : undefined);
       }
-      if (!frame) frame = core.step(0);
+      if (!frame) frame = stepStage(0);
     } else if (warmSeconds && warmSeconds > 0) {
       // Viewfinder off: a fresh take, warmed a moment in — deterministic,
       // and never a cold t = 0 frame of a pattern that starts dark.
-      core.reset();
+      resetStage();
       warmTo(warmSeconds);
-      frame = core.step(0);
+      frame = stepStage(0);
     } else {
       // The stage's current moment — exactly what the viewfinder shows.
-      frame = core.step(0);
+      frame = stepStage(0);
     }
     if (!frame) throw new Error("Nothing to capture yet.");
-    painter.paint(stage, frame, core.settings);
+    frame.paint(stage, core.settings);
     const blob = await stage.convertToBlob({ type: "image/png" });
     post({ type: "image", requestId, blob });
   } catch (error) {
     post({ type: "failed", requestId, message: describe(error) });
   } finally {
+    setStageKnobs(null);
+    if (project) core.setProject(project);
     exporting = false;
     // The stage canvas still holds the still; repaint it for the live view.
     markDirty();
@@ -302,15 +464,15 @@ async function exportVideo(
   // overrides them per frame from the automation instead.
   const pinnedKnobs = project ? [...project.knobs] : null;
   try {
-    const geometry = core.geometry();
+    const geometry = stageGeometry();
     if (!geometry) throw new Error("Nothing to capture yet.");
     // A show is a take from t = 0: fresh pattern state. A clip with the
     // viewfinder off is a fresh take too, warmed a moment in; with it on,
     // the clip records from the stage's current moment — what you see.
     if (automation) {
-      core.reset();
+      resetStage();
     } else if (warmSeconds && warmSeconds > 0 && project) {
-      core.reset();
+      resetStage();
       warmTo(warmSeconds);
     }
 
@@ -366,18 +528,18 @@ async function exportVideo(
         if (cancelRequested) throw new Error("cancelled");
         if (automation) {
           const base = index * 4;
-          core.setKnobs([
+          setStageKnobs([
             automation.knobs[base],
             automation.knobs[base + 1],
             automation.knobs[base + 2],
             automation.knobs[base + 3],
           ]);
         } else if (pinnedKnobs) {
-          core.setKnobs(pinnedKnobs);
+          setStageKnobs(pinnedKnobs);
         }
-        const frame = core.step(dt);
+        const frame = stepStage(dt);
         if (!frame) throw new Error("Project vanished mid-render.");
-        painter.paint(stage, frame, settings);
+        frame.paint(stage, settings);
         if (encodeCanvas !== stage) {
           const context = encodeCanvas.getContext("2d")!;
           context.fillStyle = settings.backdrop === "color" ? settings.backdropColor : "#000000";
@@ -412,6 +574,7 @@ async function exportVideo(
     post({ type: "failed", requestId, message: describe(error) });
   } finally {
     core.setSettings(liveSettings);
+    setStageKnobs(null);
     // Back to the live project wholesale — knobs and any edits that streamed
     // in while the export ran.
     if (project) core.setProject(project);
@@ -438,6 +601,8 @@ scope.onmessage = (event) => {
     case "project": {
       project = mergeWireProject(project, message.project);
       core.setProject(project);
+      // A ramp edit arrives as a project update like any other: repaint.
+      if (syncShaderRamp() && usingShader()) markDirty();
       // First project: probe right away so the very first frame is already
       // the right look; afterwards let edits and drags settle.
       if (!probe) {
@@ -450,9 +615,41 @@ scope.onmessage = (event) => {
       return;
     }
     case "settings": {
+      const before = core.settings.source;
       core.setSettings(message.settings);
+      // Switching renderer is a cut, not a dissolve: the incoming stage starts
+      // its own take rather than inheriting a clock it never ran.
+      if (message.settings.source !== before) {
+        resetStage();
+        warmTo(STAGE_WARM_SECONDS);
+        postState();
+      }
       refreshProbe();
       postAuto();
+      markDirty();
+      return;
+    }
+    case "shader": {
+      shaderLayerId = message.layerId;
+      shader.setSource(message.source);
+      syncShaderRamp();
+      shader.prepare();
+      postShaderStatus();
+      if (core.settings.source === "shader") {
+        postAuto();
+        markDirty();
+      }
+      return;
+    }
+    case "button": {
+      if (message.down) {
+        core.pressButton(message.index);
+        shader.pressButton(message.index);
+      } else {
+        core.releaseButton(message.index);
+        shader.releaseButton(message.index);
+      }
+      // A press has to reach a frame to be seen: a paused stage renders one.
       markDirty();
       return;
     }
@@ -462,7 +659,7 @@ scope.onmessage = (event) => {
         // The stage idles until the viewfinder opens; a first frame at the
         // pattern's cold t = 0 is black more often than not. Wake it the way
         // a fresh take starts: warmed a moment in, at matrix size.
-        if (core.ready && core.time === 0) warmTo(STAGE_WARM_SECONDS);
+        if (core.ready && stageTime() === 0) warmTo(STAGE_WARM_SECONDS);
         lastTick = performance.now();
         markDirty();
       }
@@ -482,7 +679,7 @@ scope.onmessage = (event) => {
       return;
     }
     case "restart": {
-      core.reset();
+      resetStage();
       lastTick = performance.now();
       postState();
       markDirty();
@@ -495,7 +692,9 @@ scope.onmessage = (event) => {
       // Backwards only moves the clock: pattern state cannot be un-updated,
       // so a negative step re-draws the earlier moment without an update.
       if (message.frames >= 0) {
-        for (let index = 0; index < message.frames; index++) core.step(dt);
+        for (let index = 0; index < message.frames; index++) stepStage(dt);
+      } else if (usingShader()) {
+        shader.time = Math.max(0, shader.time + message.frames * dt);
       } else {
         core.time = Math.max(0, core.time + message.frames * dt);
       }

--- a/web/src/lib/lab/capture/client.ts
+++ b/web/src/lib/lab/capture/client.ts
@@ -11,6 +11,7 @@ import type {
   CaptureSettings,
   FrameMessage,
   FromWorker,
+  ShaderStatus,
   ShowAutomation,
   ToWorker,
   VideoRequest,
@@ -34,6 +35,8 @@ export type CaptureClientHandlers = {
   onFatal: (message: string) => void;
   /** The auto probe's standalone verdict (frames don't flow while idle). */
   onAuto?: (auto: AutoVerdict | null) => void;
+  /** Compile result for the shader twin — answered even with no frames. */
+  onShader?: (status: ShaderStatus) => void;
 };
 
 type Pending =
@@ -111,6 +114,9 @@ export class CaptureClient {
       case "auto":
         this.handlers.onAuto?.(message.auto);
         return;
+      case "shader-status":
+        this.handlers.onShader?.(message.status);
+        return;
       case "fatal":
         this.failAll(message.message);
         this.handlers.onFatal(message.message);
@@ -153,6 +159,24 @@ export class CaptureClient {
 
   sendSettings(settings: CaptureSettings) {
     this.send({ type: "settings", settings });
+  }
+
+  /** The GLSL twin, or null to drop it, with the layer whose ramp it reads. */
+  sendShader(source: string | null, layerId: string | null) {
+    this.send({ type: "shader", source, layerId });
+  }
+
+  /**
+   * A knob button, pressed on the stage's own engine. The live preview keeps
+   * its own; both get the press so what the panel plays and what the stage
+   * exports react the same way.
+   */
+  pressButton(index: number) {
+    this.send({ type: "button", index, down: true });
+  }
+
+  releaseButton(index: number) {
+    this.send({ type: "button", index, down: false });
   }
 
   setVisible(visible: boolean) {

--- a/web/src/lib/lab/capture/core.ts
+++ b/web/src/lib/lab/capture/core.ts
@@ -218,6 +218,20 @@ export class CaptureCore {
     if (this.project) this.project = { ...this.project, knobs };
   }
 
+  /**
+   * The knob push buttons, forwarded to this stage's own engine. The Knobs
+   * panel presses the live preview's engine; without these the stage never
+   * saw a press, so a pattern that reseeds or triggers on a button could not
+   * be driven into the state you wanted to export.
+   */
+  pressButton(index: number) {
+    this.engine.pressButton(index);
+  }
+
+  releaseButton(index: number) {
+    this.engine.releaseButton(index);
+  }
+
   geometry(): CaptureGeometry | null {
     if (!this.project) return null;
     return resolveGeometry(this.settings, this.project.matrix, this.autoLook);

--- a/web/src/lib/lab/capture/paint.ts
+++ b/web/src/lib/lab/capture/paint.ts
@@ -4,7 +4,7 @@
 // keeps is a staging canvas for the frame pixels.
 
 import type { CaptureFrame } from "./core";
-import type { CaptureSettings } from "./types";
+import type { CaptureGeometry, CaptureSettings } from "./types";
 
 type Canvas2D = OffscreenCanvas | HTMLCanvasElement;
 type Context2D = OffscreenCanvasRenderingContext2D | CanvasRenderingContext2D;
@@ -55,8 +55,8 @@ export class StagePainter {
    * coordinates (render × scale) and lands turned clockwise by `rotation`
    * inside the output frame.
    */
-  private turn(context: Context2D, frame: CaptureFrame) {
-    const { output, rotation } = frame.geometry;
+  private turn(context: Context2D, geometry: CaptureGeometry) {
+    const { output, rotation } = geometry;
     if (rotation === 90) {
       context.translate(output.width, 0);
       context.rotate(Math.PI / 2);
@@ -69,13 +69,46 @@ export class StagePainter {
     }
   }
 
+  /**
+   * Place an already-rendered picture — the shader stage's GL canvas — in the
+   * output frame: backdrop, turn, blit. It arrives at the render size with
+   * straight alpha, so the backdrop control means the same thing it does for
+   * a pattern; the cutout controls do not apply, the shader's own alpha is
+   * the cutout.
+   */
+  paintCanvas(
+    canvas: Canvas2D,
+    source: CanvasImageSource,
+    geometry: CaptureGeometry,
+    settings: CaptureSettings,
+  ) {
+    const { output, render, scale, offsetX, offsetY } = geometry;
+    resize(canvas, output.width, output.height);
+    const context = context2D(canvas);
+    this.backdrop(context, settings, output.width, output.height);
+    this.turn(context, geometry);
+    context.imageSmoothingEnabled = false;
+    context.drawImage(
+      source,
+      0,
+      0,
+      render.width,
+      render.height,
+      offsetX,
+      offsetY,
+      render.width * scale,
+      render.height * scale,
+    );
+    context.imageSmoothingEnabled = true;
+  }
+
   paint(canvas: Canvas2D, frame: CaptureFrame, settings: CaptureSettings) {
     const { output, render, scale, look, offsetX, offsetY } = frame.geometry;
     resize(canvas, output.width, output.height);
     const context = context2D(canvas);
     this.backdrop(context, settings, output.width, output.height);
     const staging = this.stage(frame);
-    this.turn(context, frame);
+    this.turn(context, frame.geometry);
     // Where the scaled render lands inside the unturned box.
     const drawWidth = render.width * scale;
     const drawHeight = render.height * scale;

--- a/web/src/lib/lab/capture/probe.ts
+++ b/web/src/lib/lab/capture/probe.ts
@@ -7,7 +7,7 @@
 //
 // Nobody can tell from the source, so the probe renders instead: the stack at
 // its own matrix and at an aspect-true multiple, both box-filtered down to the
-// matrix grid, and compares two things —
+// matrix grid, and compares three things —
 //
 //   layout     mean |difference| after a 3×3 blur (the blur forgives the
 //              jagged-vs-antialiased edges a correct re-render always has)
@@ -15,6 +15,11 @@
 //              in pixel units comes back with N× the stripes (ratio ≫ 1) or
 //              paints only its old frame (ratio ≪ 1); one that scales stays
 //              near 1.
+//   detail     what the first two structurally cannot see: whether the big
+//              render is finer than the grid it came from, or the same picture
+//              in bigger blocks. Both metrics compare box-filtered copies, and
+//              a block upscale filters down to exactly the original — a
+//              perfect score for a render that gained nothing.
 //
 // Thresholds come from all 46 bundled presets (scripts/_probe-experiment.ts):
 // the scale-safe ones sit at layout ≤ 22 / density 0.83–1.0, the baked ones
@@ -32,6 +37,7 @@ export type ProbeReason =
   | "scales"
   | "frame-baked"
   | "layout-changes"
+  | "no-detail"
   | "too-dark"
   | "non-deterministic"
   | "errors";
@@ -41,10 +47,29 @@ export type ProbeResult = {
   reason: ProbeReason;
   /** Grid the comparison render ran at. */
   probed: MatrixSize;
-  metrics: { layout: number; density: number; luminance: number; noise: number };
+  metrics: {
+    layout: number;
+    density: number;
+    luminance: number;
+    noise: number;
+    /** Share of the big render's cells that hold detail below matrix scale. */
+    detail: number;
+  };
 };
 
 export const PROBE_LAYOUT_MAX = 27;
+/**
+ * Below this share of textured cells the big render carries no information the
+ * matrix render did not — it is the same picture in bigger blocks.
+ *
+ * The usual author is a pattern that samples a fixed internal field (a
+ * simulation grid, a sprite table) with nearest lookups: honest code, and the
+ * shape an AI "any size" rewrite of a simulation comes back in. A composition
+ * of large flat cells lands here too at some knob settings, which is not a
+ * fault of the code — in both cases the upscale is pixel-identical to the
+ * native render and costs a fraction of it, so the verdict is the same.
+ */
+export const PROBE_DETAIL_MIN = 0.02;
 export const PROBE_DENSITY_MIN = 0.55;
 export const PROBE_DENSITY_MAX = 1.5;
 export const PROBE_LUMINANCE_MIN = 10;
@@ -143,6 +168,45 @@ function variation(source: Float32Array, width: number, height: number): number 
   return sum / (width * height);
 }
 
+/**
+ * The share of factor×factor cells whose pixels are not all identical — i.e.
+ * how much of the big render is finer than the matrix grid it came from. An
+ * exact nearest blow-up scores 0; a genuine re-render scores its edges, which
+ * for any real composition is a large fraction of the frame.
+ */
+export function blockDetail(
+  data: Uint8ClampedArray,
+  width: number,
+  height: number,
+  factor: number,
+): number {
+  if (factor < 2) return 1;
+  let cells = 0;
+  let textured = 0;
+  for (let by = 0; by + factor <= height; by += factor) {
+    for (let bx = 0; bx + factor <= width; bx += factor) {
+      cells++;
+      const first = (by * width + bx) * 4;
+      let differs = false;
+      for (let y = by; y < by + factor && !differs; y++) {
+        for (let x = bx; x < bx + factor; x++) {
+          const index = (y * width + x) * 4;
+          if (
+            data[index] !== data[first] ||
+            data[index + 1] !== data[first + 1] ||
+            data[index + 2] !== data[first + 2]
+          ) {
+            differs = true;
+            break;
+          }
+        }
+      }
+      if (differs) textured++;
+    }
+  }
+  return cells === 0 ? 1 : textured / cells;
+}
+
 function luminance(source: Float32Array): number {
   let sum = 0;
   for (let i = 0; i < source.length; i += 3) {
@@ -209,6 +273,8 @@ export function probeScaling(project: CaptureProject): ProbeResult {
   let densityMin = Infinity;
   let densityMax = 0;
   let judged = 0;
+  let detail = 0;
+  const factor = Math.round(probed.width / matrix.width);
 
   for (let index = 0; index < small.samples.length; index++) {
     const a = boxDown(small.samples[index], matrix.width, matrix.height, matrix.width, matrix.height);
@@ -230,10 +296,16 @@ export function probeScaling(project: CaptureProject): ProbeResult {
     const ratio = variation(b, matrix.width, matrix.height) / variationA;
     densityMin = Math.min(densityMin, ratio);
     densityMax = Math.max(densityMax, ratio);
+    // Judged frames only: a dark or flat one is all identical cells and would
+    // read as a block upscale whatever the code does.
+    detail = Math.max(
+      detail,
+      blockDetail(big.samples[index], probed.width, probed.height, factor),
+    );
   }
 
   const density = judged > 0 ? (densityMin + densityMax) / 2 : 1;
-  const metrics = { layout, density, luminance: lum, noise };
+  const metrics = { layout, density, luminance: lum, noise, detail };
   const result = (verdict: ProbeVerdict, reason: ProbeReason): ProbeResult => ({
     verdict,
     reason,
@@ -250,6 +322,10 @@ export function probeScaling(project: CaptureProject): ProbeResult {
     return result("upscale", "frame-baked");
   }
   if (layout > PROBE_LAYOUT_MAX) return result("upscale", "layout-changes");
+  // Last, and only for code that passed everything else: it re-renders
+  // faithfully but adds nothing. Upscaling the matrix frame is then the same
+  // picture for a fraction of the work — and the panel can say so.
+  if (detail < PROBE_DETAIL_MIN) return result("upscale", "no-detail");
   return result("native", "scales");
 }
 
@@ -296,6 +372,8 @@ export function describeProbe(result: ProbeResult): string {
       return "upscaled — the frame size is baked into the code (re-rendering would tile or crop it)";
     case "layout-changes":
       return "upscaled — the picture changes with resolution";
+    case "no-detail":
+      return "upscaled — it re-renders at any size but draws nothing finer there, so the blow-up is the same picture for a fraction of the work";
     case "too-dark":
       return "upscaled — too dark or too flat to verify a re-render";
     case "non-deterministic":

--- a/web/src/lib/lab/capture/session.ts
+++ b/web/src/lib/lab/capture/session.ts
@@ -22,6 +22,7 @@ import type {
   AutoVerdict,
   CaptureSettings,
   FrameMessage,
+  ShaderStatus,
   ShowAutomation,
   VideoRequest,
 } from "./types";
@@ -41,6 +42,8 @@ export type CaptureSessionEvents = {
   /** Per-layer errors from the latest frame, named for people. */
   errors?: (errors: Record<string, string>) => void;
   auto?: (auto: AutoVerdict | null) => void;
+  /** How the shader twin compiled, whenever a source arrives. */
+  shader?: (status: ShaderStatus) => void;
   progress?: (done: number, total: number) => void;
   fatal?: (message: string) => void;
 };
@@ -54,6 +57,17 @@ type Session = {
   attachViewfinder(canvas: HTMLCanvasElement): () => void;
   /** Settings changes flow through here (the Capture panel owns the state). */
   applySettings(settings: CaptureSettings): void;
+  /** The GLSL twin for a code layer, or null to drop it. */
+  setShaderSource(source: string | null, layerId: string | null): void;
+  /**
+   * Knob push buttons. The Knobs panel presses the live engine directly; these
+   * carry the same press to the stage's engine — and to a shader's uBtn
+   * uniforms — so what you can trigger in the preview you can also export.
+   * They never start the worker: no camera, nothing to press.
+   */
+  pressButton(index: number): void;
+  releaseButton(index: number): void;
+  releaseAllButtons(): void;
   /** Latest settings the session pushed — for output-size labels. */
   settings(): CaptureSettings;
   /** Flush the project to the worker NOW (exports call this first). */
@@ -72,6 +86,8 @@ function createSession(): Session {
   const supported = captureSupported();
   let client: CaptureClient | null = null;
   let settings: CaptureSettings = loadCaptureSettings();
+  let shaderSource: string | null = null;
+  let shaderLayerId: string | null = null;
   let view = false;
   let output: { width: number; height: number } | null = null;
   let canvas: HTMLCanvasElement | null = null;
@@ -166,12 +182,16 @@ function createSession(): Session {
       onAuto: (auto) => {
         for (const listener of eventListeners) listener.auto?.(auto);
       },
+      onShader: (status) => {
+        for (const listener of eventListeners) listener.shader?.(status);
+      },
       onFatal: (message) => {
         for (const listener of eventListeners) listener.fatal?.(message);
       },
     });
     client.sendSettings(settings);
     client.sendProject(projectSlice());
+    if (shaderSource) client.sendShader(shaderSource, shaderLayerId);
     useLabStore.subscribe((state, previous) => {
       if (
         state.layers !== previous.layers ||
@@ -221,6 +241,20 @@ function createSession(): Session {
     applySettings(next) {
       settings = next;
       ensure()?.sendSettings(next);
+    },
+    setShaderSource(source, layerId) {
+      shaderSource = source && source.trim() ? source : null;
+      shaderLayerId = layerId;
+      ensure()?.sendShader(shaderSource, layerId);
+    },
+    pressButton(index) {
+      client?.pressButton(index);
+    },
+    releaseButton(index) {
+      client?.releaseButton(index);
+    },
+    releaseAllButtons() {
+      for (let index = 0; index < 4; index++) client?.releaseButton(index);
     },
     settings: () => settings,
     sendProjectNow() {

--- a/web/src/lib/lab/capture/settings.ts
+++ b/web/src/lib/lab/capture/settings.ts
@@ -71,6 +71,10 @@ export function normalizeCaptureSettings(input: unknown): CaptureSettings {
       ? Math.max(1, Math.min(CAPTURE_SECONDS_MAX, Math.round(video.seconds * 10) / 10))
       : base.video.seconds;
   return {
+    // Settings from before the shader twin (2026-09) have no source at all,
+    // and a stored "shader" is only an intent — the panel switches back to
+    // the pattern when the layer it belonged to has no shader.
+    source: pick(raw.source, ["pattern", "shader"] as const, base.source),
     // "smooth" was a look until 2026-08; stored settings carrying it fall
     // back to auto here.
     style: pick(raw.style, ["auto", "native", "pixel", "led"] as const, base.style),

--- a/web/src/lib/lab/capture/shaderPrompt.ts
+++ b/web/src/lib/lab/capture/shaderPrompt.ts
@@ -1,0 +1,121 @@
+// ── "Shader twin" conversion prompt ──────────────────────────────────────────
+// Same workflow as the C++ conversion and the any-size rewrite: copy a prompt,
+// hand it to whatever model you like, paste the answer back — except the answer
+// lands in the Graphic Export panel's shader field, not in the Code panel. The
+// JS pattern is untouched: it stays what the panel plays and what the hardware
+// export bakes. The shader is a second expression of the same composition, for
+// the one job JS cannot do — filling a poster with real detail.
+//
+// The prompt carries the whole runtime contract (shaderSource.ts), the knob
+// ranges as they actually are, and the layer's colour ramp — as a DESCRIPTION,
+// so the model knows what the picture looks like, and with an instruction to
+// call ramp(v) rather than reproduce it. Baking the colours in would freeze the
+// Color Ramp panel out of the twin; the ramp travels as a texture instead
+// (shaderRamp.ts), so editing a stop repaints the export live.
+
+import type { MatrixSize } from "@/lib/patternMatrix";
+import { parseKnobsAnnotation } from "../annotations";
+import type { KnobRange, RampState } from "../types";
+
+const MODE_NOTES: Record<string, string> = {
+  linear: "straight RGB interpolation between stops",
+  smooth: "RGB interpolation with a smoothstep ease between stops",
+  step: "no interpolation — each stop holds until the next one",
+  hsvShort: "HSV interpolation, hue takes the short way round",
+  hsvLong: "HSV interpolation, hue takes the long way round",
+  oklab: "OKLab interpolation (perceptually even, no hue drift)",
+  oklchShort: "OKLCh interpolation, hue the short way (even chroma)",
+  oklchLong: "OKLCh interpolation, hue the long way (even chroma)",
+};
+
+function describeRamp(ramp: RampState): string {
+  const stops = ramp.stops
+    .map((stop) => `${stop.position.toFixed(3)} → ${stop.color}${stop.alpha < 1 ? ` @ ${stop.alpha.toFixed(2)} alpha` : ""}`)
+    .join(", ");
+  const mode = MODE_NOTES[ramp.mode] ?? ramp.mode;
+  return `${stops}\nInterpolation: ${mode}${ramp.wrap ? "; the ramp WRAPS (value 1 meets value 0 again)" : ""}.`;
+}
+
+function describeKnobs(code: string, ranges: KnobRange[]): string {
+  const parsed = parseKnobsAnnotation(code);
+  return ranges
+    .map((range, index) => {
+      const entry = parsed?.[index];
+      const name = entry?.name ?? `Knob ${index + 1}`;
+      const [min, max] = entry ? [entry.min, entry.max] : range;
+      const component = ["x", "y", "z", "w"][index];
+      return `  uKnob.${component} — ${name}: ${min} … ${max}`;
+    })
+    .join("\n");
+}
+
+export function buildShaderPrompt(
+  code: string,
+  matrix: MatrixSize,
+  ramp: RampState,
+  ranges: KnobRange[],
+): string {
+  const { width, height } = matrix;
+  return `You are porting ONE JavaScript LED pattern to a GLSL fragment shader. The JavaScript keeps running the LED panel; the shader is a second, output-only expression of the same composition, used to render stills and clips at print and screen sizes (1024×512 up to 4096 px a side) where the JS version is far too slow and, if it carries a simulation grid, too coarse.
+
+TARGET RUNTIME
+GLSL ES 3.00, one fragment shader, rendered full-frame. Write ONLY function definitions — the stage prepends the version line, precision, the uniform block and its own main(). Do NOT write #version, do NOT declare an "out" variable, do NOT write main(), and do NOT use any texture the stage does not give you.
+
+Entry points:
+  void mainImage(out vec4 fragColor, in vec2 fragCoord)   REQUIRED — the picture. fragColor is straight (un-premultiplied) RGBA, 0..1.
+  void mainState(out vec4 stateOut, in vec2 fragCoord)    OPTIONAL — one frame of simulation state; see FEEDBACK.
+
+Uniforms and helpers, always available:
+  uniform vec2 uResolution;   // render size in pixels (NOT ${width}×${height} — anything up to 4096)
+  uniform float uTime;        // seconds since the take started
+  uniform int uFrame;         // frames since the take started, 0 on the first
+  uniform vec4 uKnob;         // the four knobs in their real ranges (below)
+  uniform vec4 uKnobNorm;     // the same four, 0..1 across their range
+  uniform vec4 uBtnPressed;   // 1.0 on the frame a knob button goes down
+  uniform vec4 uBtnHeld;      // 1.0 while it is held
+  uniform sampler2D uState;   // last frame's mainState output; wraps, NEAREST
+  vec4 stateAt(vec2 fragCoord);                    // this pixel's previous state
+  vec4 stateOffset(vec2 fragCoord, vec2 delta);    // a neighbour, delta in pixels
+  vec4 ramp(float v);                              // the layer's live colour ramp, 0..1 in
+
+KNOBS — same names, same real values the JS pattern reads from input.knobValues:
+${describeKnobs(code, ranges)}
+uKnob is the knob VALUE, not a normalised slider: use it exactly where the JS uses knobValues[i]. Buttons map 1:1 with input.btnPressed[i] / input.btnHeld[i]: uBtnPressed.x > 0.5 is "button 1 was pressed this frame".
+
+COLOUR
+${
+    /setValue\s*\(/.test(code)
+      ? `The JS draws with display.setValue(x, y, v) — a 0..1 value field the runtime colours through the layer's ramp. Do the same: write \`fragColor = ramp(v);\` wherever the JS calls setValue(x, y, v). DO NOT bake the colours in and do not write your own gradient — ramp() IS the Color Ramp panel, so the user goes on editing their colours with the shader running. For reference, it currently holds:
+${describeRamp(ramp)}
+ramp() clamps its input to 0..1 and returns straight RGBA, alpha included.`
+      : "The JS draws with display.setPixel(x, y, r, g, b) in 0..255 sRGB. Divide by 255 and keep the same colours. (A ramp(float v) helper exists but this pattern does not use one.)"
+  }
+
+RESOLUTION IS THE WHOLE POINT
+The composition must look like the ${width}×${height} original and gain REAL detail as uResolution grows — never more repetitions, never a crop, never the same picture in bigger blocks.
+- Derive every coordinate from uResolution: vec2 uv = fragCoord / uResolution, or a centred coordinate with the aspect preserved. Turn pixel-unit frequencies into frame-unit ones: a JS Math.sin(x * 0.1) is Math.sin(u * ${(0.1 * width).toFixed(1)}) in frame units.
+- Replace every literal that encodes the frame (${width}, ${height}, ${width / 2}, ${height / 2}, strides, bounds) with uResolution.
+- Anything the JS quantised to LED cells (checkerboards, dithers, scanlines, 1-pixel strokes) must keep its frame-relative SIZE, so scale the cell size with uResolution rather than testing raw pixels. Where the JS had one hard-edged LED, prefer a smooth edge sized in frame units — at 4096 px a jagged step is the one thing that will look wrong.
+- No arrays of per-pixel state, no loops over the whole frame: a fragment shader runs once per pixel. Anything the JS accumulated in a Float32Array is either recomputed from uTime, or becomes FEEDBACK.
+
+FEEDBACK — only if the JS carries state between frames
+If the pattern integrates a field (reaction–diffusion, cellular automata, fluid, decay trails, phosphor memory), write mainState as well. Rules:
+- One RGBA texel per pixel is the state. Pack the fields into channels and say which is which in a comment (e.g. R = u, G = v, B = stress).
+- Seed it: if (uFrame == 0) { ...initial field... } — reproduce the JS seeding. Reseed on a button too, where the JS does: if (uBtnPressed.x > 0.5) { ...seed... }.
+- Read neighbours with stateOffset(fragCoord, vec2(h, 0.0)) where h is a frame-relative step, NOT one pixel:
+    float h = max(1.0, floor(min(uResolution.x / ${width}.0, uResolution.y / ${height}.0)));
+  With h = 1 at the original size this is the JS lattice exactly; at 4K it keeps the structures the same size in the frame instead of shrinking them to ${width}ths of it.
+- Use a 9-tap Laplacian at that spacing (edges 0.2, corners 0.05, centre −1) rather than a 5-tap: a wide stencil with only four taps aliases into grid-scale noise.
+- Keep the same time step and coefficients the JS uses, and keep every clamp and non-finite guard it has — a shader that diverges goes to NaN and stays black.
+- mainImage then reads stateAt(fragCoord) and colours it. It must not integrate anything itself.
+
+ALSO
+- No randomness outside a hash of the coordinate (write one inline, e.g. a fract(sin(dot(...))) hash) — every frame must be reproducible from uFrame and uTime alone.
+- Keep the pattern's structure and its knob behaviour. Start the shader with a short comment block: the pattern's title, what each knob does, and the channel packing if there is state.
+- Do not add features, do not "improve" the composition, do not change the palette.
+
+Reply with the complete shader in ONE code block and nothing else.
+
+PATTERN SOURCE (JavaScript)
+${code}`;
+}

--- a/web/src/lib/lab/capture/shaderRamp.ts
+++ b/web/src/lib/lab/capture/shaderRamp.ts
@@ -1,0 +1,38 @@
+// ── The colour ramp, as something a shader can read ──────────────────────────
+// A pattern that draws with display.setValue() has no colours of its own: the
+// ramp is the user's colour decision, applied by the runtime. Baking it into
+// the shader text would freeze that decision — the Color Ramp panel would move
+// and the twin would not — so the ramp travels as a lookup texture instead and
+// the shader reads it through `ramp(v)`. Editing a stop then repaints the
+// output on the next frame, with no recompile and no AI round trip.
+//
+// Sampled 1024× rather than the runtime's 256: the panel's LUT is an 8-bit LED
+// simulation, and a poster is not. Between entries the texture interpolates, so
+// a smooth ramp comes out smooth instead of stepped at 1/256 — closer to the
+// ramp the user drew, not further from it. Hard "step" ramps land within one
+// 1024th of their edge.
+
+import { rampStateToHarness } from "../engine";
+import type { RampState } from "../types";
+import { sampleRampRGBA } from "@/lib/patternHarness";
+
+/** Entries in the ramp texture; the GLSL helper is built around this number. */
+export const SHADER_RAMP_SIZE = 1024;
+
+/** RGBA8 rows for a 1-pixel-tall texture: `SHADER_RAMP_SIZE` × 1. */
+export function buildShaderRampLUT(ramp: RampState): Uint8Array {
+  const lut = new Uint8Array(SHADER_RAMP_SIZE * 4);
+  if (ramp.stops.length === 0) {
+    lut.fill(255);
+    return lut;
+  }
+  const harness = rampStateToHarness(ramp);
+  for (let index = 0; index < SHADER_RAMP_SIZE; index++) {
+    const [r, g, b, a] = sampleRampRGBA(harness, index / (SHADER_RAMP_SIZE - 1));
+    lut[index * 4] = Math.max(0, Math.min(255, Math.round(r)));
+    lut[index * 4 + 1] = Math.max(0, Math.min(255, Math.round(g)));
+    lut[index * 4 + 2] = Math.max(0, Math.min(255, Math.round(b)));
+    lut[index * 4 + 3] = Math.max(0, Math.min(255, Math.round(a * 255)));
+  }
+  return lut;
+}

--- a/web/src/lib/lab/capture/shaderSource.ts
+++ b/web/src/lib/lab/capture/shaderSource.ts
@@ -1,0 +1,158 @@
+// ── Shader source: the GLSL contract ─────────────────────────────────────────
+// The pattern JS is the device's truth: a 128×64 grid, one setValue per LED,
+// and a CPU that has to run it. For a poster it is the wrong machine — a
+// per-pixel JS loop at 4K costs ~200 ms a frame, and a pattern that carries
+// its own simulation grid (reaction-diffusion, automata, trails) can only
+// upsample that grid, so the extra pixels hold no extra picture.
+//
+// The shader twin is the same composition written for the machine that IS
+// built for per-pixel work. It is OUTPUT ONLY — the panel and the hardware
+// export keep running the JS — so nothing here can drift into the device
+// path. What lives in this file is the pure text half of it: what a source
+// must declare, the preamble every compile gets, and how a driver's error
+// log maps back to the lines the user actually wrote. The WebGL half is in
+// shaderStage.ts; keeping them apart is what lets the smoke test run this
+// contract in node.
+
+import { SHADER_RAMP_SIZE } from "./shaderRamp";
+
+/** GLSL ES 3.00. The version line must be the first line of the source. */
+const VERSION = "#version 300 es";
+
+/** Full-screen triangle from gl_VertexID — no attribute buffers at all. */
+export const SHADER_VERTEX_SOURCE = `${VERSION}
+void main() {
+  vec2 pfVertex = vec2((gl_VertexID << 1) & 2, gl_VertexID & 2);
+  gl_Position = vec4(pfVertex * 2.0 - 1.0, 0.0, 1.0);
+}
+`;
+
+/**
+ * Everything a source can rely on. Uniform names are the contract the
+ * conversion prompt hands the model, so they are stable: renaming one is a
+ * breaking change for every shader anyone has already pasted in.
+ */
+export const SHADER_PREAMBLE = `${VERSION}
+precision highp float;
+precision highp int;
+precision highp sampler2D;
+
+uniform vec2 uResolution;   // render size in pixels
+uniform float uTime;        // seconds since the take started
+uniform int uFrame;         // frames since the take started (0 on the first)
+uniform vec4 uKnob;         // the four knobs, in their real @knobs ranges
+uniform vec4 uKnobNorm;     // the same four, 0..1 across their range
+uniform vec4 uBtnPressed;   // 1.0 on the frame a knob button goes down
+uniform vec4 uBtnHeld;      // 1.0 while it is held
+uniform sampler2D uState;   // last frame's mainState output (wraps, nearest)
+uniform sampler2D uRamp;    // the layer's colour ramp, live from the panel
+
+out vec4 pfFragColor;
+
+vec4 stateAt(vec2 fragCoord) {
+  return texture(uState, fragCoord / uResolution);
+}
+
+vec4 stateOffset(vec2 fragCoord, vec2 delta) {
+  return texture(uState, (fragCoord + delta) / uResolution);
+}
+
+// The Color Ramp panel, as a function: 0..1 in, straight RGBA out. Editing a
+// stop moves this on the next frame — nothing here is baked into the shader.
+vec4 ramp(float v) {
+  float u = (clamp(v, 0.0, 1.0) * ${SHADER_RAMP_SIZE - 1}.0 + 0.5) / ${SHADER_RAMP_SIZE}.0;
+  return texture(uRamp, vec2(u, 0.5));
+}
+
+#line 1
+`;
+
+/** How many lines the preamble adds before the user's line 1. */
+export const SHADER_PREAMBLE_LINES = SHADER_PREAMBLE.split("\n").length - 1;
+
+export type ShaderPass = "image" | "state";
+
+/** The name of the entry point a pass calls. */
+export const SHADER_ENTRY: Record<ShaderPass, string> = {
+  image: "mainImage",
+  state: "mainState",
+};
+
+/** Strip line and block comments — entry detection must not read a mention. */
+function withoutComments(source: string): string {
+  return source.replace(/\/\*[\s\S]*?\*\//g, " ").replace(/\/\/[^\n]*/g, " ");
+}
+
+export function declaresPass(source: string, pass: ShaderPass): boolean {
+  const entry = SHADER_ENTRY[pass];
+  return new RegExp(`\\bvoid\\s+${entry}\\s*\\(`).test(withoutComments(source));
+}
+
+/**
+ * The fragment source for one pass: preamble, the user's code verbatim
+ * (`#line 1` keeps their numbering), and a main() that calls the entry.
+ * The user's source is never rewritten — a shader that compiles here is the
+ * shader they wrote.
+ */
+export function buildFragmentSource(source: string, pass: ShaderPass): string {
+  const entry = SHADER_ENTRY[pass];
+  return `${SHADER_PREAMBLE}${source}
+#line 100000
+void main() {
+  vec4 pfOut = vec4(0.0, 0.0, 0.0, 1.0);
+  ${entry}(pfOut, gl_FragCoord.xy);
+  pfFragColor = pfOut;
+}
+`;
+}
+
+/**
+ * Drivers report `ERROR: 0:37: …` — string index, then line, counted in the
+ * source they were handed. `#line 1` after the preamble already makes that
+ * number the user's own, so it only needs saying in words; the wrapper past
+ * `#line 100000` is ours, and a fault in there is reported as the wrapper
+ * rather than as line 100003 of a 40-line shader. Logs also arrive
+ * NUL-terminated and padded from some drivers, hence the control-character
+ * strip: it is going straight into the panel.
+ */
+export function remapShaderLog(log: string): string {
+  return log
+    .replace(/[\u0000-\u0008\u000b-\u001f]/g, "")
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) =>
+      line.replace(/\b0:(\d+):/g, (whole, digits: string) =>
+        Number(digits) >= 100000 ? "wrapper:" : `line ${digits}:`,
+      ),
+    )
+    .slice(0, 6)
+    .join("\n");
+}
+
+export type ShaderSourceCheck = { ok: true; hasState: boolean } | { ok: false; error: string };
+
+/** What can be said about a source without a GPU. */
+export function checkShaderSource(source: string): ShaderSourceCheck {
+  const trimmed = source.trim();
+  if (!trimmed) return { ok: false, error: "The shader is empty." };
+  if (/^\s*#version/m.test(source)) {
+    return {
+      ok: false,
+      error: "Remove the #version line — the stage adds `#version 300 es` and the uniform block itself.",
+    };
+  }
+  if (!declaresPass(source, "image")) {
+    return {
+      ok: false,
+      error: "No `void mainImage(out vec4 fragColor, in vec2 fragCoord)` — that entry point is what the stage calls.",
+    };
+  }
+  if (/\bout\s+vec4\s+\w+\s*;/.test(withoutComments(source))) {
+    return {
+      ok: false,
+      error: "Remove the `out vec4` declaration — write the colour into mainImage's out parameter instead.",
+    };
+  }
+  return { ok: true, hasState: declaresPass(source, "state") };
+}

--- a/web/src/lib/lab/capture/shaderStage.ts
+++ b/web/src/lib/lab/capture/shaderStage.ts
@@ -1,0 +1,443 @@
+// ── Shader stage: the GPU half of Graphic Export ─────────────────────────────
+// A WebGL2 renderer that stands in for CaptureCore when the panel's source is
+// a shader twin. Same shape as the core from the worker's side — reset,
+// setKnobs, step(dt, geometry) — so the export paths (still, clip, Director
+// automation, warm-up) drive either one without knowing which.
+//
+// Two passes at most, both from the ONE source the user pasted:
+//   mainState   optional, ping-ponged through a pair of textures — this is
+//               what makes a simulation possible at output size: the state IS
+//               the frame, so a 4K take integrates 8 M cells instead of
+//               stretching a 128×64 grid over them.
+//   mainImage   required, drawn to the canvas the painter picks up.
+// State textures are RGBA16F where the driver renders float and RGBA8 where it
+// does not; the difference matters for feedback that accumulates, so the stage
+// reports which it got rather than quietly losing precision.
+//
+// The canvas is straight-alpha (premultipliedAlpha: false): a shader that
+// writes alpha gets a transparent PNG through the same backdrop control the
+// pattern path uses.
+
+import type { CaptureGeometry } from "./types";
+import { SHADER_RAMP_SIZE } from "./shaderRamp";
+import {
+  SHADER_VERTEX_SOURCE,
+  buildFragmentSource,
+  checkShaderSource,
+  remapShaderLog,
+  type ShaderPass,
+} from "./shaderSource";
+
+export type ShaderFrame = {
+  geometry: CaptureGeometry;
+  /** The picture at `geometry.render`, for the painter to place. */
+  canvas: OffscreenCanvas;
+  renderMs: number;
+  time: number;
+};
+
+type Programs = {
+  source: string;
+  image: WebGLProgram | null;
+  state: WebGLProgram | null;
+  error: string | null;
+};
+
+const KNOB_COUNT = 4;
+
+export class ShaderStage {
+  private gl: WebGL2RenderingContext | null = null;
+  private canvas: OffscreenCanvas | null = null;
+  private programs: Programs | null = null;
+  private source: string | null = null;
+  /** Set when the GPU itself is unavailable (compile faults live on programs). */
+  private failure: string | null = null;
+
+  private textures: [WebGLTexture | null, WebGLTexture | null] = [null, null];
+  private framebuffer: WebGLFramebuffer | null = null;
+  // The colour ramp as a 1-row texture. Held as bytes so a ramp that arrives
+  // before the context exists is still waiting when it does.
+  private rampLut: Uint8Array | null = null;
+  private rampTexture: WebGLTexture | null = null;
+  private rampSmooth = true;
+  private rampDirty = false;
+  private stateWidth = 0;
+  private stateHeight = 0;
+  private read = 0;
+  private floatState = false;
+
+  private knobs = new Float32Array(KNOB_COUNT);
+  private knobsNorm = new Float32Array(KNOB_COUNT);
+  private btnPressed = new Float32Array(KNOB_COUNT);
+  private btnHeld = new Float32Array(KNOB_COUNT);
+
+  time = 0;
+  private frame = 0;
+
+  constructor(private readonly makeCanvas: (width: number, height: number) => OffscreenCanvas) {}
+
+  /** Compile error, GPU failure, or null when the stage is healthy. */
+  get error(): string | null {
+    return this.failure ?? this.programs?.error ?? null;
+  }
+
+  get hasSource(): boolean {
+    return this.source !== null;
+  }
+
+  /** False once the stage has run without float render targets. */
+  get floatFeedback(): boolean {
+    return this.floatState;
+  }
+
+  setSource(source: string | null) {
+    const next = source && source.trim() ? source : null;
+    if (next === this.source) return;
+    this.source = next;
+    this.disposePrograms();
+    this.failure = null;
+    this.reset();
+  }
+
+  /**
+   * Swap the ramp the `ramp()` helper reads. Cheap on purpose: one 4 KB
+   * upload, no recompile, so dragging a stop repaints the stage live.
+   *
+   * `smooth` interpolates between entries — right for every ramp mode except
+   * "step", where the point IS the hard edge and blending across it would put
+   * a seam of in-between colour the panel never shows.
+   */
+  setRamp(lut: Uint8Array, smooth = true) {
+    this.rampLut = lut;
+    this.rampSmooth = smooth;
+    this.rampDirty = true;
+  }
+
+  setKnobs(values: number[], normalized: number[]) {
+    for (let index = 0; index < KNOB_COUNT; index++) {
+      this.knobs[index] = values[index] ?? 0;
+      this.knobsNorm[index] = normalized[index] ?? 0;
+    }
+  }
+
+  pressButton(index: number) {
+    if (index < 0 || index >= KNOB_COUNT) return;
+    if (this.btnHeld[index]) return;
+    this.btnHeld[index] = 1;
+    this.btnPressed[index] = 1;
+  }
+
+  releaseButton(index: number) {
+    if (index < 0 || index >= KNOB_COUNT) return;
+    this.btnHeld[index] = 0;
+  }
+
+  releaseAllButtons() {
+    this.btnHeld.fill(0);
+  }
+
+  /** Fresh take: time zero, frame zero, feedback cleared. */
+  reset() {
+    this.time = 0;
+    this.frame = 0;
+    this.clearState();
+  }
+
+  /**
+   * Compile now rather than at the first frame, so a paste is answered while
+   * the viewfinder is off. Returns the error, or null when it built.
+   */
+  prepare(): string | null {
+    if (!this.source) return null;
+    const gl = this.context(1, 1);
+    if (!gl) return this.failure;
+    return this.compile(gl, this.source).error;
+  }
+
+  /** Whether the loaded source runs a feedback pass. */
+  get hasFeedback(): boolean {
+    return this.programs?.state !== null && this.programs?.state !== undefined;
+  }
+
+  step(dt: number, geometry: CaptureGeometry): ShaderFrame | null {
+    if (!this.source) return null;
+    const startedAt = performance.now();
+    const { width, height } = geometry.render;
+    const gl = this.context(width, height);
+    if (!gl || !this.canvas) return null;
+    const programs = this.compile(gl, this.source);
+    if (!programs.image) return null;
+
+    this.time += dt;
+    this.ensureState(gl, width, height);
+    this.ensureRamp(gl);
+
+    if (programs.state && this.framebuffer) {
+      const write = 1 - this.read;
+      gl.bindFramebuffer(gl.FRAMEBUFFER, this.framebuffer);
+      gl.framebufferTexture2D(
+        gl.FRAMEBUFFER,
+        gl.COLOR_ATTACHMENT0,
+        gl.TEXTURE_2D,
+        this.textures[write],
+        0,
+      );
+      this.draw(gl, programs.state, width, height, this.textures[this.read]);
+      this.read = write;
+    }
+
+    gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+    this.draw(gl, programs.image, width, height, this.textures[this.read]);
+    gl.flush();
+
+    this.btnPressed.fill(0);
+    this.frame++;
+    return {
+      geometry,
+      canvas: this.canvas,
+      renderMs: performance.now() - startedAt,
+      time: this.time,
+    };
+  }
+
+  dispose() {
+    this.disposePrograms();
+    const gl = this.gl;
+    if (gl) {
+      for (const texture of this.textures) if (texture) gl.deleteTexture(texture);
+      if (this.rampTexture) gl.deleteTexture(this.rampTexture);
+      if (this.framebuffer) gl.deleteFramebuffer(this.framebuffer);
+    }
+    this.textures = [null, null];
+    this.rampTexture = null;
+    this.rampDirty = true;
+    this.framebuffer = null;
+    this.gl = null;
+    this.canvas = null;
+  }
+
+  // ── internals ──
+
+  private context(width: number, height: number): WebGL2RenderingContext | null {
+    if (this.failure) return null;
+    if (!this.gl) {
+      if (typeof OffscreenCanvas === "undefined") {
+        this.failure = "This browser has no OffscreenCanvas for the shader stage.";
+        return null;
+      }
+      const canvas = this.makeCanvas(Math.max(1, width), Math.max(1, height));
+      const gl = canvas.getContext("webgl2", {
+        alpha: true,
+        premultipliedAlpha: false,
+        antialias: false,
+        depth: false,
+        stencil: false,
+        // The painter reads the canvas right after the draw; without this the
+        // buffer can already be gone on some drivers.
+        preserveDrawingBuffer: true,
+      }) as WebGL2RenderingContext | null;
+      if (!gl) {
+        this.failure = "WebGL2 is unavailable here — the shader stage needs it.";
+        return null;
+      }
+      this.floatState = gl.getExtension("EXT_color_buffer_float") !== null;
+      this.canvas = canvas;
+      this.gl = gl;
+    }
+    const canvas = this.canvas!;
+    if (canvas.width !== width || canvas.height !== height) {
+      canvas.width = width;
+      canvas.height = height;
+    }
+    return this.gl;
+  }
+
+  private compile(gl: WebGL2RenderingContext, source: string): Programs {
+    if (this.programs && this.programs.source === source) return this.programs;
+    this.disposePrograms();
+
+    const fail = (error: string): Programs => {
+      this.programs = { source, image: null, state: null, error };
+      return this.programs;
+    };
+
+    const check = checkShaderSource(source);
+    if (!check.ok) return fail(check.error);
+
+    const vertex = this.shader(gl, gl.VERTEX_SHADER, SHADER_VERTEX_SOURCE);
+    if (typeof vertex === "string") return fail(vertex);
+
+    const image = this.program(gl, vertex, source, "image");
+    if (typeof image === "string") {
+      gl.deleteShader(vertex);
+      return fail(image);
+    }
+
+    let state: WebGLProgram | null = null;
+    if (check.hasState) {
+      const built = this.program(gl, vertex, source, "state");
+      if (typeof built === "string") {
+        gl.deleteShader(vertex);
+        gl.deleteProgram(image);
+        return fail(built);
+      }
+      state = built;
+    }
+
+    gl.deleteShader(vertex);
+    this.programs = { source, image, state, error: null };
+    return this.programs;
+  }
+
+  /** A compiled shader, or the driver's log remapped to the user's lines. */
+  private shader(gl: WebGL2RenderingContext, type: number, source: string): WebGLShader | string {
+    const shader = gl.createShader(type);
+    if (!shader) return "The GPU refused to create a shader.";
+    gl.shaderSource(shader, source);
+    gl.compileShader(shader);
+    if (gl.getShaderParameter(shader, gl.COMPILE_STATUS)) return shader;
+    const log = remapShaderLog(gl.getShaderInfoLog(shader) ?? "Compile failed.");
+    gl.deleteShader(shader);
+    return log;
+  }
+
+  private program(
+    gl: WebGL2RenderingContext,
+    vertex: WebGLShader,
+    source: string,
+    pass: ShaderPass,
+  ): WebGLProgram | string {
+    const fragment = this.shader(gl, gl.FRAGMENT_SHADER, buildFragmentSource(source, pass));
+    if (typeof fragment === "string") return `${pass} pass — ${fragment}`;
+    const program = gl.createProgram();
+    if (!program) {
+      gl.deleteShader(fragment);
+      return "The GPU refused to create a program.";
+    }
+    gl.attachShader(program, vertex);
+    gl.attachShader(program, fragment);
+    gl.linkProgram(program);
+    gl.deleteShader(fragment);
+    if (gl.getProgramParameter(program, gl.LINK_STATUS)) return program;
+    const log = remapShaderLog(gl.getProgramInfoLog(program) ?? "Link failed.");
+    gl.deleteProgram(program);
+    return `${pass} pass — ${log}`;
+  }
+
+  private draw(
+    gl: WebGL2RenderingContext,
+    program: WebGLProgram,
+    width: number,
+    height: number,
+    state: WebGLTexture | null,
+  ) {
+    gl.viewport(0, 0, width, height);
+    gl.useProgram(program);
+    const at = (name: string) => gl.getUniformLocation(program, name);
+    gl.uniform2f(at("uResolution"), width, height);
+    gl.uniform1f(at("uTime"), this.time);
+    gl.uniform1i(at("uFrame"), this.frame);
+    gl.uniform4fv(at("uKnob"), this.knobs);
+    gl.uniform4fv(at("uKnobNorm"), this.knobsNorm);
+    gl.uniform4fv(at("uBtnPressed"), this.btnPressed);
+    gl.uniform4fv(at("uBtnHeld"), this.btnHeld);
+    gl.activeTexture(gl.TEXTURE0);
+    gl.bindTexture(gl.TEXTURE_2D, state);
+    gl.uniform1i(at("uState"), 0);
+    gl.activeTexture(gl.TEXTURE1);
+    gl.bindTexture(gl.TEXTURE_2D, this.rampTexture);
+    gl.uniform1i(at("uRamp"), 1);
+    gl.disable(gl.BLEND);
+    gl.disable(gl.DEPTH_TEST);
+    gl.clearColor(0, 0, 0, 0);
+    gl.clear(gl.COLOR_BUFFER_BIT);
+    gl.drawArrays(gl.TRIANGLES, 0, 3);
+  }
+
+  private ensureState(gl: WebGL2RenderingContext, width: number, height: number) {
+    if (this.stateWidth === width && this.stateHeight === height && this.textures[0]) return;
+    for (const texture of this.textures) if (texture) gl.deleteTexture(texture);
+    if (!this.framebuffer) this.framebuffer = gl.createFramebuffer();
+    this.textures = [this.texture(gl, width, height), this.texture(gl, width, height)];
+    this.stateWidth = width;
+    this.stateHeight = height;
+    this.read = 0;
+    // Feedback is bound to its grid: a resized take starts its simulation over
+    // rather than stretching the old one across a different lattice.
+    this.frame = 0;
+    this.clearState();
+  }
+
+  private ensureRamp(gl: WebGL2RenderingContext) {
+    if (!this.rampTexture) {
+      this.rampTexture = gl.createTexture();
+      this.rampDirty = true;
+      // A shader that calls ramp() before one arrives gets white, not garbage.
+      if (!this.rampLut) this.rampLut = new Uint8Array(SHADER_RAMP_SIZE * 4).fill(255);
+    }
+    if (!this.rampDirty || !this.rampLut || !this.rampTexture) return;
+    this.rampDirty = false;
+    gl.activeTexture(gl.TEXTURE1);
+    gl.bindTexture(gl.TEXTURE_2D, this.rampTexture);
+    gl.texImage2D(
+      gl.TEXTURE_2D,
+      0,
+      gl.RGBA8,
+      SHADER_RAMP_SIZE,
+      1,
+      0,
+      gl.RGBA,
+      gl.UNSIGNED_BYTE,
+      this.rampLut,
+    );
+    // Interpolating between entries where the ramp interpolates: the runtime's
+    // 256-step lookup is an 8-bit LED simulation and this is not one, so a
+    // smooth ramp comes out smooth. A step ramp reads NEAREST instead.
+    const filter = this.rampSmooth ? gl.LINEAR : gl.NEAREST;
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, filter);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, filter);
+  }
+
+  private texture(gl: WebGL2RenderingContext, width: number, height: number): WebGLTexture | null {
+    const texture = gl.createTexture();
+    if (!texture) return null;
+    gl.bindTexture(gl.TEXTURE_2D, texture);
+    if (this.floatState) {
+      gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA16F, width, height, 0, gl.RGBA, gl.HALF_FLOAT, null);
+    } else {
+      gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA8, width, height, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
+    }
+    // Wrapping neighbour reads: an LED pattern's edges meet, and NEAREST keeps
+    // a state texel a cell rather than a blend of four.
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.REPEAT);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.REPEAT);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
+    return texture;
+  }
+
+  private clearState() {
+    const gl = this.gl;
+    if (!gl || !this.framebuffer) return;
+    for (const texture of this.textures) {
+      if (!texture) continue;
+      gl.bindFramebuffer(gl.FRAMEBUFFER, this.framebuffer);
+      gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, texture, 0);
+      gl.clearColor(0, 0, 0, 0);
+      gl.clear(gl.COLOR_BUFFER_BIT);
+    }
+    gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+    this.read = 0;
+  }
+
+  private disposePrograms() {
+    const gl = this.gl;
+    if (gl && this.programs) {
+      if (this.programs.image) gl.deleteProgram(this.programs.image);
+      if (this.programs.state) gl.deleteProgram(this.programs.state);
+    }
+    this.programs = null;
+  }
+}

--- a/web/src/lib/lab/capture/shaderStore.ts
+++ b/web/src/lib/lab/capture/shaderStore.ts
@@ -1,0 +1,97 @@
+// ── Shader twin storage ──────────────────────────────────────────────────────
+// A shader belongs to the code layer it was converted from, but it is not part
+// of the pattern: the project format (serialize.ts) stays exactly what the
+// device and the community share. So it lives here, in the capture module's own
+// localStorage — a working file next to the pattern rather than a second thing
+// to publish.
+//
+// Filed under TWO keys, because neither one alone survives the way people work:
+//   id:<layer>    holds while the tab is open, so switching between two code
+//                 layers switches between their twins — and an edit to the JS
+//                 does not orphan the shader written for it.
+//   code:<hash>   the lab does not persist its project, so every reload mints
+//                 new layer ids; the hash of the pattern source is what says
+//                 "this twin is this pattern's" across one.
+// Reading tries the id first and falls back to the hash. Writing does both.
+//
+// Bounded on purpose: the newest few, a couple of hundred KB. A shader lost to
+// pruning is one re-paste; a full quota breaks saving settings too.
+
+const STORAGE_KEY = "patternflow_lab_shader_v1";
+const MAX_ENTRIES = 12;
+const MAX_TOTAL_CHARS = 200_000;
+
+type Entry = { source: string; at: number };
+type Store = Record<string, Entry>;
+
+function hash(text: string): number {
+  let h = 2166136261;
+  for (let i = 0; i < text.length; i++) {
+    h ^= text.charCodeAt(i);
+    h = Math.imul(h, 16777619);
+  }
+  return h >>> 0;
+}
+
+function keysFor(layerId: string, code: string): string[] {
+  return [`id:${layerId}`, `code:${hash(code)}`];
+}
+
+function read(): Store {
+  if (typeof window === "undefined") return {};
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return {};
+    const parsed: unknown = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object") return {};
+    const store: Store = {};
+    for (const [key, value] of Object.entries(parsed as Record<string, unknown>)) {
+      if (!value || typeof value !== "object") continue;
+      const entry = value as { source?: unknown; at?: unknown };
+      if (typeof entry.source !== "string") continue;
+      store[key] = { source: entry.source, at: typeof entry.at === "number" ? entry.at : 0 };
+    }
+    return store;
+  } catch {
+    return {};
+  }
+}
+
+function write(store: Store) {
+  if (typeof window === "undefined") return;
+  const entries = Object.entries(store).sort((a, b) => b[1].at - a[1].at);
+  const kept: Store = {};
+  let total = 0;
+  for (const [key, entry] of entries.slice(0, MAX_ENTRIES)) {
+    total += entry.source.length;
+    if (total > MAX_TOTAL_CHARS) break;
+    kept[key] = entry;
+  }
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(kept));
+  } catch {
+    // Quota or private mode: the shader stays in the panel for this session.
+  }
+}
+
+export function loadShaderSource(layerId: string, code: string): string {
+  const store = read();
+  for (const key of keysFor(layerId, code)) {
+    const entry = store[key];
+    if (entry) return entry.source;
+  }
+  return "";
+}
+
+export function saveShaderSource(layerId: string, code: string, source: string) {
+  const store = read();
+  const at = Date.now();
+  for (const key of keysFor(layerId, code)) {
+    if (source.trim()) {
+      store[key] = { source, at };
+    } else {
+      delete store[key];
+    }
+  }
+  write(store);
+}

--- a/web/src/lib/lab/capture/types.ts
+++ b/web/src/lib/lab/capture/types.ts
@@ -17,6 +17,16 @@
 import type { MatrixSize } from "@/lib/patternMatrix";
 import type { Layer, PixelLayer } from "../types";
 
+/**
+ * Which renderer fills the stage.
+ *   pattern  the lab's own engine runs the layer stack — the panel's picture,
+ *            the device's truth, and what every look below describes.
+ *   shader   a GLSL twin of the composition runs on the GPU instead
+ *            (shaderStage.ts). Output only: nothing about the pattern, the
+ *            project or the hardware export changes when this is on.
+ */
+export type CaptureSource = "pattern" | "shader";
+
 /** What the user picks. */
 export type CaptureStyle = "auto" | "native" | "pixel" | "led";
 /** What actually gets painted once `auto` has been resolved. */
@@ -54,6 +64,7 @@ export type CaptureRotation = 0 | 90 | 180 | 270;
 export const CAPTURE_ROTATIONS: CaptureRotation[] = [0, 90, 180, 270];
 
 export type CaptureSettings = {
+  source: CaptureSource;
   style: CaptureStyle;
   /**
    * Output size for `auto` / `native`. Native runs the pattern code at
@@ -86,6 +97,7 @@ export const CAPTURE_FPS = [24, 30, 60] as const;
 export const CAPTURE_SECONDS_MAX = 60;
 
 export const DEFAULT_CAPTURE_SETTINGS: CaptureSettings = {
+  source: "pattern",
   style: "auto",
   width: 1024,
   height: 512,
@@ -175,6 +187,19 @@ export type ShowAutomation = {
 export type ToWorker =
   | { type: "project"; project: WireProject }
   | { type: "settings"; settings: CaptureSettings }
+  /**
+   * The GLSL twin's source, or null to drop it. Compiled on arrival so a paste
+   * is answered even with the viewfinder off. `layerId` says which code layer
+   * it belongs to — that layer's colour ramp is what the shader's `ramp()`
+   * helper reads, live.
+   */
+  | { type: "shader"; source: string | null; layerId: string | null }
+  /**
+   * A knob's push button. The stage runs its own engine, so the live
+   * preview's presses never reached it — a pattern that resets or triggers on
+   * a button was unreachable in an export until these started flowing.
+   */
+  | { type: "button"; index: number; down: boolean }
   | { type: "visible"; visible: boolean }
   | { type: "play" }
   | { type: "pause" }
@@ -224,9 +249,22 @@ export type FrameMessage = {
   preview: number | null;
 };
 
+/** What the shader stage has to say about the source it was handed. */
+export type ShaderStatus = {
+  /** Present = the stage holds a source; the panel can switch to it. */
+  loaded: boolean;
+  /** Compile/link error, remapped to the user's line numbers. */
+  error: string | null;
+  /** True when the driver gave the feedback pass float render targets. */
+  floatFeedback: boolean;
+  /** Whether the source declares a mainState feedback pass. */
+  feedback: boolean;
+};
+
 export type FromWorker =
   | { type: "ready" }
   | FrameMessage
+  | { type: "shader-status"; status: ShaderStatus }
   /** The auto probe's verdict, standalone — frames only flow while the
       viewfinder shows, but the Capture controls always want this. */
   | { type: "auto"; auto: AutoVerdict | null }


### PR DESCRIPTION
The Capture panel is now **Graphic Export**, and it can render a composition on the GPU instead of through the pattern JS.

This started from one report: an AI-rewritten simulation pattern still came out blocky at print size, the panel said it was fine, and the knob button that would have reseeded it did nothing. Four separate faults, one story.

### What was wrong

- **The any-size prompt cannot fix a simulation pattern.** Asked to make a reaction–diffusion pattern scale, the model keeps the fixed field and nearest-samples it in `draw()`. Measured: a 2048×4096 render is *bit-identical* to a 32× block upscale — 0.00 % of 32×32 blocks carry any inner variation — while costing 0.2 ms → 182 ms a frame. The prompt now carries a SIMULATIONS clause naming that non-answer and giving two ways out.
- **The probe was lying.** `layout 0 · density ×1.00` is a *perfect* score for a block upscale, because both metrics compare box-filtered copies and a block upscale filters back to exactly the original. A third metric (`detail`) and a `no-detail` verdict close it: Auto stops paying hundreds of times over for the same pixels, and the HUD offers a way forward instead of claiming the code scales. Swept over the bundled presets, only `pattern-0622` moves — at its default knobs, where its two flat cells make the upscale pixel-identical anyway.
- **Knob buttons never reached the stage.** The Knobs panel pressed the live singleton engine; the worker protocol had no button message at all, so a pattern that reseeds on a press could not be driven into the state you wanted to export.

### The shader twin

One GLSL source per code layer: `mainImage`, plus an optional `mainState` ping-ponged through float textures so a simulation runs *at output size* rather than being stretched over it. The stage prepends the version line, uniforms and its own `main()`, and `#line 1` keeps compile errors on the lines the author wrote.

It is output only — the panel, the Director and the hardware export all keep running the pattern — and the source lives in the capture module's own storage, keyed by both layer id and a hash of the pattern code, so it survives a reload without touching the project format. Knobs, buttons and the colour ramp reach it live; the ramp travels as a 1024-entry texture built by the runtime's own sampler, so editing a stop repaints the export with no recompile and no AI round trip.

### Measured

| | |
|---|---|
| 4K PNG, pattern re-rendered natively | 643 ms |
| 4K PNG, shader twin | **110 ms** |
| 1 s · 1024×512 MP4 (shader) | 467 ms, H.264 |
| Ramp parity vs the panel's own ramp bar | 1/255 (smooth modes), exact (`step`) |
| Live ramp edit → visible on the stage | ~317 ms |

Transparent PNGs keep straight alpha; a shader that fails to compile falls back to the pattern and says why.

### Checks

`tsc`, `eslint` (no new warnings), `npm run check:capture` (extended with the shader contract, ramp parity and the `no-detail` verdict), `check:director` / `check:flatten` / `check:labedit`, and `next build`. Verified end to end in a real browser: compile, feedback, knob-button reseed, 4K PNG, MP4, rotation, transparency, reload persistence.

Not exercised yet: a Director-linked show render through the shader path, the RGBA8 fallback on a GPU without `EXT_color_buffer_float`, and two code layers each holding their own twin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
