### PR TITLE
Merge dev: upload open errno, storage re-diagnosis after mount (#431)

### DIFF
--- a/firmware/patternflow/pattern_registry.h
+++ b/firmware/patternflow/pattern_registry.h
@@ -442,6 +442,10 @@ inline bool mountModuleStorage(bool afterFormat = false) {
   moduleStorageMounted = FFat.begin(false, "/ffat", MODULE_FS_MAX_FILES, "ffat");
   if (moduleStorageMounted) {
     moduleStorageError[0] = '\0';
+    // Diagnosed once is not diagnosed for good: that reason described a
+    // volume that has since mounted. A later failure gets a fresh look, or
+    // fsError would be the empty string this success leaves behind.
+    moduleStorageDiagnosed = false;
     return true;
   }
   if (afterFormat || !moduleStorageDiagnosed) diagnoseModuleStorage(afterFormat);

--- a/firmware/patternflow/src/core_patterns_http.h
+++ b/firmware/patternflow/src/core_patterns_http.h
@@ -27,6 +27,7 @@
 
 #if PF_PATTERNS_HTTP_ENABLED
 #include <FFat.h>
+#include <errno.h>
 #include "webserver/WebServer.h"  // vendored: fixes the 5 s final-chunk stall (see src/webserver/VENDORED.md)
 #include <WiFi.h>
 #include <esp_heap_caps.h>
@@ -658,10 +659,14 @@ inline void handleUpload() {
       return;
     }
 
+    // errno is what the VFS made of FatFs's verdict: ENOENT is a missing
+    // /patterns, EIO a volume that will not write. Without it the two read
+    // the same, which is what made #424 hard to tell apart from afar.
     uploadFile = FFat.open(uploadPath, FILE_WRITE);
     if (!uploadFile) {
       uploadFailed = true;
-      snprintf(uploadError, sizeof(uploadError), "cannot open destination (heap %u)",
+      snprintf(uploadError, sizeof(uploadError),
+               "cannot open destination errno=%d (heap %u)", errno,
                (unsigned)heap_caps_get_free_size(MALLOC_CAP_INTERNAL));
       return;
     }
@@ -763,7 +768,8 @@ inline void handlePutBody() {
     uploadFile = FFat.open(uploadPath, FILE_WRITE);
     if (!uploadFile) {
       uploadFailed = true;
-      snprintf(uploadError, sizeof(uploadError), "cannot open destination (heap %u)",
+      snprintf(uploadError, sizeof(uploadError),
+               "cannot open destination errno=%d (heap %u)", errno,
                (unsigned)heap_caps_get_free_size(MALLOC_CAP_INTERNAL));
       return;
     }


### PR DESCRIPTION
## Summary

Brings `dev` into `main`: PR #431 (errno in the upload "cannot open destination" error, storage re-diagnosed after a successful mount), taken from RayWolters' investigation on #424.

## Test plan

- [x] Firmware CI on #431: all editions built, boundary checks passed
- [x] Board .119 on the built image: upload, select, file, delete and Format of the empty volume all behave; serial clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
