### PR TITLE
Pace MQTT /param and PFS ease writes (Performance sequences)

### DIFF
--- a/firmware/patternflow/features/mqtt/core_mqtt.h
+++ b/firmware/patternflow/features/mqtt/core_mqtt.h
@@ -102,6 +102,12 @@ constexpr uint32_t FL_RECONNECT_MID_MS = 45000;
 constexpr uint32_t FL_RECONNECT_MAX_MS = 90000;
 constexpr uint8_t RERESOLVE_AFTER = 4;
 constexpr uint32_t SNAPSHOT_HEARTBEAT_MS = 8000;
+// Cap outbound /param traffic. PFS v2 curves must stay well below Director
+// authoring rates — subscribers buffer and the console dies otherwise.
+// Show easing is also paced (~10 Hz); this is a second, slower gate.
+constexpr uint32_t PARAM_PUB_MIN_MS = 1000;
+// Ignore easing chatter smaller than this (0..1000 bus units).
+constexpr uint16_t PARAM_PUB_MIN_DELTA = 20;
 
 inline WiFiClient net;
 inline PubSubClient client(net);
@@ -113,6 +119,10 @@ inline char clientId[20] = {};
 inline char lastError[80] = {};
 inline char lastPattern[NAME_BYTES] = {};
 inline char publishedPattern[NAME_BYTES] = {};
+// Last absolute params published on /param/N (Publisher mirror of the bus).
+inline uint16_t publishedParam[4] = {};
+inline bool publishedParamValid[4] = {false, false, false, false};
+inline uint32_t lastParamPubMs = 0;
 inline long lastKnobs[4] = {0, 0, 0, 0};
 inline bool haveKnob[4] = {false, false, false, false};
 inline long lastRemoteKnob[4] = {0, 0, 0, 0};
@@ -830,8 +840,15 @@ inline void publishLiveBurst() {
     snprintf(publishedPattern, sizeof(publishedPattern), "%s", lastPattern);
   }
   for (int i = 0; i < 4; ++i) {
-    if (paramHeld[i]) publishParam(i, paramValue[i]);
+    if (paramHeld[i]) {
+      publishParam(i, paramValue[i]);
+      publishedParam[i] = paramValue[i];
+      publishedParamValid[i] = true;
+    } else {
+      publishedParamValid[i] = false;
+    }
   }
+  lastParamPubMs = millis();
   publishChannelSnapshot(true);
 }
 
@@ -999,6 +1016,8 @@ inline void resetSessionState() {
   // the sleep state itself.
   publishedSleep = -1;
   publishedPattern[0] = '\0';
+  for (int i = 0; i < 4; ++i) publishedParamValid[i] = false;
+  lastParamPubMs = 0;
   PatternflowBanner::clear();
   lastSnapshotPubMs = 0;
 }
@@ -1351,7 +1370,14 @@ inline void update(const InputFrame& input, const char* contentName) {
   if (contentName) snprintf(lastPattern, sizeof(lastPattern), "%s", contentName);
   if (role != ROLE_PUBLISHER || !client.connected()) return;
 
+  // Publish /knob only for real relative motion. While a lane is held on the
+  // absolute bus (show easing, Director, HTTP sliders), fillAbsolute copies
+  // synthetic pendingDelta clicks into knobDeltas for legacy patterns —
+  // mirroring those as /knob every frame floods the broker, stalls Core 1,
+  // and kills sequence timing + the web console. Absolutes go out via
+  // noteParams() on /param/N (rate-capped).
   for (int i = 0; i < 4; ++i) {
+    if (input.paramAbsoluteActive[i]) continue;
     if (input.knobDeltas[i] != 0) publishKnob(i, input.knobs[i]);
   }
 }
@@ -1362,7 +1388,60 @@ inline void notePattern(const char* contentName) {
   if (strcmp(publishedPattern, lastPattern) == 0) return;
   snprintf(publishedPattern, sizeof(publishedPattern), "%s", lastPattern);
   publishPatternName(lastPattern);
+  // Force a param republish with the new pattern so subscribers do not
+  // keep stale /param values across a cue that only changed the name.
+  for (int i = 0; i < 4; ++i) publishedParamValid[i] = false;
+  lastParamPubMs = 0;
   publishChannelSnapshot(true);
+}
+
+// Mirror absolute bus values on /param/1..4 (non-retained). Covers local
+// show cues and HTTP absolute sets. Rate-limited so a Publisher running a
+// sequence cannot drown Subscribers (and their console) in easing traffic.
+inline void noteParams(const InputFrame& input, bool force = false) {
+  if (role != ROLE_PUBLISHER || !client.connected()) return;
+
+  bool changed = false;
+  for (int i = 0; i < 4; ++i) {
+    if (!input.paramAbsoluteActive[i]) {
+      publishedParamValid[i] = false;
+      continue;
+    }
+    uint16_t v = input.paramAbsolute[i];
+    if (!publishedParamValid[i]) {
+      changed = true;
+      continue;
+    }
+    uint16_t d = (v > publishedParam[i]) ? (uint16_t)(v - publishedParam[i])
+                                         : (uint16_t)(publishedParam[i] - v);
+    if (d >= PARAM_PUB_MIN_DELTA) changed = true;
+  }
+  if (!changed && !force) return;
+
+  uint32_t now = millis();
+  if (!force && lastParamPubMs != 0 &&
+      (now - lastParamPubMs) < PARAM_PUB_MIN_MS) {
+    return;
+  }
+
+  bool published = false;
+  for (int i = 0; i < 4; ++i) {
+    if (!input.paramAbsoluteActive[i]) continue;
+    uint16_t v = input.paramAbsolute[i];
+    if (!force && publishedParamValid[i]) {
+      uint16_t d = (v > publishedParam[i]) ? (uint16_t)(v - publishedParam[i])
+                                           : (uint16_t)(publishedParam[i] - v);
+      if (d < PARAM_PUB_MIN_DELTA) continue;
+    }
+    publishParam(i, v);
+    publishedParam[i] = v;
+    publishedParamValid[i] = true;
+    published = true;
+  }
+  if (!published) return;
+  lastParamPubMs = now;
+  // Channel mid-join snapshot; debounced. Broadcast has no retained snapshot.
+  publishChannelSnapshot(false);
 }
 
 // Mirror of notePattern() for the sleep state, with two differences: it runs in
@@ -1386,6 +1465,7 @@ inline void begin() {}
 inline void handle() {}
 inline void update(const InputFrame&, const char*) {}
 inline void notePattern(const char*) {}
+inline void noteParams(const InputFrame&, bool = false) {}
 inline void noteSleep(bool) {}
 inline void setRole(Role) {}
 inline void applyChannel(Channel, Role) {}

--- a/firmware/patternflow/features/mqtt/feature_mqtt.h
+++ b/firmware/patternflow/features/mqtt/feature_mqtt.h
@@ -63,12 +63,13 @@ inline void fillInput(InputFrame& input) {
   }
 }
 
-// The finished frame, mirrored outward. notePattern dedupes, so this does
-// not republish every frame.
+// The finished frame, mirrored outward. notePattern / noteParams dedupe, so
+// this does not republish every frame (params are also rate-capped ~1 Hz).
 inline void observeFrame(const InputFrame& input, const PFFeatureFrame& frame) {
   const char* patternName = frame.patternName;
   PatternflowMqtt::update(input, patternName);
   PatternflowMqtt::notePattern(patternName);
+  PatternflowMqtt::noteParams(input);
 }
 
 inline void onSleep(bool sleeping) {

--- a/firmware/patternflow/features/show/core_show.h
+++ b/firmware/patternflow/features/show/core_show.h
@@ -117,9 +117,19 @@ inline uint16_t easeFromV[4] = {};
 inline uint16_t easeToV[4] = {};
 inline uint16_t easeFromT[4] = {};
 inline uint16_t easeToT[4] = {};
+// Pace bus writes during a curve. Applying every render frame (~40–60 Hz)
+// made Publisher panels flood MQTT (/param + synthetic /knob clicks on
+// older builds) and buffered subscribers into visible lag.
+constexpr uint32_t EASE_APPLY_MIN_MS = 100;    // ≤10 Hz into the absolute bus
+constexpr uint16_t EASE_APPLY_MIN_DELTA = 8;   // or when the lerp moves enough
+inline uint16_t easeLastApplied[4] = {};
+inline uint32_t easeLastApplyMs[4] = {};
 
 inline void clearEase() {
-  for (int i = 0; i < 4; i++) easeActive[i] = false;
+  for (int i = 0; i < 4; i++) {
+    easeActive[i] = false;
+    easeLastApplyMs[i] = 0;
+  }
 }
 inline constexpr uint8_t VARIANCE_CUE_MAX = 4;  // five demo changes
 
@@ -384,6 +394,8 @@ inline void applyCue(uint16_t cueIdx) {
     // Any cue that sets a channel ends its running ease; an EASE cue re-arms
     // it toward the channel's next value (one <=256-entry scan per fired cue).
     easeActive[i] = false;
+    easeLastApplied[i] = v;
+    easeLastApplyMs[i] = millis();
     if (header.version != VERSION2 || !(cue.flags & FLAG_EASE)) continue;
     for (uint16_t j = cueIdx + 1; j < cueCount; j++) {
       if (!(cueTable[j].flags & (FLAG_PARAM1 << i))) continue;
@@ -393,6 +405,8 @@ inline void applyCue(uint16_t cueIdx) {
         easeToV[i] = cueTable[j].param[i];
         easeFromT[i] = cue.t;
         easeToT[i] = cueTable[j].t;
+        easeLastApplied[i] = v;
+        easeLastApplyMs[i] = 0;  // allow first mid-curve sample immediately
       }
       break;
     }
@@ -699,9 +713,9 @@ inline void tick() {
     nextCue++;
   }
 
-  // v2 eased channels: one lerp per active channel per frame — a handful of
-  // FPU ops against a multi-million-cycle frame budget. The terminating cue
-  // fires the exact end value; past it the ease disarms itself.
+  // v2 eased channels: lerp is continuous in time, but bus writes are paced
+  // (see EASE_APPLY_MIN_*), so Publisher MQTT stays calm. The terminating
+  // cue still lands the exact end value; past it the ease disarms itself.
   if (header.version == VERSION2) {
     for (int i = 0; i < 4; i++) {
       if (!easeActive[i]) continue;
@@ -715,7 +729,16 @@ inline void tick() {
       float u = (float)(nowMs - t0) / (float)(t1 - t0);
       long v = (long)((float)easeFromV[i] +
                       ((float)easeToV[i] - (float)easeFromV[i]) * u + 0.5f);
+      uint16_t dv = (v > (long)easeLastApplied[i])
+                        ? (uint16_t)(v - (long)easeLastApplied[i])
+                        : (uint16_t)((long)easeLastApplied[i] - v);
+      uint32_t wall = millis();
+      bool due = (easeLastApplyMs[i] == 0) ||
+                 ((wall - easeLastApplyMs[i]) >= EASE_APPLY_MIN_MS);
+      if (!due && dv < EASE_APPLY_MIN_DELTA) continue;
       PatternflowBus::applyRemoteParam(i, v);
+      easeLastApplied[i] = (uint16_t)v;
+      easeLastApplyMs[i] = wall;
     }
   }
 }


### PR DESCRIPTION
## Summary
- Skip Publisher `/knob` while absolute params are held (show easing / Director / HTTP absolutes synthesize knob deltas for legacy patterns).
- Rate-limit outbound `/param` (~1 Hz, Δ≥20).
- Pace PFS v2 ease bus applies (~10 Hz / Δ≥8) so Publisher sequences do not flood the broker.

## Why
On Performance, playing a PFS v2 table as MQTT Publisher was drowning Subscribers and killing the web console. Tested in SimonePDA Performance builds (p5.5.1-3102).

## Test plan
- [ ] Performance edition: Publisher + Sequence with v2 easings — broker traffic stays calm; Subscriber follows smoothly
- [ ] Physical knobs still publish `/knob` when absolute is not held
- [ ] Default / Audio editions still build

Contributed by @SimonePDA

Made with [Cursor](https://cursor.com)