### PR TITLE
Raise sequence playlist max from 24 to 64

### DIFF
--- a/firmware/patternflow/features/show/core_show.h
+++ b/firmware/patternflow/features/show/core_show.h
@@ -87,7 +87,7 @@ inline uint8_t missingCount = 0;
 inline char missingNames[MAX_MISSING][48] = {};
 
 // Multi-sequence playlist (loop applies to the list, not each .pfs).
-constexpr uint8_t PLAYLIST_MAX = 24;
+constexpr uint8_t PLAYLIST_MAX = 64;
 inline char playlist[PLAYLIST_MAX][SLUG_BYTES] = {};
 inline uint8_t playlistCount = 0;
 inline uint8_t playlistIndex = 0;

--- a/firmware/toolchain/check_footprint.py
+++ b/firmware/toolchain/check_footprint.py
@@ -57,7 +57,7 @@ IRAM_END = 0x403E0000
 PINS = {
     "default": (141080, 72311),
     "audio": (160096, 72791),
-    "performance": (149968, 72311),
+    "performance": (153448, 72467),
     "clock": (141352, 72311),
 }
 


### PR DESCRIPTION
## Summary
- `PLAYLIST_MAX` 24 → 64.

## Why
Longer Performance playlists were truncating at 24.

## Test plan
- [ ] Save/load a playlist with >24 shows on Performance
- [ ] NVS blob still fits (existing static buffer path)

Contributed by @SimonePDA