### PR TITLE
Add errno to the upload open error; re-diagnose storage after a mount succeeds

### DIFF
--- a/firmware/patternflow/pattern_registry.h
+++ b/firmware/patternflow/pattern_registry.h
@@ -442,6 +442,10 @@ inline bool mountModuleStorage(bool afterFormat = false) {
   moduleStorageMounted = FFat.begin(false, "/ffat", MODULE_FS_MAX_FILES, "ffat");
   if (moduleStorageMounted) {
     moduleStorageError[0] = '\0';
+    // Diagnosed once is not diagnosed for good: that reason described a
+    // volume that has since mounted. A later failure gets a fresh look, or
+    // fsError would be the empty string this success leaves behind.
+    moduleStorageDiagnosed = false;
     return true;
   }
   if (afterFormat || !moduleStorageDiagnosed) diagnoseModuleStorage(afterFormat);

--- a/firmware/patternflow/src/core_patterns_http.h
+++ b/firmware/patternflow/src/core_patterns_http.h
@@ -27,6 +27,7 @@
 
 #if PF_PATTERNS_HTTP_ENABLED
 #include <FFat.h>
+#include <errno.h>
 #include "webserver/WebServer.h"  // vendored: fixes the 5 s final-chunk stall (see src/webserver/VENDORED.md)
 #include <WiFi.h>
 #include <esp_heap_caps.h>
@@ -658,10 +659,14 @@ inline void handleUpload() {
       return;
     }
 
+    // errno is what the VFS made of FatFs's verdict: ENOENT is a missing
+    // /patterns, EIO a volume that will not write. Without it the two read
+    // the same, which is what made #424 hard to tell apart from afar.
     uploadFile = FFat.open(uploadPath, FILE_WRITE);
     if (!uploadFile) {
       uploadFailed = true;
-      snprintf(uploadError, sizeof(uploadError), "cannot open destination (heap %u)",
+      snprintf(uploadError, sizeof(uploadError),
+               "cannot open destination errno=%d (heap %u)", errno,
                (unsigned)heap_caps_get_free_size(MALLOC_CAP_INTERNAL));
       return;
     }
@@ -763,7 +768,8 @@ inline void handlePutBody() {
     uploadFile = FFat.open(uploadPath, FILE_WRITE);
     if (!uploadFile) {
       uploadFailed = true;
-      snprintf(uploadError, sizeof(uploadError), "cannot open destination (heap %u)",
+      snprintf(uploadError, sizeof(uploadError),
+               "cannot open destination errno=%d (heap %u)", errno,
                (unsigned)heap_caps_get_free_size(MALLOC_CAP_INTERNAL));
       return;
     }


### PR DESCRIPTION
## Summary

Two small changes kept from the debugging patch RayWolters shared while investigating #424 (the DevKitC-1 whose FFAT volume reads back wrong at runtime). The rest of that patch is deliberately not taken; see below.

- `cannot open destination` now includes `errno`, so a missing `/patterns` (ENOENT) is distinguishable from a volume that will not write (EIO), both in the console's error text and on serial.
- `mountModuleStorage()` resets `moduleStorageDiagnosed` when a mount succeeds. The flag meant "explained once", and that explanation was for a volume that has since mounted; a later failure skipped the diagnosis and published an empty `fsError`.

Not taken from that patch, and why:

- **Raw erase + direct `f_mkfs` retry.** It makes the same volume, and because `wl_unmount()` flushes with a forced wear-levelling move, the following mount reads the boot sector from the same physical sector as before. It also depends on IDF-internal headers and the FatFs R0.13c `f_mkfs` signature, which core 3 does not have.
- **Root-directory fallback for uploads.** It runs only after a mount succeeds, so it cannot explain the recovery; it also gives every slug two possible homes and lets a stale root copy resurface after a delete.
- **`[env:firmware_safe_flash]`.** It changes QIO to DIO only (the flash clock stays 80 MHz despite its comment), and the reporter had already built DIO/80 on v3.10.2 with the identical failure.

Thanks to RayWolters for the time and testing behind #424.

## Test plan

- [x] `platformio run -e firmware` builds locally (RAM 26.0%, Flash 33.2%)
- [ ] CI: firmware-build (all editions + marker scan) and firmware-checks
- Not exercised on a board: the change only alters an error string and a flag reset, and the open failure it annotates does not occur on a healthy volume.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
